### PR TITLE
Fix json format of index mapping in USER_GUIDE

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -67,9 +67,9 @@ func main() {
 
 	// Add a document to the index.
 	document := strings.NewReader(`{
-        "title": "Moneyball",
-        "director": "Bennett Miller",
-        "year": "2011"
+	    "title": "Moneyball",
+	    "director": "Bennett Miller",
+	    "year": "2011"
     }`)
 
 	docId := "1"
@@ -87,14 +87,14 @@ func main() {
 
 	// Search for the document.
 	content := strings.NewReader(`{
-       "size": 5,
-       "query": {
-           "multi_match": {
-           "query": "miller",
-           "fields": ["title^2", "director"]
-           }
-      }
-    }`)
+	    "size": 5,
+	    "query": {
+	        "multi_match": {
+	            "query": "miller",
+	            "fields": ["title^2", "director"]
+	        }
+	    }
+	}`)
 
 	search := opensearchapi.SearchRequest{
 		Body: content,

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -70,7 +70,7 @@ func main() {
 	    "title": "Moneyball",
 	    "director": "Bennett Miller",
 	    "year": "2011"
-    }`)
+	}`)
 
 	docId := "1"
 	req := opensearchapi.IndexRequest{

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -46,12 +46,12 @@ func main() {
 
 	// Define index mapping.
 	mapping := strings.NewReader(`{
-     'settings': {
-       'index': {
-            'number_of_shards': 4
-            }
-          }
-     }`)
+	    "settings": {
+	        "index": {
+	            "number_of_shards": 4
+	        }
+	    }
+	}`)
 
 	// Create an index with non-default settings.
 	createIndex := opensearchapi.IndicesCreateRequest{


### PR DESCRIPTION
### Description

Single quotes are used in the json representing the index mapping, resulting in a parse error. Fix this.

```
[400 Bad Request] {"error":{"root_cause":[{"type":"parse_exception","reason":"Failed to parse content to map"}],"type":"parse_exception","reason":"Failed to parse content to map","caused_by":{"type":"json_parse_exception","reason":"Unexpected character (''' (code 39)): was expecting double-quote to start field name\n at [Source: (byte[])\"{\n\t    'settings': {\n\t        'index': {\n\t            'number_of_shards': 4\n\t        }\n\t    }\n\t}\"; line: 2, column: 7]"}},"status":400}
```

↓

```
[200 OK] {"acknowledged":true,"shards_acknowledged":true,"index":"go-test-index1"}
```

### Issues Resolved

For minor modifications, the step of opening an Issue was omitted.
