### PR TITLE
fix: Update request path

### DIFF
--- a/opensearchapi/api.update.go
+++ b/opensearchapi/api.update.go
@@ -55,8 +55,8 @@ type Update func(index string, id string, body io.Reader, o ...func(*UpdateReque
 // UpdateRequest configures the Update API request.
 //
 type UpdateRequest struct {
-	Index        string
-	DocumentID   string
+	Index      string
+	DocumentID string
 
 	Body io.Reader
 
@@ -98,9 +98,9 @@ func (r UpdateRequest) Do(ctx context.Context, transport Transport) (*Response, 
 	path.WriteString("/")
 	path.WriteString(r.Index)
 	path.WriteString("/")
-	path.WriteString("_update")
-	path.WriteString("/")
 	path.WriteString(r.DocumentID)
+	path.WriteString("/")
+	path.WriteString("_update")
 
 	params = make(map[string]string)
 


### PR DESCRIPTION
### Description
The generated HTTP request for the opensearchapi.UpdateRequest command is incorrect. The position of the documentID parameter should be the last one, but instead, it is coming before the _update argument. In other words:

Instead of:

POST /sample-index/_update/1

It is doing:

POST /sample-index/1/_update

### Issues Resolved
Issues: #145 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
