### PR TITLE
Adding support to test against unreleased OpenSearch

### DIFF
--- a/.github/workflows/test-integration-unreleased.yml
+++ b/.github/workflows/test-integration-unreleased.yml
@@ -1,0 +1,53 @@
+name: Integration with Unreleased OpenSearch
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        entry:
+          - { opensearch_ref: '1.x' }
+    steps:
+      - name: Checkout OpenSearch
+        uses: actions/checkout@v2
+        with:
+          repository: opensearch-project/OpenSearch
+          ref: ${{ matrix.entry.opensearch_ref }}
+          path: opensearch
+
+      - name: Assemble OpenSearch
+        run: |
+          cd opensearch
+          ./gradlew assemble
+        # This step runs the docker image generated during gradle assemble in OpenSearch. It is tagged as opensearch:test.
+        # Reference: https://github.com/opensearch-project/OpenSearch/blob/2.0/distribution/docker/build.gradle#L190
+      - name: Run Docker Image
+        run: |
+          docker run -p 9200:9200 -p 9600:9600 -d -e "discovery.type=single-node" -e "bootstrap.memory_lock=true" opensearch:test
+          sleep 90
+      
+      - name: Checkout Go Client
+        uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v2.1.3
+        with: { go-version: '1.x' }
+
+      - name: Increase system limits
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+
+      - name: Integration test
+        run: make test-integ race=true


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Adding support to run integration tests against unreleased versions of OpenSearch. This will help in getting the client ready for the next OpenSearch release.

### Issues Resolved
Part of #99  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
