### PR TITLE
Update reference to opensearch

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -25,7 +25,7 @@
 // under the License.
 
 /*
-Package opensearch provides a Go client for Elasticsearch.
+Package opensearch provides a Go client for OpenSearch.
 
 Create the client with the NewDefaultClient function:
 
@@ -55,14 +55,11 @@ To configure the client, pass a Config object to the NewClient function:
 
 		opensearch.NewClient(cfg)
 
-When using the Elastic Service (https://elastic.co/cloud), you can use CloudID instead of Addresses.
-When either Addresses or CloudID is set, the ELASTICSEARCH_URL environment variable is ignored.
+See the opensearch_integration_test.go file for more information.
 
-See the opensearch_integration_test.go file and the _examples folder for more information.
+Call the OpenSearch APIs by invoking the corresponding methods on the client:
 
-Call the Elasticsearch APIs by invoking the corresponding methods on the client:
-
-		res, err := es.Info()
+		res, err := client.Info()
 		if err != nil {
 		  log.Fatalf("Error getting response: %s", err)
 		}

--- a/internal/build/cmd/generate/commands/genexamples/generator.go
+++ b/internal/build/cmd/generate/commands/genexamples/generator.go
@@ -107,7 +107,7 @@ var (
 	if !g.Example.IsTranslated() {
 		out.WriteString("// ")
 	}
-	out.WriteString(`es, _ := opensearch.NewDefaultClient()` + "\n")
+	out.WriteString(`client, _ := opensearch.NewDefaultClient()` + "\n")
 
 	if !g.Example.IsTranslated() {
 		out.WriteString("\n\tt.Error(`Missing implementation for: ")

--- a/internal/build/cmd/generate/commands/genexamples/model.go
+++ b/internal/build/cmd/generate/commands/genexamples/model.go
@@ -111,8 +111,6 @@ var (
 
 // Example represents the code example in documentation.
 //
-// See: https://github.com/elastic/built-docs/blob/master/raw/en/elasticsearch/reference/master/alternatives_report.json
-//
 type Example struct {
 	SourceLocation struct {
 		File string
@@ -165,7 +163,8 @@ func (e Example) Chapter() string {
 // GithubURL returns a link for the example source.
 //
 func (e Example) GithubURL() string {
-	return fmt.Sprintf("https://github.com/elastic/elasticsearch/blob/master/docs/reference/%s#L%d", e.SourceLocation.File, e.SourceLocation.Line)
+	//TODO: fix url
+	return fmt.Sprintf("https://github.com/opensearch-project/documentation-website")
 }
 
 // Commands returns the list of commands from source.

--- a/internal/build/cmd/generate/commands/genexamples/translator.go
+++ b/internal/build/cmd/generate/commands/genexamples/translator.go
@@ -57,13 +57,13 @@ var ConsoleToGo = []TranslateRule{
 	{ // ----- Info() -----------------------------------------------------------
 		Pattern: `^GET /\s*$`,
 		Func: func(in string) (string, error) {
-			return "res, err := es.Info()", nil
+			return "res, err := client.Info()", nil
 		}},
 
 	{ // ----- Cat.Health() -----------------------------------------------------
 		Pattern: `^GET /?_cat/health\?v`,
 		Func: func(in string) (string, error) {
-			return "\tres, err := es.Cat.Health(es.Cat.Health.WithV(true))", nil
+			return "\tres, err := client.Cat.Health(client.Cat.Health.WithV(true))", nil
 		}},
 
 	{ // ----- Cat.Indices() -----------------------------------------------------
@@ -77,7 +77,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			fmt.Fprint(&src, "\tres, err := es.Cat.Indices(\n")
+			fmt.Fprint(&src, "\tres, err := client.Cat.Indices(\n")
 
 			if matches[1] != "" {
 				fmt.Fprintf(&src, "\tes.Cat.Indices.WithIndex([]string{%q}...),\n", matches[1])
@@ -110,7 +110,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			fmt.Fprint(&src, "\tres, err := es.Cluster.Health(\n")
+			fmt.Fprint(&src, "\tres, err := client.Cluster.Health(\n")
 
 			if matches[2] != "" {
 				fmt.Fprintf(&src, "\tes.Cluster.Health.WithIndex([]string{%q}...),\n", matches[2])
@@ -143,7 +143,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			fmt.Fprint(&src, "\tres, err := es.Cluster.State(\n")
+			fmt.Fprint(&src, "\tres, err := client.Cluster.State(\n")
 
 			if matches[2] != "" {
 				fmt.Fprintf(&src, "\tes.Cluster.State.WithIndex([]string{%q}...),\n", matches[2])
@@ -176,7 +176,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			fmt.Fprint(&src, "\tres, err := es.Cluster.PutSettings(\n")
+			fmt.Fprint(&src, "\tres, err := client.Cluster.PutSettings(\n")
 			body, err := bodyStringToReader(matches[3])
 			if err != nil {
 				return "", fmt.Errorf("error converting body: %s", err)
@@ -214,7 +214,7 @@ var ConsoleToGo = []TranslateRule{
 			for i, m := range matches {
 				fmt.Println(i, ":", m)
 			}
-			fmt.Fprint(&src, "\tres, err := es.Nodes.Stats(\n")
+			fmt.Fprint(&src, "\tres, err := client.Nodes.Stats(\n")
 
 			if matches[2] != "" {
 				fmt.Fprintf(&src, "\tes.Nodes.Stats.WithNodeID([]string{%q}...),\n", matches[2])
@@ -256,7 +256,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.UpdateByQueryRethrottle(\n")
+			src.WriteString("\tres, err := client.UpdateByQueryRethrottle(\n")
 			fmt.Fprintf(&src, "%q,\n", matches[1])
 			if matches[2] != "" {
 				params, err := url.ParseQuery(strings.TrimPrefix(strings.TrimPrefix(matches[2], "/"), "?"))
@@ -295,7 +295,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.UpdateByQuery(\n")
+			src.WriteString("\tres, err := client.UpdateByQuery(\n")
 			if matches[2] != "" {
 				fmt.Fprintf(&src, "\t[]string{%q},\n", matches[2])
 			}
@@ -339,7 +339,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.Ingest.PutPipeline(\n")
+			src.WriteString("\tres, err := client.Ingest.PutPipeline(\n")
 			fmt.Fprintf(&src, "\t%q,\n", matches[1])
 
 			if matches[3] != "" {
@@ -392,7 +392,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", fmt.Errorf("Unknown API [%s]", matches[3])
 			}
 
-			src.WriteString("\tres, err := es." + apiName + "(\n")
+			src.WriteString("\tres, err := client." + apiName + "(\n")
 
 			fmt.Fprintf(&src, "\t%q,\n", matches[2])
 
@@ -441,7 +441,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.Indices.GetMapping(")
+			src.WriteString("\tres, err := client.Indices.GetMapping(")
 			if matches[1] != "" {
 				fmt.Fprintf(&src, "\tes.Indices.GetMapping.WithIndex(%q),\n", matches[1])
 			}
@@ -473,7 +473,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.Indices.PutMapping(")
+			src.WriteString("\tres, err := client.Indices.PutMapping(")
 
 			if matches[2] != "" || matches[3] != "" {
 				fmt.Fprintf(&src, "\n\t[]string{%q},\n", matches[1])
@@ -514,7 +514,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.Indices.GetSettings(")
+			src.WriteString("\tres, err := client.Indices.GetSettings(")
 
 			if matches[1] != "" {
 				fmt.Fprintf(&src, "\n\t\tes.Indices.GetSettings.WithIndex([]string{%q}...),\n", matches[1])
@@ -547,7 +547,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.Indices.PutSettings(")
+			src.WriteString("\tres, err := client.Indices.PutSettings(")
 
 			if matches[2] != "" || matches[3] != "" {
 				if matches[3] != "" {
@@ -590,7 +590,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.Indices.PutTemplate(")
+			src.WriteString("\tres, err := client.Indices.PutTemplate(")
 			fmt.Fprintf(&src, "\n\t%q,\n", matches[1])
 
 			if matches[2] != "" || matches[3] != "" {
@@ -630,7 +630,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.Indices.GetTemplate(")
+			src.WriteString("\tres, err := client.Indices.GetTemplate(")
 			if matches[1] != "" {
 				fmt.Fprintf(&src, "\n\tes.Indices.GetTemplate.WithName(%q),\n", matches[1])
 			}
@@ -662,7 +662,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.Indices.Create(")
+			src.WriteString("\tres, err := client.Indices.Create(")
 			if matches[2] != "" || matches[3] != "" {
 				fmt.Fprintf(&src, "\n\t%q,\n", matches[1])
 
@@ -704,7 +704,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.ClearScroll(\n")
+			src.WriteString("\tres, err := client.ClearScroll(\n")
 
 			if strings.TrimSpace(matches[1]) != "" {
 				src.WriteString("\t\tes.ClearScroll.WithScrollID(")
@@ -755,7 +755,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			fmt.Fprint(&src, "\tres, err := es.Delete(")
+			fmt.Fprint(&src, "\tres, err := client.Delete(")
 
 			if matches[3] != "" {
 				fmt.Fprintf(&src, "\t%q,\n\t%q,\n", matches[1], matches[2])
@@ -769,9 +769,9 @@ var ConsoleToGo = []TranslateRule{
 				}
 				fmt.Fprint(&src, args)
 
-				src.WriteString("\tes.Delete.WithPretty(),\n")
+				src.WriteString("\tclient.Delete.WithPretty(),\n")
 			} else {
-				fmt.Fprintf(&src, "\t%q, %q, es.Delete.WithPretty()", matches[1], matches[2])
+				fmt.Fprintf(&src, "\t%q, %q, client.Delete.WithPretty()", matches[1], matches[2])
 			}
 			src.WriteString(")")
 
@@ -789,7 +789,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.Indices.Delete(")
+			src.WriteString("\tres, err := client.Indices.Delete(")
 
 			if matches[2] != "" {
 				fmt.Fprintf(&src, "\n\t[]string{%q},\n", matches[1])
@@ -822,7 +822,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.Indices.Refresh(")
+			src.WriteString("\tres, err := client.Indices.Refresh(")
 
 			if matches[1] != "" {
 				fmt.Fprintf(&src, "[]string{%q}", matches[1])
@@ -853,7 +853,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", fmt.Errorf("unknown operation [%s]", matches[2])
 			}
 
-			fmt.Fprintf(&src, "\tres, err := es.Indices.%s(", apiName)
+			fmt.Fprintf(&src, "\tres, err := client.Indices.%s(", apiName)
 
 			if matches[1] != "" {
 				fmt.Fprintf(&src, "[]string{%q}", matches[1])
@@ -877,11 +877,11 @@ var ConsoleToGo = []TranslateRule{
 
 			if matches[1] != "" {
 				apiName = "PutAlias"
-				src.WriteString("\tres, err := es.Indices.PutAlias(")
+				src.WriteString("\tres, err := client.Indices.PutAlias(")
 				fmt.Fprintf(&src, "[]string{%q}", matches[1])
 			} else {
 				apiName = "UpdateAliases"
-				src.WriteString("\tres, err := es.Indices.UpdateAliases(")
+				src.WriteString("\tres, err := client.Indices.UpdateAliases(")
 			}
 
 			if strings.TrimSpace(matches[3]) != "" {
@@ -923,10 +923,10 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.Indices.Forcemerge(")
+			src.WriteString("\tres, err := client.Indices.Forcemerge(")
 
 			if matches[1] != "" {
-				fmt.Fprintf(&src, "\tes.Indices.Forcemerge.WithIndex([]string{%q}...),\n", matches[1])
+				fmt.Fprintf(&src, "\tclient.Indices.Forcemerge.WithIndex([]string{%q}...),\n", matches[1])
 			}
 
 			if matches[2] != "" {
@@ -967,9 +967,9 @@ var ConsoleToGo = []TranslateRule{
 			}
 
 			if matches[4] == "" {
-				fmt.Fprintf(&src, "\tres, err := es."+apiName+"(%q, %q, es."+apiName+".WithPretty()", matches[1], matches[3])
+				fmt.Fprintf(&src, "\tres, err := client."+apiName+"(%q, %q, client."+apiName+".WithPretty()", matches[1], matches[3])
 			} else {
-				fmt.Fprintf(&src, "\tres, err := es."+apiName+"(\n\t%q,\n\t%q,\n\t", matches[1], matches[3])
+				fmt.Fprintf(&src, "\tres, err := client."+apiName+"(\n\t%q,\n\t%q,\n\t", matches[1], matches[3])
 
 				params, err := url.ParseQuery(strings.TrimPrefix(strings.TrimPrefix(matches[4], "/"), "?"))
 				if err != nil {
@@ -1011,9 +1011,9 @@ var ConsoleToGo = []TranslateRule{
 			}
 
 			if matches[4] == "" {
-				fmt.Fprintf(&src, "\tres, err := es."+apiName+"(%q, %q, es."+apiName+".WithPretty()", matches[1], matches[2])
+				fmt.Fprintf(&src, "\tres, err := client."+apiName+"(%q, %q, client."+apiName+".WithPretty()", matches[1], matches[2])
 			} else {
-				fmt.Fprintf(&src, "\tres, err := es."+apiName+"(\n\t%q,\n\t%q,\n\t", matches[1], matches[2])
+				fmt.Fprintf(&src, "\tres, err := client."+apiName+"(\n\t%q,\n\t%q,\n\t", matches[1], matches[2])
 				params, err := url.ParseQuery(strings.TrimPrefix(strings.TrimPrefix(matches[4], "/"), "?"))
 				if err != nil {
 					return "", fmt.Errorf("error parsing URL params: %s", err)
@@ -1043,14 +1043,14 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.Scroll(\n")
+			src.WriteString("\tres, err := client.Scroll(\n")
 
 			if strings.TrimSpace(matches[3]) != "" {
 				body, err := bodyStringToReader(matches[3])
 				if err != nil {
 					return "", fmt.Errorf("error converting body: %s", err)
 				}
-				fmt.Fprintf(&src, "\tes.Scroll.WithBody(%s),\n", body)
+				fmt.Fprintf(&src, "\tclient.Scroll.WithBody(%s),\n", body)
 			}
 
 			var params url.Values
@@ -1075,7 +1075,7 @@ var ConsoleToGo = []TranslateRule{
 			}
 
 			if !hasPretty {
-				src.WriteString("\tes.Scroll.WithPretty(),\n")
+				src.WriteString("\tclient.Scroll.WithPretty(),\n")
 			}
 
 			src.WriteString("\t)")
@@ -1093,9 +1093,9 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.Search(\n")
+			src.WriteString("\tres, err := client.Search(\n")
 			if matches[2] != "" {
-				fmt.Fprintf(&src, "\tes.Search.WithIndex(%q),\n", matches[2])
+				fmt.Fprintf(&src, "\tclient.Search.WithIndex(%q),\n", matches[2])
 			}
 
 			if strings.TrimSpace(matches[4]) != "" {
@@ -1128,7 +1128,7 @@ var ConsoleToGo = []TranslateRule{
 			}
 
 			if !hasPretty {
-				src.WriteString("\tes.Search.WithPretty(),\n")
+				src.WriteString("\tclient.Search.WithPretty(),\n")
 			}
 
 			src.WriteString("\t)")
@@ -1146,7 +1146,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.Count(\n")
+			src.WriteString("\tres, err := client.Count(\n")
 			if matches[1] != "" {
 				fmt.Fprintf(&src, "\tes.Count.WithIndex(%q),\n", matches[2])
 			}
@@ -1181,7 +1181,7 @@ var ConsoleToGo = []TranslateRule{
 			}
 
 			if !hasPretty {
-				src.WriteString("\tes.Count.WithPretty(),\n")
+				src.WriteString("\tclient.Count.WithPretty(),\n")
 			}
 
 			src.WriteString("\t)")
@@ -1200,7 +1200,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.DeleteByQueryRethrottle(\n")
+			src.WriteString("\tres, err := client.DeleteByQueryRethrottle(\n")
 			fmt.Fprintf(&src, "%q,\n", matches[1])
 
 			if matches[2] != "" {
@@ -1240,7 +1240,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.DeleteByQuery(\n")
+			src.WriteString("\tres, err := client.DeleteByQuery(\n")
 			if matches[2] != "" {
 				fmt.Fprintf(&src, "\t[]string{%q},\n", matches[2])
 			}
@@ -1283,7 +1283,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.ReindexRethrottle(\n")
+			src.WriteString("\tres, err := client.ReindexRethrottle(\n")
 			fmt.Fprintf(&src, "%q,\n", matches[1])
 
 			if matches[2] != "" {
@@ -1324,7 +1324,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.Reindex(\n")
+			src.WriteString("\tres, err := client.Reindex(\n")
 
 			if strings.TrimSpace(matches[2]) != "" {
 				body, err := bodyStringToReader(matches[2])
@@ -1362,7 +1362,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.Bulk(\n")
+			src.WriteString("\tres, err := client.Bulk(\n")
 
 			if matches[3] != "" {
 				fmt.Fprintf(&src, "\tstrings.NewReader(`\n%s`),\n", matches[3])
@@ -1400,7 +1400,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.Tasks.Get(\n")
+			src.WriteString("\tres, err := client.Tasks.Get(\n")
 
 			if matches[1] != "" {
 				fmt.Fprintf(&src, "\t%q,\n", matches[1])
@@ -1435,7 +1435,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.Tasks.List(\n")
+			src.WriteString("\tres, err := client.Tasks.List(\n")
 
 			if matches[1] != "" {
 				params, err := url.ParseQuery(strings.TrimPrefix(strings.TrimPrefix(matches[1], "/"), "?"))
@@ -1466,9 +1466,9 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.Tasks.Cancel(\n")
+			src.WriteString("\tres, err := client.Tasks.Cancel(\n")
 			if matches[1] != "" {
-				fmt.Fprintf(&src, "es.Tasks.Cancel.WithTaskID(%q),\n", matches[1])
+				fmt.Fprintf(&src, "client.Tasks.Cancel.WithTaskID(%q),\n", matches[1])
 			}
 
 			if matches[2] != "" {
@@ -1499,7 +1499,7 @@ var ConsoleToGo = []TranslateRule{
 				return "", errors.New("cannot match example source to pattern")
 			}
 
-			src.WriteString("\tres, err := es.Indices.Get(")
+			src.WriteString("\tres, err := client.Indices.Get(")
 
 			if matches[2] != "" {
 				fmt.Fprintf(&src, "\n\t[]string{%q},\n", matches[1])
@@ -1682,13 +1682,13 @@ func paramsToArguments(api string, params url.Values) (string, error) {
 		default:
 			value = strconv.Quote(value)
 		}
-		fmt.Fprintf(&b, "\tes.%s.With%s(%s),\n", api, name, value)
+		fmt.Fprintf(&b, "\tclient.%s.With%s(%s),\n", api, name, value)
 	}
 
 	return b.String(), nil
 }
 
-// bodyStringToReader reformats input JSON string and returns it wrapped in strings.NewReader.
+// bodyStringToReader re formats input JSON string and returns it wrapped in strings.NewReader.
 //
 func bodyStringToReader(input string) (string, error) {
 	var body bytes.Buffer

--- a/internal/build/cmd/generate/commands/gentests/model.go
+++ b/internal/build/cmd/generate/commands/gentests/model.go
@@ -819,8 +819,6 @@ func (s Stash) Value() string {
 
 // expand "unwraps" a field name like `foo.bar.0.baz` into a proper Go structure
 //
-// See https://github.com/elastic/elasticsearch/tree/master/rest-api-spec/src/main/resources/rest-api-spec/test#dot-notation
-//
 func expand(s string, format ...string) string {
 	var (
 		b bytes.Buffer

--- a/internal/build/cmd/generate/commands/gentests/testdata/info/10_basic.yml
+++ b/internal/build/cmd/generate/commands/gentests/testdata/info/10_basic.yml
@@ -24,13 +24,13 @@ teardown:
 
   - is_false: foobar
 
-  - match: { cluster_name: "go-elasticsearch" }
+  - match: { cluster_name: "opensearch-go" }
 
   - match:
       version.lucene_version: /\d\.\d\.\d/
 
   - match:
-      $body: /.*elasticsearch.*/
+      $body: /.*opensearch.*/
 
 # Comment
 ---

--- a/internal/build/cmd/tools/commands/spec/command_test.go
+++ b/internal/build/cmd/tools/commands/spec/command_test.go
@@ -42,15 +42,15 @@ func TestBuild_zipfileUrl(t *testing.T) {
 			json: `
 			{
 			  "start_time": "Mon, 19 Apr 2021 12:15:47 GMT",
-			  "version": "8.0.0-SNAPSHOT",
-			  "build_id": "8.0.0-ab7cd914",
+			  "version": "1.0.0-SNAPSHOT",
+			  "build_id": "1.0.0-ab7cd914",
 			  "projects": {
-				"elasticsearch": {
+				"opensearch": {
 				  "branch": "master",
 				  "commit_hash": "d3be79018b5b70a118ea5a897a539428b728df5a",
 				  "Packages": {
 					"rest-resources-zip-8.0.0-SNAPSHOT.zip": {
-					  "url": "https://snapshots.elastic.co/8.0.0-ab7cd914/downloads/elasticsearch/rest-resources-zip-8.0.0-SNAPSHOT.zip",
+					  "url": "https://artifacts.opensearch.org/rest-resources-zip-1.0.0-SNAPSHOT.zip",
 					  "type": "zip"
 					}
 				  }
@@ -58,7 +58,7 @@ func TestBuild_zipfileUrl(t *testing.T) {
 			  }
 			}
 			`,
-			want: "https://snapshots.elastic.co/8.0.0-ab7cd914/downloads/elasticsearch/rest-resources-zip-8.0.0-SNAPSHOT.zip",
+			want: "https://artifacts.opensearch.org/rest-resources-zip-1.0.0-SNAPSHOT.zip",
 		},
 	}
 	for _, tt := range tests {

--- a/opensearch_benchmark_test.go
+++ b/opensearch_benchmark_test.go
@@ -64,7 +64,7 @@ func (t *FakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		response := t.InfoResponse
 		response.Body = ioutil.NopCloser(strings.NewReader(`{
 		  "name" : "es1",
-		  "cluster_name" : "go-elasticsearch",
+		  "cluster_name" : "opensearch-go",
 		  "cluster_uuid" : "clusteruuid",
 		  "version" : {
 			"number" : "1.0.0",

--- a/opensearch_integration_test.go
+++ b/opensearch_integration_test.go
@@ -48,7 +48,7 @@ import (
 
 func TestClientTransport(t *testing.T) {
 	t.Run("Persistent", func(t *testing.T) {
-		es, err := opensearch.NewDefaultClient()
+		client, err := opensearch.NewDefaultClient()
 		if err != nil {
 			t.Fatalf("Error creating the client: %s", err)
 		}
@@ -58,7 +58,7 @@ func TestClientTransport(t *testing.T) {
 		for i := 0; i < 101; i++ {
 			var curTotal int
 
-			res, err := es.Nodes.Stats(es.Nodes.Stats.WithMetric("http"))
+			res, err := client.Nodes.Stats(client.Nodes.Stats.WithMetric("http"))
 			if err != nil {
 				t.Fatalf("Unexpected error: %s", err)
 			}
@@ -100,7 +100,7 @@ func TestClientTransport(t *testing.T) {
 	t.Run("Concurrent", func(t *testing.T) {
 		var wg sync.WaitGroup
 
-		es, err := opensearch.NewDefaultClient()
+		client, err := opensearch.NewDefaultClient()
 		if err != nil {
 			t.Fatalf("Error creating the client: %s", err)
 		}
@@ -111,7 +111,7 @@ func TestClientTransport(t *testing.T) {
 
 			go func(i int) {
 				defer wg.Done()
-				res, err := es.Info()
+				res, err := client.Info()
 				if err != nil {
 					t.Errorf("Unexpected error: %s", err)
 				} else {
@@ -123,7 +123,7 @@ func TestClientTransport(t *testing.T) {
 	})
 
 	t.Run("WithContext", func(t *testing.T) {
-		es, err := opensearch.NewDefaultClient()
+		client, err := opensearch.NewDefaultClient()
 		if err != nil {
 			t.Fatalf("Error creating the client: %s", err)
 		}
@@ -131,7 +131,7 @@ func TestClientTransport(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
 		defer cancel()
 
-		res, err := es.Info(es.Info.WithContext(ctx))
+		res, err := client.Info(client.Info.WithContext(ctx))
 		if err == nil {
 			res.Body.Close()
 			t.Fatal("Expected 'context deadline exceeded' error")
@@ -153,12 +153,12 @@ func TestClientTransport(t *testing.T) {
 			},
 		}
 
-		es, err := opensearch.NewClient(cfg)
+		client, err := opensearch.NewClient(cfg)
 		if err != nil {
 			t.Fatalf("Error creating the client: %s", err)
 		}
 
-		_, err = es.Info()
+		_, err = client.Info()
 		if err == nil {
 			t.Fatalf("Expected error, but got: %v", err)
 		}
@@ -186,13 +186,13 @@ func TestClientCustomTransport(t *testing.T) {
 			},
 		}
 
-		es, err := opensearch.NewClient(cfg)
+		client, err := opensearch.NewClient(cfg)
 		if err != nil {
 			t.Fatalf("Error creating the client: %s", err)
 		}
 
 		for i := 0; i < 10; i++ {
-			res, err := es.Info()
+			res, err := client.Info()
 			if err != nil {
 				t.Fatalf("Unexpected error: %s", err)
 			}
@@ -208,12 +208,12 @@ func TestClientCustomTransport(t *testing.T) {
 			Transport: http.DefaultTransport,
 		})
 
-		es := opensearch.Client{
+		client := opensearch.Client{
 			Transport: tp, API: opensearchapi.New(tp),
 		}
 
 		for i := 0; i < 10; i++ {
-			res, err := es.Info()
+			res, err := client.Info()
 			if err != nil {
 				t.Fatalf("Unexpected error: %s", err)
 			}
@@ -242,12 +242,12 @@ func (t *ReplacedTransport) Count() uint64 {
 func TestClientReplaceTransport(t *testing.T) {
 	t.Run("Replaced", func(t *testing.T) {
 		tr := &ReplacedTransport{}
-		es := opensearch.Client{
+		client := opensearch.Client{
 			Transport: tr, API: opensearchapi.New(tr),
 		}
 
 		for i := 0; i < 10; i++ {
-			res, err := es.Info()
+			res, err := client.Info()
 			if err != nil {
 				t.Fatalf("Unexpected error: %s", err)
 			}
@@ -262,12 +262,12 @@ func TestClientReplaceTransport(t *testing.T) {
 
 func TestClientAPI(t *testing.T) {
 	t.Run("Info", func(t *testing.T) {
-		es, err := opensearch.NewDefaultClient()
+		client, err := opensearch.NewDefaultClient()
 		if err != nil {
 			log.Fatalf("Error creating the client: %s\n", err)
 		}
 
-		res, err := es.Info()
+		res, err := client.Info()
 		if err != nil {
 			log.Fatalf("Error getting the response: %s\n", err)
 		}

--- a/opensearch_internal_test.go
+++ b/opensearch_internal_test.go
@@ -331,19 +331,19 @@ func TestParseElasticsearchVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1, got2, err := ParseElasticsearchVersion(tt.version)
+			got, got1, got2, err := ParseVersion(tt.version)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseElasticsearchVersion() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ParseVersion() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.major {
-				t.Errorf("ParseElasticsearchVersion() got = %v, want %v", got, tt.major)
+				t.Errorf("ParseVersion() got = %v, want %v", got, tt.major)
 			}
 			if got1 != tt.minor {
-				t.Errorf("ParseElasticsearchVersion() got1 = %v, want %v", got1, tt.minor)
+				t.Errorf("ParseVersion() got1 = %v, want %v", got1, tt.minor)
 			}
 			if got2 != tt.patch {
-				t.Errorf("ParseElasticsearchVersion() got2 = %v, want %v", got2, tt.patch)
+				t.Errorf("ParseVersion() got2 = %v, want %v", got2, tt.patch)
 			}
 		})
 	}

--- a/opensearch_secure_integration_test.go
+++ b/opensearch_secure_integration_test.go
@@ -47,11 +47,11 @@ type Info struct {
 
 func TestSecuredClientAPI(t *testing.T) {
 	t.Run("Check Info", func(t *testing.T) {
-		es, err := getSecuredClient()
+		client, err := getSecuredClient()
 		if err != nil {
 			log.Fatalf("Error creating the client: %s\n", err)
 		}
-		res, err := es.Info()
+		res, err := client.Info()
 		if err != nil {
 			log.Fatalf("Error getting the response: %s\n", err)
 		}

--- a/opensearchapi/api._.go
+++ b/opensearchapi/api._.go
@@ -26,7 +26,7 @@
 
 package opensearchapi
 
-// API contains the Elasticsearch APIs
+// API contains the OpenSearch APIs
 //
 type API struct {
 	Cat         *Cat

--- a/opensearchapi/api.nodes.reload_secure_settings.go
+++ b/opensearchapi/api.nodes.reload_secure_settings.go
@@ -169,7 +169,7 @@ func (f NodesReloadSecureSettings) WithContext(v context.Context) func(*NodesRel
 	}
 }
 
-// WithBody - An object containing the password for the elasticsearch keystore.
+// WithBody - An object containing the password for the opensearch keystore.
 //
 func (f NodesReloadSecureSettings) WithBody(v io.Reader) func(*NodesReloadSecureSettingsRequest) {
 	return func(r *NodesReloadSecureSettingsRequest) {

--- a/opensearchapi/doc.go
+++ b/opensearchapi/doc.go
@@ -25,26 +25,26 @@
 // under the License.
 
 /*
-Package opensearchapi provides the Go API for Elasticsearch.
+Package opensearchapi provides the Go API for OpenSearch.
 
 It is automatically included in the client provided by the
 github.com/opensearch-project/opensearch-go package:
 
-	es, _ := opensearch.NewDefaultClient()
-	res, _ := es.Info()
+	client, _ := opensearch.NewDefaultClient()
+	res, _ := client.Info()
 	log.Println(res)
 
-For each Elasticsearch API, such as "Index", the package exports two corresponding types:
+For each OpenSearch API, such as "Index", the package exports two corresponding types:
 a function and a struct.
 
-The function type allows you to call the Elasticsearch API as a method on the client,
+The function type allows you to call the OpenSearch API as a method on the client,
 passing the parameters as arguments:
 
-	res, err := es.Index(
+	res, err := client.Index(
 		"test",                                  // Index name
 		strings.NewReader(`{"title" : "Test"}`), // Document body
-		es.Index.WithDocumentID("1"),            // Document ID
-		es.Index.WithRefresh("true"),            // Refresh
+		client.Index.WithDocumentID("1"),            // Document ID
+		client.Index.WithRefresh("true"),            // Refresh
 	)
 	if err != nil {
 		log.Fatalf("ERROR: %s", err)
@@ -66,7 +66,7 @@ with a context and the client as arguments:
 		Refresh:    "true",                                  // Refresh
 	}
 
-	res, err := req.Do(context.Background(), es)
+	res, err := req.Do(context.Background(), client)
 	if err != nil {
 		log.Fatalf("Error getting response: %s", err)
 	}
@@ -101,21 +101,6 @@ It is imperative to close the response body for a non-nil response.
 The Response type implements a couple of convenience methods for accessing
 the status, checking an error status code or printing
 the response body for debugging purposes.
-
-Additional Information
-
-See the Elasticsearch documentation at
-https://www.elastic.co/guide/en/elasticsearch/reference/master/api-conventions.html for detailed information
-about the API endpoints and parameters.
-
-The Go API is generated from the Elasticsearch JSON specification at
-https://github.com/elastic/elasticsearch/tree/master/rest-api-spec/src/main/resources/rest-api-spec/api
-by the internal package available at
-https://github.com/opensearch-project/opensearch-go/tree/main/internal/build/cmd/generate/commands/gensource.
-
-The API is tested by integration tests common to all Elasticsearch official clients, generated from the
-source at https://github.com/elastic/elasticsearch/tree/master/rest-api-spec/src/main/resources/rest-api-spec/test.
-The generator is provided by the internal package available at internal/cmd/generate/commands/gentests.
 
 */
 package opensearchapi

--- a/opensearchapi/opensearchapi.response_example_test.go
+++ b/opensearchapi/opensearchapi.response_example_test.go
@@ -33,9 +33,9 @@ import (
 )
 
 func ExampleResponse_IsError() {
-	es, _ := opensearch.NewDefaultClient()
+	client, _ := opensearch.NewDefaultClient()
 
-	res, err := es.Info()
+	res, err := client.Info()
 
 	// Handle connection errors
 	//
@@ -56,23 +56,23 @@ func ExampleResponse_IsError() {
 }
 
 func ExampleResponse_Status() {
-	es, _ := opensearch.NewDefaultClient()
+	client, _ := opensearch.NewDefaultClient()
 
-	res, _ := es.Info()
+	res, _ := client.Info()
 	log.Println(res.Status())
 
 	// 200 OK
 }
 
 func ExampleResponse_String() {
-	es, _ := opensearch.NewDefaultClient()
+	client, _ := opensearch.NewDefaultClient()
 
-	res, _ := es.Info()
+	res, _ := client.Info()
 	log.Println(res.String())
 
 	// [200 OK] {
-	// "name" : "es1",
-	// "cluster_name" : "go-elasticsearch",
+	// "name" : "opensearch1",
+	// "cluster_name" : "opensearch-go",
 	// ...
 	// }
 }

--- a/opensearchapi/opensearchapi_benchmark_test.go
+++ b/opensearchapi/opensearchapi_benchmark_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/opensearch-project/opensearch-go/opensearchapi"
 )
 
-// TODO(karmi): Refactor into a shared mock/testing package
+// TODO: Refactor into a shared mock/testing package
 
 var (
 	defaultResponse    = &http.Response{
@@ -89,34 +89,34 @@ func (t *FakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func newFakeClient(b *testing.B) *opensearch.Client {
 	cfg := opensearch.Config{Transport: &FakeTransport{RoundTripFn: defaultRoundTripFn}}
-	es, err := opensearch.NewClient(cfg)
+	client, err := opensearch.NewClient(cfg)
 
 	if err != nil {
 		b.Fatalf("Unexpected error when creating a client: %s", err)
 	}
 
-	return es
+	return client
 }
 
 func newFakeClientWithError(b *testing.B) *opensearch.Client {
 	cfg := opensearch.Config{Transport: &FakeTransport{RoundTripFn: errorRoundTripFn}}
-	es, err := opensearch.NewClient(cfg)
+	client, err := opensearch.NewClient(cfg)
 
 	if err != nil {
 		b.Fatalf("Unexpected error when creating a client: %s", err)
 	}
 
-	return es
+	return client
 }
 
 func BenchmarkAPI(b *testing.B) {
-	var es = newFakeClient(b)
-	var eserr = newFakeClientWithError(b)
+	var client = newFakeClient(b)
+	var fakeClientWithError = newFakeClientWithError(b)
 
 	b.Run("client.Info()                      ", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			if _, err := es.Info(); err != nil {
+			if _, err := client.Info(); err != nil {
 				b.Errorf("Unexpected error when getting a response: %s", err)
 			}
 		}
@@ -125,7 +125,7 @@ func BenchmarkAPI(b *testing.B) {
 	b.Run("client.Info() WithContext          ", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			if _, err := es.Info(es.Info.WithContext(context.Background())); err != nil {
+			if _, err := client.Info(client.Info.WithContext(context.Background())); err != nil {
 				b.Errorf("Unexpected error when getting a response: %s", err)
 			}
 		}
@@ -135,7 +135,7 @@ func BenchmarkAPI(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			req := opensearchapi.InfoRequest{}
-			if _, err := req.Do(context.Background(), es); err != nil {
+			if _, err := req.Do(context.Background(), client); err != nil {
 				b.Errorf("Unexpected error when getting a response: %s", err)
 			}
 		}
@@ -144,7 +144,7 @@ func BenchmarkAPI(b *testing.B) {
 	b.Run("client.Cluster.Health()            ", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			if _, err := es.Cluster.Health(); err != nil {
+			if _, err := client.Cluster.Health(); err != nil {
 				b.Errorf("Unexpected error when getting a response: %s", err)
 			}
 		}
@@ -153,10 +153,10 @@ func BenchmarkAPI(b *testing.B) {
 	b.Run("client.Cluster.Health() With()     ", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			_, err := es.Cluster.Health(
-				es.Cluster.Health.WithContext(context.Background()),
-				es.Cluster.Health.WithLevel("indices"),
-				es.Cluster.Health.WithPretty(),
+			_, err := client.Cluster.Health(
+				client.Cluster.Health.WithContext(context.Background()),
+				client.Cluster.Health.WithLevel("indices"),
+				client.Cluster.Health.WithPretty(),
 			)
 
 			if err != nil {
@@ -169,7 +169,7 @@ func BenchmarkAPI(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			req := opensearchapi.ClusterHealthRequest{}
-			if _, err := req.Do(context.Background(), es); err != nil {
+			if _, err := req.Do(context.Background(), client); err != nil {
 				b.Errorf("Unexpected error when getting a response: %s", err)
 			}
 		}
@@ -179,7 +179,7 @@ func BenchmarkAPI(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			req := opensearchapi.ClusterHealthRequest{Level: "indices", Pretty: true}
-			if _, err := req.Do(context.Background(), es); err != nil {
+			if _, err := req.Do(context.Background(), client); err != nil {
 				b.Errorf("Unexpected error when getting a response: %s", err)
 			}
 		}
@@ -190,15 +190,15 @@ func BenchmarkAPI(b *testing.B) {
 		body := strings.NewReader(`{"title" : "Test"}`)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			_, err := es.Index(
+			_, err := client.Index(
 				indx,
 				body,
-				es.Index.WithDocumentID("1"),
-				es.Index.WithRefresh("true"),
-				es.Index.WithContext(context.Background()),
-				es.Index.WithRefresh("true"),
-				es.Index.WithPretty(),
-				es.Index.WithTimeout(100),
+				client.Index.WithDocumentID("1"),
+				client.Index.WithRefresh("true"),
+				client.Index.WithContext(context.Background()),
+				client.Index.WithRefresh("true"),
+				client.Index.WithPretty(),
+				client.Index.WithTimeout(100),
 			)
 
 			if err != nil {
@@ -226,7 +226,7 @@ func BenchmarkAPI(b *testing.B) {
 				Timeout:    100,
 			}
 
-			if _, err := req.Do(context.Background(), es); err != nil {
+			if _, err := req.Do(context.Background(), client); err != nil {
 				b.Errorf("Unexpected error when getting a response: %s", err)
 			}
 		}
@@ -251,7 +251,7 @@ func BenchmarkAPI(b *testing.B) {
 			req.DocumentID = docID
 			req.Body = strings.NewReader(body.String())
 
-			if _, err := req.Do(context.Background(), es); err != nil {
+			if _, err := req.Do(context.Background(), client); err != nil {
 				b.Errorf("Unexpected error when getting a response: %s", err)
 			}
 		}
@@ -261,7 +261,7 @@ func BenchmarkAPI(b *testing.B) {
 		body := strings.NewReader(`{"query" : { "match_all" : {} } }`)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			_, err := es.Search(es.Search.WithContext(context.Background()), es.Search.WithBody(body))
+			_, err := client.Search(client.Search.WithContext(context.Background()), client.Search.WithBody(body))
 
 			if err != nil {
 				b.Errorf("Unexpected error when getting a response: %s", err)
@@ -274,7 +274,7 @@ func BenchmarkAPI(b *testing.B) {
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			_, err := eserr.Search(eserr.Search.WithContext(context.Background()), eserr.Search.WithBody(body))
+			_, err := fakeClientWithError.Search(fakeClientWithError.Search.WithContext(context.Background()), fakeClientWithError.Search.WithBody(body))
 
 			if err != nil {
 				b.Errorf("Unexpected error when getting a response: %s", err)
@@ -288,7 +288,7 @@ func BenchmarkAPI(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			req := opensearchapi.SearchRequest{Body: body}
-			if _, err := req.Do(context.Background(), es); err != nil {
+			if _, err := req.Do(context.Background(), client); err != nil {
 				b.Errorf("Unexpected error when getting a response: %s", err)
 			}
 		}
@@ -300,7 +300,7 @@ func BenchmarkAPI(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			req := opensearchapi.SearchRequest{Body: body}
-			if _, err := req.Do(context.Background(), eserr); err != nil {
+			if _, err := req.Do(context.Background(), fakeClientWithError); err != nil {
 				b.Errorf("Unexpected error when getting a response: %s", err)
 			}
 		}

--- a/opensearchtransport/discovery.go
+++ b/opensearchtransport/discovery.go
@@ -46,8 +46,6 @@ type Discoverable interface {
 
 // nodeInfo represents the information about node in a cluster.
 //
-// See: https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html
-//
 type nodeInfo struct {
 	ID         string
 	Name       string
@@ -93,7 +91,7 @@ func (c *Client) DiscoverNodes() error {
 		}
 
 		// Skip master only nodes
-		// TODO(karmi): Move logic to Selector?
+		// TODO: Move logic to Selector?
 		if isMasterOnlyNode {
 			continue
 		}
@@ -118,7 +116,7 @@ func (c *Client) DiscoverNodes() error {
 	if c.poolFunc != nil {
 		c.pool = c.poolFunc(conns, c.selector)
 	} else {
-		// TODO(karmi): Replace only live connections, leave dead scheduled for resurrect?
+		// TODO: Replace only live connections, leave dead scheduled for resurrect?
 		c.pool, err = NewConnectionPool(conns, c.selector)
 		if err != nil {
 			return err
@@ -142,7 +140,7 @@ func (c *Client) getNodesInfo() ([]nodeInfo, error) {
 	c.Lock()
 	conn, err := c.pool.Next()
 	c.Unlock()
-	// TODO(karmi): If no connection is returned, fallback to original URLs
+	// TODO: If no connection is returned, fallback to original URLs
 	if err != nil {
 		return out, err
 	}

--- a/opensearchtransport/doc.go
+++ b/opensearchtransport/doc.go
@@ -25,13 +25,12 @@
 // under the License.
 
 /*
-Package opensearchtransport provides the transport layer for the Elasticsearch client.
+Package opensearchtransport provides the transport layer for the OpenSearch client.
 
-It is automatically included in the client provided by the github.com/opensearchproject/opensearch-go package
-and is not intended for direct use: to configure the client, use the elasticsearch.Config struct.
+It is automatically included in the client provided by the github.com/opensearch-project/opensearch-go package
+and is not intended for direct use: to configure the client, use the opensearch.Config struct.
 
 The default HTTP transport of the client is http.Transport; use the Transport option to customize it;
-see the _examples/coniguration.go and _examples/customization.go files in this repository for information.
 
 The package will automatically retry requests on network-related errors, and on specific
 response status codes (by default 502, 503, 504). Use the RetryOnStatus option to customize the list.

--- a/opensearchtransport/logger.go
+++ b/opensearchtransport/logger.go
@@ -305,9 +305,7 @@ func (l *CurlLogger) ResponseBodyEnabled() bool { return l.EnableResponseBody }
 // LogRoundTrip prints the information about request and response.
 //
 func (l *JSONLogger) LogRoundTrip(req *http.Request, res *http.Response, err error, start time.Time, dur time.Duration) error {
-	// https://github.com/elastic/ecs/blob/master/schemas/http.yml
-	//
-	// TODO(karmi): Research performance optimization of using sync.Pool
+	// TODO: Research performance optimization of using sync.Pool
 
 	bsize := 200
 	var b = bytes.NewBuffer(make([]byte, 0, bsize))

--- a/opensearchtransport/opensearchtransport.go
+++ b/opensearchtransport/opensearchtransport.go
@@ -481,7 +481,7 @@ func (c *Client) logRoundTrip(
 func initUserAgent() string {
 	var b strings.Builder
 
-	b.WriteString("go-elasticsearch")
+	b.WriteString("opensearch-go")
 	b.WriteRune('/')
 	b.WriteString(Version)
 	b.WriteRune(' ')

--- a/opensearchtransport/opensearchtransport_internal_test.go
+++ b/opensearchtransport/opensearchtransport_internal_test.go
@@ -350,7 +350,7 @@ func TestTransportPerform(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/abc", nil)
 		tp.setReqUserAgent(req)
 
-		if !strings.HasPrefix(req.UserAgent(), "go-elasticsearch") {
+		if !strings.HasPrefix(req.UserAgent(), "opensearch-go") {
 			t.Errorf("Unexpected user agent: %s", req.UserAgent())
 		}
 	})
@@ -913,12 +913,12 @@ func TestRequestCompression(t *testing.T) {
 		{
 			name:            "Uncompressed",
 			compressionFlag: false,
-			inputBody:       "elasticsearch",
+			inputBody:       "opensearch",
 		},
 		{
 			name:            "Compressed",
 			compressionFlag: true,
-			inputBody:       "elasticsearch",
+			inputBody:       "opensearch",
 		},
 	}
 

--- a/opensearchtransport/testdata/nodes.info.json
+++ b/opensearchtransport/testdata/nodes.info.json
@@ -4,7 +4,7 @@
     "successful": 3,
     "failed": 0
   },
-  "cluster_name": "elasticsearch",
+  "cluster_name": "opensearch",
   "nodes": {
     "8g1UNpQNS06tlH1DUMBNhg": {
       "name": "es1",

--- a/opensearchutil/bulk_indexer.go
+++ b/opensearchutil/bulk_indexer.go
@@ -44,7 +44,7 @@ import (
 	"github.com/opensearch-project/opensearch-go/opensearchapi"
 )
 
-// BulkIndexer represents a parallel, asynchronous, efficient indexer for Elasticsearch.
+// BulkIndexer represents a parallel, asynchronous, efficient indexer for OpenSearch.
 //
 type BulkIndexer interface {
 	// Add adds an item to the indexer. It returns an error when the item cannot be added.
@@ -70,7 +70,7 @@ type BulkIndexerConfig struct {
 	FlushBytes    int           // The flush threshold in bytes. Defaults to 5MB.
 	FlushInterval time.Duration // The flush threshold as duration. Defaults to 30sec.
 
-	Client      *opensearch.Client      // The Elasticsearch client.
+	Client      *opensearch.Client      // The OpenSearch client.
 	Decoder     BulkResponseJSONDecoder // A custom JSON decoder.
 	DebugLogger BulkIndexerDebugLogger  // An optional logger for debugging.
 
@@ -121,7 +121,7 @@ type BulkIndexerItem struct {
 	OnFailure func(context.Context, BulkIndexerItem, BulkIndexerResponseItem, error) // Per item
 }
 
-// BulkIndexerResponse represents the Elasticsearch response.
+// BulkIndexerResponse represents the OpenSearch response.
 //
 type BulkIndexerResponse struct {
 	Took      int                                  `json:"took"`
@@ -129,7 +129,7 @@ type BulkIndexerResponse struct {
 	Items     []map[string]BulkIndexerResponseItem `json:"items,omitempty"`
 }
 
-// BulkIndexerResponseItem represents the Elasticsearch response item.
+// BulkIndexerResponseItem represents the OpenSearch response item.
 //
 type BulkIndexerResponseItem struct {
 	Index      string `json:"_index"`
@@ -552,7 +552,7 @@ func (w *worker) flush(ctx context.Context) error {
 		)
 
 		item = w.items[i]
-		// The Elasticsearch bulk response contains an array of maps like this:
+		// The OpenSearch bulk response contains an array of maps like this:
 		//   [ { "index": { ... } }, { "create": { ... } }, ... ]
 		// We range over the map, to set the first key and value as "op" and "info".
 		for k, v := range blkItem {

--- a/opensearchutil/bulk_indexer_benchmark_test.go
+++ b/opensearchutil/bulk_indexer_benchmark_test.go
@@ -72,9 +72,9 @@ func BenchmarkBulkIndexer(b *testing.B) {
 	b.Run("Basic", func(b *testing.B) {
 		b.ResetTimer()
 
-		es, _ := opensearch.NewClient(opensearch.Config{Transport: &mockTransp{}})
+		client, _ := opensearch.NewClient(opensearch.Config{Transport: &mockTransp{}})
 		bi, _ := opensearchutil.NewBulkIndexer(opensearchutil.BulkIndexerConfig{
-			Client:     es,
+			Client:     client,
 			FlushBytes: 1024,
 		})
 		defer bi.Close(context.Background())

--- a/opensearchutil/bulk_indexer_example_test.go
+++ b/opensearchutil/bulk_indexer_example_test.go
@@ -42,9 +42,9 @@ import (
 func ExampleNewBulkIndexer() {
 	log.SetFlags(0)
 
-	// Create the Elasticsearch client
+	// Create the OpenSearch client
 	//
-	es, err := opensearch.NewClient(opensearch.Config{
+	client, err := opensearch.NewClient(opensearch.Config{
 		// Retry on 429 TooManyRequests statuses
 		//
 		RetryOnStatus: []int{502, 503, 504, 429},
@@ -64,7 +64,7 @@ func ExampleNewBulkIndexer() {
 	// Create the indexer
 	//
 	indexer, err := opensearchutil.NewBulkIndexer(opensearchutil.BulkIndexerConfig{
-		Client:     es,     // The Elasticsearch client
+		Client:     client, // The OpenSearch client
 		Index:      "test", // The default index name
 		NumWorkers: 4,      // The number of worker goroutines (default: number of CPUs)
 		FlushBytes: 5e+6,   // The flush threshold in bytes (default: 5M)

--- a/opensearchutil/bulk_indexer_integration_test.go
+++ b/opensearchutil/bulk_indexer_integration_test.go
@@ -66,20 +66,20 @@ func TestBulkIndexerIntegration(t *testing.T) {
 				var countSuccessful uint64
 				indexName := "test-bulk-integration"
 
-				es, _ := opensearch.NewClient(opensearch.Config{
+				client, _ := opensearch.NewClient(opensearch.Config{
 					CompressRequestBody: tt.CompressRequestBodyEnabled,
 					Logger:              &opensearchtransport.ColorLogger{Output: os.Stdout},
 				})
 
-				es.Indices.Delete([]string{indexName}, es.Indices.Delete.WithIgnoreUnavailable(true))
-				es.Indices.Create(
+				client.Indices.Delete([]string{indexName}, client.Indices.Delete.WithIgnoreUnavailable(true))
+				client.Indices.Create(
 					indexName,
-					es.Indices.Create.WithBody(strings.NewReader(`{"settings": {"number_of_shards": 1, "number_of_replicas": 0, "refresh_interval":"5s"}}`)),
-					es.Indices.Create.WithWaitForActiveShards("1"))
+					client.Indices.Create.WithBody(strings.NewReader(`{"settings": {"number_of_shards": 1, "number_of_replicas": 0, "refresh_interval":"5s"}}`)),
+					client.Indices.Create.WithWaitForActiveShards("1"))
 
 				bi, _ := opensearchutil.NewBulkIndexer(opensearchutil.BulkIndexerConfig{
 					Index:  indexName,
-					Client: es,
+					Client: client,
 					// FlushBytes: 3e+6,
 				})
 
@@ -132,14 +132,14 @@ func TestBulkIndexerIntegration(t *testing.T) {
 			})
 
 			t.Run("Multiple indices", func(t *testing.T) {
-				es, _ := opensearch.NewClient(opensearch.Config{
+				client, _ := opensearch.NewClient(opensearch.Config{
 					CompressRequestBody: tt.CompressRequestBodyEnabled,
 					Logger:              &opensearchtransport.ColorLogger{Output: os.Stdout},
 				})
 
 				bi, _ := opensearchutil.NewBulkIndexer(opensearchutil.BulkIndexerConfig{
 					Index:  "test-index-a",
-					Client: es,
+					Client: client,
 				})
 
 				// Default index
@@ -188,7 +188,7 @@ func TestBulkIndexerIntegration(t *testing.T) {
 					t.Errorf("Unexpected NumIndexed: want=%d, got=%d", expectedIndexed, stats.NumIndexed)
 				}
 
-				res, err := es.Indices.Exists([]string{"test-index-a", "test-index-b", "test-index-c"})
+				res, err := client.Indices.Exists([]string{"test-index-a", "test-index-b", "test-index-c"})
 				if err != nil {
 					t.Fatalf("Unexpected error: %s", err)
 				}

--- a/opensearchutil/doc.go
+++ b/opensearchutil/doc.go
@@ -25,7 +25,7 @@
 // under the License.
 
 /*
-Package opensearchutil provides helper utilities to the Go client for Elasticsearch.
+Package opensearchutil provides helper utilities to the Go client for OpenSearch.
 
 */
 package opensearchutil

--- a/opensearchutil/json_reader_integration_test.go
+++ b/opensearchutil/json_reader_integration_test.go
@@ -44,18 +44,18 @@ func TestJSONReaderIntegration(t *testing.T) {
 			err error
 		)
 
-		es, err := opensearch.NewDefaultClient()
+		client, err := opensearch.NewDefaultClient()
 		if err != nil {
 			t.Fatalf("Error creating the client: %s\n", err)
 		}
 
-		es.Indices.Delete([]string{"test"}, es.Indices.Delete.WithIgnoreUnavailable(true))
+		client.Indices.Delete([]string{"test"}, client.Indices.Delete.WithIgnoreUnavailable(true))
 
 		doc := struct {
 			Title string `json:"title"`
 		}{Title: "Foo Bar"}
 
-		res, err = es.Index("test", opensearchutil.NewJSONReader(&doc), es.Index.WithRefresh("true"))
+		res, err = client.Index("test", opensearchutil.NewJSONReader(&doc), client.Index.WithRefresh("true"))
 		if err != nil {
 			t.Fatalf("Error getting response: %s", err)
 		}
@@ -73,10 +73,10 @@ func TestJSONReaderIntegration(t *testing.T) {
 			},
 		}
 
-		res, err = es.Search(
-			es.Search.WithIndex("test"),
-			es.Search.WithBody(opensearchutil.NewJSONReader(&query)),
-			es.Search.WithPretty(),
+		res, err = client.Search(
+			client.Search.WithIndex("test"),
+			client.Search.WithBody(opensearchutil.NewJSONReader(&query)),
+			client.Search.WithPretty(),
 		)
 		if err != nil {
 			t.Fatalf("Error getting response: %s", err)


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
Update variable, link, reference to opensearch.
Renamed variable name using Goland refactor.
Rest, manually replaced by identifying using grep 
```
grep -w -R "es" .
grep -w -R "elasticsearch" .
grep -w -R "elasticsearch-go" .
grep -w -R "github.com/elastic" .
grep -w -R "elastic" .
grep -w -R "Elasticsearch" .
```
 
### Issues Resolved
#51 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
