### PR TITLE
Bumping client version to 2.0.1

### DIFF
--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -22,6 +22,7 @@ jobs:
           - { opensearch_version: 1.3.3 }
           - { opensearch_version: 2.0.0 }
           - { opensearch_version: 2.0.1 }
+          - { opensearch_version: 2.1.0 }
     steps:
       - uses: actions/checkout@v2
         with: { fetch-depth: 1 }

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -9,8 +9,8 @@ The below matrix shows the compatibility of the [`opensearch-go`](https://pkg.go
 | --- | --- |
 | 1.0.0 | 1.0.0-1.0.1 |
 | 1.1.0 | 1.1.0-1.3.1 |
-| 2.0.0 | 2.0.0-2.0.1 |
-| 2.0.1 | 2.0.0-2.0.1 |
+| 2.0.0 | 2.0.0-2.1.0 |
+| 2.0.1 | 2.0.0-2.1.0 |
 
 ## Upgrading
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -5,22 +5,12 @@
 
 The below matrix shows the compatibility of the [`opensearch-go`](https://pkg.go.dev/github.com/opensearch-project/opensearch-go) with versions of [`OpenSearch`](https://opensearch.org/downloads.html#opensearch).
 
-| OpenSearch Version | Client Version |
+| Client Version | OpenSearch Version |
 | --- | --- |
-| 1.0.0 | 1.0.0 |
-| 1.0.1 | 1.0.0 |
-| 1.1.0 | 1.1.0 |
-| 1.2.0 | 1.1.0 |
-| 1.2.1 | 1.1.0 |
-| 1.2.2 | 1.1.0 |
-| 1.2.3 | 1.1.0 |
-| 1.2.4 | 1.1.0 |
-| 1.3.0 | 1.1.0 |
-| 1.3.1 | 1.1.0 |
-| 1.3.2 | 1.1.0 |
-| 1.3.3 | 1.1.0 |
-| 2.0.0 | 2.0.0 |
-| 2.0.1 | 2.0.0 |
+| 1.0.0 | 1.0.0-1.0.1 |
+| 1.1.0 | 1.1.0-1.3.1 |
+| 2.0.0 | 2.0.0-2.0.1 |
+| 2.0.1 | 2.0.0-2.0.1 |
 
 ## Upgrading
 

--- a/internal/build/go.mod
+++ b/internal/build/go.mod
@@ -6,7 +6,7 @@ replace github.com/opensearch-project/opensearch-go/v2 => ../../
 
 require (
 	github.com/alecthomas/chroma v0.8.2
-	github.com/opensearch-project/opensearch-go/v2 v2.0.0
+	github.com/opensearch-project/opensearch-go/v2 v2.0.1
 	github.com/spf13/cobra v1.1.3
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/tools v0.1.0

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -28,4 +28,4 @@ package version
 
 // Client returns the client version as a string.
 //
-const Client = "2.0.0"
+const Client = "2.0.1"

--- a/opensearchapi/test/go.mod
+++ b/opensearchapi/test/go.mod
@@ -5,7 +5,7 @@ go 1.11
 replace github.com/opensearch-project/opensearch-go/v2 => ../../
 
 require (
-	github.com/opensearch-project/opensearch-go/v2 v2.0.0
+	github.com/opensearch-project/opensearch-go/v2 v2.0.1
 
 	gopkg.in/yaml.v2 v2.4.0
 )


### PR DESCRIPTION
### Description
Bumping client version to 2.0.1 and updating+simplifying the compatibility matrix.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
