### PR TITLE
Update github url path to opensearch

### DIFF
--- a/_examples/xkcdsearch/web/index.html
+++ b/_examples/xkcdsearch/web/index.html
@@ -43,7 +43,7 @@
     <p v-if="state.error" id="app-error">[{{ state.error.status }}] {{ state.error.statusText }}</p>
   </div>
 
-  <a href="https://github.com/elastic/go-elasticsearch/tree/master/_examples/xkcd" title="See the source code at GitHub" style="position: fixed; top: 0; right: 0; border: 0; display: inline-block;"><img src="/assets/images/github-ribbon.svg" width="50px" height="50px" alt=""></a>
+  <a href="https://github.com/opensearch-project/opensearch-go/tree/main/_examples/xkcdsearch" title="See the source code at GitHub" style="position: fixed; top: 0; right: 0; border: 0; display: inline-block;"><img src="/assets/images/github-ribbon.svg" width="50px" height="50px" alt=""></a>
 
   <a href="https://xkcd.com/license.html" style="position: fixed; bottom: 0; right: 0; border: 0; display: inline-block;"><img src="https://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc.png" height="15px"></img></a>
 

--- a/doc.go
+++ b/doc.go
@@ -69,8 +69,8 @@ Call the Elasticsearch APIs by invoking the corresponding methods on the client:
 
 		log.Println(res)
 
-See the github.com/elastic/go-elasticsearch/opensearchapi package for more information about using the API.
+See the github.com/opensearch-project/opensearch-go/opensearchapi package for more information about using the API.
 
-See the github.com/elastic/go-elasticsearch/opensearchtransport package for more information about configuring the transport.
+See the github.com/opensearch-project/opensearch-go/opensearchtransport package for more information about configuring the transport.
 */
 package elasticsearch

--- a/opensearchapi/doc.go
+++ b/opensearchapi/doc.go
@@ -111,7 +111,7 @@ about the API endpoints and parameters.
 The Go API is generated from the Elasticsearch JSON specification at
 https://github.com/elastic/elasticsearch/tree/master/rest-api-spec/src/main/resources/rest-api-spec/api
 by the internal package available at
-https://github.com/elastic/go-elasticsearch/tree/master/internal/cmd/generate/commands/gensource.
+https://github.com/opensearch-project/opensearch-go/tree/main/internal/build/cmd/generate/commands/gensource.
 
 The API is tested by integration tests common to all Elasticsearch official clients, generated from the
 source at https://github.com/elastic/elasticsearch/tree/master/rest-api-spec/src/main/resources/rest-api-spec/test.


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
Update github url to opensearch.
 
### Issues Resolved
 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
