### PR TITLE
Accept OPENSEARCH_URL for address

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -31,8 +31,9 @@ Create the client with the NewDefaultClient function:
 
 		opensearch.NewDefaultClient()
 
-The ELASTICSEARCH_URL environment variable is used instead of the default URL, when set.
+The OPENSEARCH_URL/ELASTICSEARCH_URL environment variable is used instead of the default URL, when set.
 Use a comma to separate multiple URLs.
+It is an error to set both environment variable.
 
 To configure the client, pass a Config object to the NewClient function:
 


### PR DESCRIPTION
### Description
Accept OPENSEARCH_URL and ELASTICSEARCH_URL for backward compatibility, but not together.
 
### Issues Resolved
#49
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
