### PR TITLE
Remove API Key and Service Token

### DIFF
--- a/estransport/estransport.go
+++ b/estransport/estransport.go
@@ -86,8 +86,6 @@ type Config struct {
 	URLs         []*url.URL
 	Username     string
 	Password     string
-	APIKey       string
-	ServiceToken string
 
 	Header http.Header
 	CACert []byte
@@ -122,8 +120,6 @@ type Client struct {
 	urls         []*url.URL
 	username     string
 	password     string
-	apikey       string
-	servicetoken string
 	header       http.Header
 
 	retryOnStatus         []int
@@ -188,8 +184,6 @@ func New(cfg Config) (*Client, error) {
 		urls:         cfg.URLs,
 		username:     cfg.Username,
 		password:     cfg.Password,
-		apikey:       cfg.APIKey,
-		servicetoken: cfg.ServiceToken,
 		header:       cfg.Header,
 
 		retryOnStatus:         cfg.RetryOnStatus,
@@ -440,24 +434,6 @@ func (c *Client) setReqAuth(u *url.URL, req *http.Request) *http.Request {
 		if u.User != nil {
 			password, _ := u.User.Password()
 			req.SetBasicAuth(u.User.Username(), password)
-			return req
-		}
-
-		if c.apikey != "" {
-			var b bytes.Buffer
-			b.Grow(len("APIKey ") + len(c.apikey))
-			b.WriteString("APIKey ")
-			b.WriteString(c.apikey)
-			req.Header.Set("Authorization", b.String())
-			return req
-		}
-
-		if c.servicetoken != "" {
-			var b bytes.Buffer
-			b.Grow(len("Bearer ") + len(c.servicetoken))
-			b.WriteString("Bearer ")
-			b.WriteString(c.servicetoken)
-			req.Header.Set("Authorization", b.String())
 			return req
 		}
 

--- a/estransport/estransport_internal_test.go
+++ b/estransport/estransport_internal_test.go
@@ -343,57 +343,6 @@ func TestTransportPerform(t *testing.T) {
 		}
 	})
 
-	t.Run("Sets APIKey Authentication from configuration", func(t *testing.T) {
-		u, _ := url.Parse("http://example.com")
-		tp, _ := New(Config{URLs: []*url.URL{u}, APIKey: "Zm9vYmFy"}) // foobar
-
-		req, _ := http.NewRequest("GET", "/", nil)
-		tp.setReqAuth(u, req)
-
-		value := req.Header.Get("Authorization")
-		if value == "" {
-			t.Errorf("Expected the request to have the Authorization header set")
-		}
-
-		if value != "APIKey Zm9vYmFy" {
-			t.Errorf(`Unexpected value for Authorization: want="APIKey Zm9vYmFy", got="%s"`, value)
-		}
-	})
-
-	t.Run("Sets APIKey Authentication over ServiceToken", func(t *testing.T) {
-		u, _ := url.Parse("http://example.com")
-		tp, _ := New(Config{URLs: []*url.URL{u}, APIKey: "Zm9vYmFy", ServiceToken: "AAEAAWVs"}) // foobar
-
-		req, _ := http.NewRequest("GET", "/", nil)
-		tp.setReqAuth(u, req)
-
-		value := req.Header.Get("Authorization")
-		if value == "" {
-			t.Errorf("Expected the request to have the Authorization header set")
-		}
-
-		if value != "APIKey Zm9vYmFy" {
-			t.Errorf(`Unexpected value for Authorization: want="APIKey Zm9vYmFy", got="%s"`, value)
-		}
-	})
-
-	t.Run("Sets ServiceToken Authentication from configuration", func(t *testing.T) {
-		u, _ := url.Parse("http://example.com")
-		tp, _ := New(Config{URLs: []*url.URL{u}, ServiceToken: "AAEAAWVs"})
-
-		req, _ := http.NewRequest("GET", "/", nil)
-		tp.setReqAuth(u, req)
-
-		value := req.Header.Get("Authorization")
-		if value == "" {
-			t.Errorf("Expected the request to have the Authorization header set")
-		}
-
-		if value != "Bearer AAEAAWVs" {
-			t.Errorf(`Unexpected value for Authorization: want="Bearer AAEAAWVs", got="%s"`, value)
-		}
-	})
-
 	t.Run("Sets UserAgent", func(t *testing.T) {
 		u, _ := url.Parse("http://example.com")
 		tp, _ := New(Config{URLs: []*url.URL{u}})


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
OpenSearch GO client will not support authentication based on API Key and Service Token yet. It will be confusing to users to have unsupported configuration as part of SDK. Hence, remove all unsupported security authentication config parameters.
 
### Issues Resolved
#5 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
