### PR TITLE
Bump client version to 2.0 and add OpenSearch 2.0

### DIFF
--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -18,6 +18,7 @@ jobs:
           - { opensearch_version: 1.2.4 }
           - { opensearch_version: 1.3.0 }
           - { opensearch_version: 1.3.1 }
+          - { opensearch_version: 2.0.0 }
     steps:
       - uses: actions/checkout@v2
         with: { fetch-depth: 1 }

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,4 +1,5 @@
 - [Compatibility with OpenSearch](#compatibility-with-opensearch)
+- [Upgrading](#upgrading)
 
 ## Compatibility with OpenSearch
 
@@ -16,3 +17,8 @@ The below matrix shows the compatibility of the [`opensearch-go`](https://pkg.go
 | 1.2.4 | 1.1.0 |
 | 1.3.0 | 1.1.0 |
 | 1.3.1 | 1.1.0 |
+| 2.0.0 | 2.0.0 |
+
+## Upgrading
+
+Major versions of OpenSearch introduce breaking changes that require careful upgrades of the client. While `opensearch-go-client` 2.0.0 works against OpenSearch 1.3.1, certain deprecated features removed in OpenSearch 2.0 have also been removed from the client. Please refer to the [OpenSearch documentation](https://opensearch.org/docs/latest/clients/index/) for more information.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -28,4 +28,4 @@ package version
 
 // Client returns the client version as a string.
 //
-const Client = "1.0.0"
+const Client = "2.0.0"


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
* Bump client version to 2.0.0.
* Add OpenSearch 2.0 to test matrix.

### Issues Resolved
#110 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
