### PR TITLE
Update cluster to use opendistro

### DIFF
--- a/.ci/opendistro/Dockerfile.opendistro
+++ b/.ci/opendistro/Dockerfile.opendistro
@@ -1,0 +1,10 @@
+ARG OPENDISTRO_VERSION
+FROM amazon/opendistro-for-elasticsearch:${OPENDISTRO_VERSION}
+
+ARG es_path=/usr/share/elasticsearch
+
+ARG SECURE_INTEGRATION
+RUN if [ "$SECURE_INTEGRATION" != "true" ] ; then $es_path/bin/elasticsearch-plugin remove opendistro_security; fi
+
+
+COPY --chown=elasticsearch:elasticsearch elasticsearch-run.sh $es_path/

--- a/.ci/opendistro/docker-compose.yml
+++ b/.ci/opendistro/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+services:
+
+  elasticsearch:
+    build:
+      context: .
+      dockerfile: Dockerfile.opendistro
+      args:
+        - SECURE_INTEGRATION=${SECURE_INTEGRATION:-false}
+        - OPENDISTRO_VERSION=${OPENDISTRO_VERSION:-latest}
+    command: /usr/share/elasticsearch/elasticsearch-run.sh
+    ports:
+      - "9200:9200"
+    user: elasticsearch

--- a/.ci/opendistro/elasticsearch-run.sh
+++ b/.ci/opendistro/elasticsearch-run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ex
+
+/usr/share/elasticsearch/bin/elasticsearch -Ediscovery.type=single-node

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   GITHUB_ACTIONS: true
-  ELASTICSEARCH_VERSION: elasticsearch-oss:7.10.2
 
 jobs:
   test:
@@ -28,11 +27,9 @@ jobs:
           sudo sysctl -w vm.swappiness=1
           sudo sysctl -w fs.file-max=262144
           sudo sysctl -w vm.max_map_count=262144
-      - name: Launch Elasticsearch
+      - name: Launch OpenDistro cluster
         run: |
-          docker pull --quiet docker.elastic.co/elasticsearch/${{ env.ELASTICSEARCH_VERSION }}
-          docker pull --quiet appropriate/curl
-          make cluster-clean cluster-update cluster detach=true version="${{ env.ELASTICSEARCH_VERSION }}"
+          make cluster.clean cluster.opendistro.build cluster.opendistro.start
       - run: make test-integ race=true
       - uses: codecov/codecov-action@v1
         with:
@@ -54,11 +51,9 @@ jobs:
           sudo sysctl -w vm.swappiness=1
           sudo sysctl -w fs.file-max=262144
           sudo sysctl -w vm.max_map_count=262144
-      - name: Launch Elasticsearch
+      - name: Launch OpenDistro cluster
         run: |
-          docker pull --quiet docker.elastic.co/elasticsearch/${{ env.ELASTICSEARCH_VERSION }}
-          docker pull --quiet appropriate/curl
-          make cluster-clean cluster-update cluster detach=true version="${{ env.ELASTICSEARCH_VERSION }}"
+          make cluster.clean cluster.opendistro.build cluster.opendistro.start
       - name: Run setup
         run: |
           cd _examples/encoding && make setup


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
Replace integration test cluster with
amazon/opendistro-for-elasticsearch:latest docker image.
 
### Issues Resolved
#21 #4 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
