### PR TITLE
Add documentation badge to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Go Reference](https://pkg.go.dev/badge/github.com/opensearch-project/opensearch-go.svg)](https://pkg.go.dev/github.com/opensearch-project/opensearch-go)
 [![Build](https://github.com/opensearch-project/opensearch-go/actions/workflows/build.yml/badge.svg)](https://github.com/opensearch-project/opensearch-go/actions/workflows/build.yml)
 [![Unit](https://github.com/opensearch-project/opensearch-go/actions/workflows/test-unit.yml/badge.svg)](https://github.com/opensearch-project/opensearch-go/actions/workflows/test-unit.yml)
 [![Integration](https://github.com/opensearch-project/opensearch-go/actions/workflows/test-integration.yml/badge.svg)](https://github.com/opensearch-project/opensearch-go/actions/workflows/test-integration.yml)


### PR DESCRIPTION
Just adding the documentation badge pointing to the documentation on pkg.go.dev.