### PR TITLE
opensearchutil: fix dropped test error

### DIFF
--- a/opensearchutil/bulk_indexer_internal_test.go
+++ b/opensearchutil/bulk_indexer_internal_test.go
@@ -314,6 +314,9 @@ func TestBulkIndexer(t *testing.T) {
 			successfulItemBodies = append(successfulItemBodies, string(buf))
 		}
 		failureFunc := func(ctx context.Context, item BulkIndexerItem, res BulkIndexerResponseItem, err error) {
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
 			atomic.AddUint64(&countFailed, 1)
 			failedIDs = append(failedIDs, item.DocumentID)
 


### PR DESCRIPTION
This fixes a spot in the tests where an `err` was being passed into a function but then dropped.

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
