### PR TITLE
Correct copyright notices to reflect Copyright OpenSearch Contributors.

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,8 @@
+OpenSearch (https://opensearch.org/)
+Copyright 2021 OpenSearch Contributors
+
+This product includes software developed by
+Elasticsearch (http://www.elastic.co).
+
+This product includes software developed by The Apache Software
+Foundation (http://www.apache.org/).

--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ This project is licensed under the [Apache v2.0 License](LICENSE.txt).
 
 ## Copyright
 
-Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright OpenSearch Contributors. See [NOTICE](NOTICE.txt) for details.


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description

- Removed Amazon copyright, the correct copyright for OpenSearch projects is "Copyright OpenSearch Contributors".
- Added NOTICE.txt and linked it from README.

 
### Issues Resolved

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
