### PR TITLE
Add support for inclusive naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ lint:  ## Run lint on the package
 	}
 
 
-backport: ## Backport one or more commits from master into version branches
+backport: ## Backport one or more commits from main into version branches
 ifeq ($(origin commits), undefined)
 	@echo "Missing commit(s), exiting..."
 	@exit 2

--- a/internal/build/cmd/tools/commands/spec/command_test.go
+++ b/internal/build/cmd/tools/commands/spec/command_test.go
@@ -46,7 +46,7 @@ func TestBuild_zipfileUrl(t *testing.T) {
 			  "build_id": "1.0.0-ab7cd914",
 			  "projects": {
 				"opensearch": {
-				  "branch": "master",
+				  "branch": "main",
 				  "commit_hash": "d3be79018b5b70a118ea5a897a539428b728df5a",
 				  "Packages": {
 					"rest-resources-zip-8.0.0-SNAPSHOT.zip": {

--- a/opensearchapi/api._.go
+++ b/opensearchapi/api._.go
@@ -84,26 +84,29 @@ type API struct {
 
 // Cat contains the Cat APIs
 type Cat struct {
-	Aliases      CatAliases
-	Allocation   CatAllocation
-	Count        CatCount
-	Fielddata    CatFielddata
-	Health       CatHealth
-	Help         CatHelp
-	Indices      CatIndices
-	Master       CatMaster
-	Nodeattrs    CatNodeattrs
-	Nodes        CatNodes
-	PendingTasks CatPendingTasks
-	Plugins      CatPlugins
-	Recovery     CatRecovery
-	Repositories CatRepositories
-	Segments     CatSegments
-	Shards       CatShards
-	Snapshots    CatSnapshots
-	Tasks        CatTasks
-	Templates    CatTemplates
-	ThreadPool   CatThreadPool
+	Aliases        CatAliases
+	Allocation     CatAllocation
+	ClusterManager CatClusterManager
+	Count          CatCount
+	Fielddata      CatFielddata
+	Health         CatHealth
+	Help           CatHelp
+	Indices        CatIndices
+	Nodeattrs      CatNodeattrs
+	Nodes          CatNodes
+	PendingTasks   CatPendingTasks
+	Plugins        CatPlugins
+	Recovery       CatRecovery
+	Repositories   CatRepositories
+	Segments       CatSegments
+	Shards         CatShards
+	Snapshots      CatSnapshots
+	Tasks          CatTasks
+	Templates      CatTemplates
+	ThreadPool     CatThreadPool
+
+	// Deprecated: To promote inclusive language, please use ClusterManager instead.
+	Master CatMaster
 }
 
 // Cluster contains the Cluster APIs
@@ -220,7 +223,6 @@ type Tasks struct {
 }
 
 // New creates new API
-//
 func New(t Transport) *API {
 	return &API{
 		Bulk:                               newBulkFunc(t),
@@ -266,26 +268,27 @@ func New(t Transport) *API {
 		UpdateByQueryRethrottle:            newUpdateByQueryRethrottleFunc(t),
 		Update:                             newUpdateFunc(t),
 		Cat: &Cat{
-			Aliases:      newCatAliasesFunc(t),
-			Allocation:   newCatAllocationFunc(t),
-			Count:        newCatCountFunc(t),
-			Fielddata:    newCatFielddataFunc(t),
-			Health:       newCatHealthFunc(t),
-			Help:         newCatHelpFunc(t),
-			Indices:      newCatIndicesFunc(t),
-			Master:       newCatMasterFunc(t),
-			Nodeattrs:    newCatNodeattrsFunc(t),
-			Nodes:        newCatNodesFunc(t),
-			PendingTasks: newCatPendingTasksFunc(t),
-			Plugins:      newCatPluginsFunc(t),
-			Recovery:     newCatRecoveryFunc(t),
-			Repositories: newCatRepositoriesFunc(t),
-			Segments:     newCatSegmentsFunc(t),
-			Shards:       newCatShardsFunc(t),
-			Snapshots:    newCatSnapshotsFunc(t),
-			Tasks:        newCatTasksFunc(t),
-			Templates:    newCatTemplatesFunc(t),
-			ThreadPool:   newCatThreadPoolFunc(t),
+			Aliases:        newCatAliasesFunc(t),
+			Allocation:     newCatAllocationFunc(t),
+			ClusterManager: newCatClusterManagerFunc(t),
+			Count:          newCatCountFunc(t),
+			Fielddata:      newCatFielddataFunc(t),
+			Health:         newCatHealthFunc(t),
+			Help:           newCatHelpFunc(t),
+			Indices:        newCatIndicesFunc(t),
+			Master:         newCatMasterFunc(t),
+			Nodeattrs:      newCatNodeattrsFunc(t),
+			Nodes:          newCatNodesFunc(t),
+			PendingTasks:   newCatPendingTasksFunc(t),
+			Plugins:        newCatPluginsFunc(t),
+			Recovery:       newCatRecoveryFunc(t),
+			Repositories:   newCatRepositoriesFunc(t),
+			Segments:       newCatSegmentsFunc(t),
+			Shards:         newCatShardsFunc(t),
+			Snapshots:      newCatSnapshotsFunc(t),
+			Tasks:          newCatTasksFunc(t),
+			Templates:      newCatTemplatesFunc(t),
+			ThreadPool:     newCatThreadPoolFunc(t),
 		},
 		Cluster: &Cluster{
 			AllocationExplain:            newClusterAllocationExplainFunc(t),

--- a/opensearchapi/api.cat.aliases.go
+++ b/opensearchapi/api.cat.aliases.go
@@ -231,7 +231,7 @@ func (f CatAliases) WithHelp(v bool) func(*CatAliasesRequest) {
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f CatAliases) WithLocal(v bool) func(*CatAliasesRequest) {
 	return func(r *CatAliasesRequest) {

--- a/opensearchapi/api.cat.allocation.go
+++ b/opensearchapi/api.cat.allocation.go
@@ -57,14 +57,15 @@ type CatAllocation func(o ...func(*CatAllocationRequest)) (*Response, error)
 type CatAllocationRequest struct {
 	NodeID []string
 
-	Bytes         string
-	Format        string
-	H             []string
-	Help          *bool
-	Local         *bool
-	MasterTimeout time.Duration
-	S             []string
-	V             *bool
+	Bytes                 string
+	Format                string
+	H                     []string
+	Help                  *bool
+	Local                 *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	S                     []string
+	V                     *bool
 
 	Pretty     bool
 	Human      bool
@@ -121,6 +122,10 @@ func (r CatAllocationRequest) Do(ctx context.Context, transport Transport) (*Res
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if len(r.S) > 0 {
@@ -246,11 +251,21 @@ func (f CatAllocation) WithLocal(v bool) func(*CatAllocationRequest) {
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f CatAllocation) WithMasterTimeout(v time.Duration) func(*CatAllocationRequest) {
 	return func(r *CatAllocationRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f CatAllocation) WithClusterManagerTimeout(v time.Duration) func(*CatAllocationRequest) {
+	return func(r *CatAllocationRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cat.allocation.go
+++ b/opensearchapi/api.cat.allocation.go
@@ -238,7 +238,7 @@ func (f CatAllocation) WithHelp(v bool) func(*CatAllocationRequest) {
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f CatAllocation) WithLocal(v bool) func(*CatAllocationRequest) {
 	return func(r *CatAllocationRequest) {

--- a/opensearchapi/api.cat.cluster_manager.go
+++ b/opensearchapi/api.cat.cluster_manager.go
@@ -7,23 +7,6 @@
 // Modifications Copyright OpenSearch Contributors. See
 // GitHub history for details.
 
-// Licensed to Elasticsearch B.V. under one or more contributor
-// license agreements. See the NOTICE file distributed with
-// this work for additional information regarding copyright
-// ownership. Elasticsearch B.V. licenses this file to you under
-// the Apache License, Version 2.0 (the "License"); you may
-// not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 package opensearchapi
 
 import (
@@ -34,9 +17,9 @@ import (
 	"time"
 )
 
-func newCatMasterFunc(t Transport) CatMaster {
-	return func(o ...func(*CatMasterRequest)) (*Response, error) {
-		var r = CatMasterRequest{}
+func newCatClusterManagerFunc(t Transport) CatClusterManager {
+	return func(o ...func(*CatClusterManagerRequest)) (*Response, error) {
+		var r = CatClusterManagerRequest{}
 		for _, f := range o {
 			f(&r)
 		}
@@ -46,13 +29,11 @@ func newCatMasterFunc(t Transport) CatMaster {
 
 // ----- API Definition -------------------------------------------------------
 
-// CatMaster returns information about the cluster-manager node.
-//
-// Deprecated: To promote inclusive language, please use CatClusterManager instead.
-type CatMaster func(o ...func(*CatMasterRequest)) (*Response, error)
+// CatClusterManager returns information about the cluster-manager node.
+type CatClusterManager func(o ...func(*CatClusterManagerRequest)) (*Response, error)
 
-// CatMasterRequest configures the Cat Master API request.
-type CatMasterRequest struct {
+// CatClusterManagerRequest configures the Cat Cluster Manager API request.
+type CatClusterManagerRequest struct {
 	Format                string
 	H                     []string
 	Help                  *bool
@@ -73,7 +54,7 @@ type CatMasterRequest struct {
 }
 
 // Do executes the request and returns response or error.
-func (r CatMasterRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
+func (r CatClusterManagerRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
 	var (
 		method string
 		path   strings.Builder
@@ -82,8 +63,8 @@ func (r CatMasterRequest) Do(ctx context.Context, transport Transport) (*Respons
 
 	method = "GET"
 
-	path.Grow(len("/_cat/master"))
-	path.WriteString("/_cat/master")
+	path.Grow(len("/_cat/cluster_manager"))
+	path.WriteString("/_cat/cluster_manager")
 
 	params = make(map[string]string)
 
@@ -179,36 +160,36 @@ func (r CatMasterRequest) Do(ctx context.Context, transport Transport) (*Respons
 }
 
 // WithContext sets the request context.
-func (f CatMaster) WithContext(v context.Context) func(*CatMasterRequest) {
-	return func(r *CatMasterRequest) {
+func (f CatClusterManager) WithContext(v context.Context) func(*CatClusterManagerRequest) {
+	return func(r *CatClusterManagerRequest) {
 		r.ctx = v
 	}
 }
 
 // WithFormat - a short version of the accept header, e.g. json, yaml.
-func (f CatMaster) WithFormat(v string) func(*CatMasterRequest) {
-	return func(r *CatMasterRequest) {
+func (f CatClusterManager) WithFormat(v string) func(*CatClusterManagerRequest) {
+	return func(r *CatClusterManagerRequest) {
 		r.Format = v
 	}
 }
 
 // WithH - comma-separated list of column names to display.
-func (f CatMaster) WithH(v ...string) func(*CatMasterRequest) {
-	return func(r *CatMasterRequest) {
+func (f CatClusterManager) WithH(v ...string) func(*CatClusterManagerRequest) {
+	return func(r *CatClusterManagerRequest) {
 		r.H = v
 	}
 }
 
 // WithHelp - return help information.
-func (f CatMaster) WithHelp(v bool) func(*CatMasterRequest) {
-	return func(r *CatMasterRequest) {
+func (f CatClusterManager) WithHelp(v bool) func(*CatClusterManagerRequest) {
+	return func(r *CatClusterManagerRequest) {
 		r.Help = &v
 	}
 }
 
 // WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
-func (f CatMaster) WithLocal(v bool) func(*CatMasterRequest) {
-	return func(r *CatMasterRequest) {
+func (f CatClusterManager) WithLocal(v bool) func(*CatClusterManagerRequest) {
+	return func(r *CatClusterManagerRequest) {
 		r.Local = &v
 	}
 }
@@ -216,64 +197,64 @@ func (f CatMaster) WithLocal(v bool) func(*CatMasterRequest) {
 // WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
 //
 // Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
-func (f CatMaster) WithMasterTimeout(v time.Duration) func(*CatMasterRequest) {
-	return func(r *CatMasterRequest) {
+func (f CatClusterManager) WithMasterTimeout(v time.Duration) func(*CatClusterManagerRequest) {
+	return func(r *CatClusterManagerRequest) {
 		r.MasterTimeout = v
 	}
 }
 
 // WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
-func (f CatMaster) WithClusterManagerTimeout(v time.Duration) func(*CatMasterRequest) {
-	return func(r *CatMasterRequest) {
+func (f CatClusterManager) WithClusterManagerTimeout(v time.Duration) func(*CatClusterManagerRequest) {
+	return func(r *CatClusterManagerRequest) {
 		r.ClusterManagerTimeout = v
 	}
 }
 
 // WithS - comma-separated list of column names or column aliases to sort by.
-func (f CatMaster) WithS(v ...string) func(*CatMasterRequest) {
-	return func(r *CatMasterRequest) {
+func (f CatClusterManager) WithS(v ...string) func(*CatClusterManagerRequest) {
+	return func(r *CatClusterManagerRequest) {
 		r.S = v
 	}
 }
 
 // WithV - verbose mode. display column headers.
-func (f CatMaster) WithV(v bool) func(*CatMasterRequest) {
-	return func(r *CatMasterRequest) {
+func (f CatClusterManager) WithV(v bool) func(*CatClusterManagerRequest) {
+	return func(r *CatClusterManagerRequest) {
 		r.V = &v
 	}
 }
 
 // WithPretty makes the response body pretty-printed.
-func (f CatMaster) WithPretty() func(*CatMasterRequest) {
-	return func(r *CatMasterRequest) {
+func (f CatClusterManager) WithPretty() func(*CatClusterManagerRequest) {
+	return func(r *CatClusterManagerRequest) {
 		r.Pretty = true
 	}
 }
 
 // WithHuman makes statistical values human-readable.
-func (f CatMaster) WithHuman() func(*CatMasterRequest) {
-	return func(r *CatMasterRequest) {
+func (f CatClusterManager) WithHuman() func(*CatClusterManagerRequest) {
+	return func(r *CatClusterManagerRequest) {
 		r.Human = true
 	}
 }
 
 // WithErrorTrace includes the stack trace for errors in the response body.
-func (f CatMaster) WithErrorTrace() func(*CatMasterRequest) {
-	return func(r *CatMasterRequest) {
+func (f CatClusterManager) WithErrorTrace() func(*CatClusterManagerRequest) {
+	return func(r *CatClusterManagerRequest) {
 		r.ErrorTrace = true
 	}
 }
 
 // WithFilterPath filters the properties of the response body.
-func (f CatMaster) WithFilterPath(v ...string) func(*CatMasterRequest) {
-	return func(r *CatMasterRequest) {
+func (f CatClusterManager) WithFilterPath(v ...string) func(*CatClusterManagerRequest) {
+	return func(r *CatClusterManagerRequest) {
 		r.FilterPath = v
 	}
 }
 
 // WithHeader adds the headers to the HTTP request.
-func (f CatMaster) WithHeader(h map[string]string) func(*CatMasterRequest) {
-	return func(r *CatMasterRequest) {
+func (f CatClusterManager) WithHeader(h map[string]string) func(*CatClusterManagerRequest) {
+	return func(r *CatClusterManagerRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}
@@ -284,8 +265,8 @@ func (f CatMaster) WithHeader(h map[string]string) func(*CatMasterRequest) {
 }
 
 // WithOpaqueID adds the X-Opaque-Id header to the HTTP request.
-func (f CatMaster) WithOpaqueID(s string) func(*CatMasterRequest) {
-	return func(r *CatMasterRequest) {
+func (f CatClusterManager) WithOpaqueID(s string) func(*CatClusterManagerRequest) {
+	return func(r *CatClusterManagerRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}

--- a/opensearchapi/api.cat.indices.go
+++ b/opensearchapi/api.cat.indices.go
@@ -286,7 +286,7 @@ func (f CatIndices) WithIncludeUnloadedSegments(v bool) func(*CatIndicesRequest)
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f CatIndices) WithLocal(v bool) func(*CatIndicesRequest) {
 	return func(r *CatIndicesRequest) {

--- a/opensearchapi/api.cat.indices.go
+++ b/opensearchapi/api.cat.indices.go
@@ -65,6 +65,7 @@ type CatIndicesRequest struct {
 	IncludeUnloadedSegments *bool
 	Local                   *bool
 	MasterTimeout           time.Duration
+	ClusterManagerTimeout   time.Duration
 	Pri                     *bool
 	S                       []string
 	Time                    string
@@ -137,6 +138,10 @@ func (r CatIndicesRequest) Do(ctx context.Context, transport Transport) (*Respon
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Pri != nil {
@@ -294,11 +299,21 @@ func (f CatIndices) WithLocal(v bool) func(*CatIndicesRequest) {
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f CatIndices) WithMasterTimeout(v time.Duration) func(*CatIndicesRequest) {
 	return func(r *CatIndicesRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f CatIndices) WithClusterManagerTimeout(v time.Duration) func(*CatIndicesRequest) {
+	return func(r *CatIndicesRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cat.master.go
+++ b/opensearchapi/api.cat.master.go
@@ -207,7 +207,7 @@ func (f CatMaster) WithHelp(v bool) func(*CatMasterRequest) {
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f CatMaster) WithLocal(v bool) func(*CatMasterRequest) {
 	return func(r *CatMasterRequest) {

--- a/opensearchapi/api.cat.master.go
+++ b/opensearchapi/api.cat.master.go
@@ -46,21 +46,19 @@ func newCatMasterFunc(t Transport) CatMaster {
 
 // ----- API Definition -------------------------------------------------------
 
-// CatMaster returns information about the master node.
-//
-//
+// CatMaster returns information about the cluster-manager node.
 type CatMaster func(o ...func(*CatMasterRequest)) (*Response, error)
 
 // CatMasterRequest configures the Cat Master API request.
-//
 type CatMasterRequest struct {
-	Format        string
-	H             []string
-	Help          *bool
-	Local         *bool
-	MasterTimeout time.Duration
-	S             []string
-	V             *bool
+	Format                string
+	H                     []string
+	Help                  *bool
+	Local                 *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	S                     []string
+	V                     *bool
 
 	Pretty     bool
 	Human      bool
@@ -73,7 +71,6 @@ type CatMasterRequest struct {
 }
 
 // Do executes the request and returns response or error.
-//
 func (r CatMasterRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
 	var (
 		method string
@@ -106,6 +103,10 @@ func (r CatMasterRequest) Do(ctx context.Context, transport Transport) (*Respons
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if len(r.S) > 0 {
@@ -176,7 +177,6 @@ func (r CatMasterRequest) Do(ctx context.Context, transport Transport) (*Respons
 }
 
 // WithContext sets the request context.
-//
 func (f CatMaster) WithContext(v context.Context) func(*CatMasterRequest) {
 	return func(r *CatMasterRequest) {
 		r.ctx = v
@@ -184,7 +184,6 @@ func (f CatMaster) WithContext(v context.Context) func(*CatMasterRequest) {
 }
 
 // WithFormat - a short version of the accept header, e.g. json, yaml.
-//
 func (f CatMaster) WithFormat(v string) func(*CatMasterRequest) {
 	return func(r *CatMasterRequest) {
 		r.Format = v
@@ -192,7 +191,6 @@ func (f CatMaster) WithFormat(v string) func(*CatMasterRequest) {
 }
 
 // WithH - comma-separated list of column names to display.
-//
 func (f CatMaster) WithH(v ...string) func(*CatMasterRequest) {
 	return func(r *CatMasterRequest) {
 		r.H = v
@@ -200,7 +198,6 @@ func (f CatMaster) WithH(v ...string) func(*CatMasterRequest) {
 }
 
 // WithHelp - return help information.
-//
 func (f CatMaster) WithHelp(v bool) func(*CatMasterRequest) {
 	return func(r *CatMasterRequest) {
 		r.Help = &v
@@ -208,23 +205,29 @@ func (f CatMaster) WithHelp(v bool) func(*CatMasterRequest) {
 }
 
 // WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
-//
 func (f CatMaster) WithLocal(v bool) func(*CatMasterRequest) {
 	return func(r *CatMasterRequest) {
 		r.Local = &v
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
 //
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 func (f CatMaster) WithMasterTimeout(v time.Duration) func(*CatMasterRequest) {
 	return func(r *CatMasterRequest) {
 		r.MasterTimeout = v
 	}
 }
 
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+func (f CatMaster) WithClusterManagerTimeout(v time.Duration) func(*CatMasterRequest) {
+	return func(r *CatMasterRequest) {
+		r.ClusterManagerTimeout = v
+	}
+}
+
 // WithS - comma-separated list of column names or column aliases to sort by.
-//
 func (f CatMaster) WithS(v ...string) func(*CatMasterRequest) {
 	return func(r *CatMasterRequest) {
 		r.S = v
@@ -232,7 +235,6 @@ func (f CatMaster) WithS(v ...string) func(*CatMasterRequest) {
 }
 
 // WithV - verbose mode. display column headers.
-//
 func (f CatMaster) WithV(v bool) func(*CatMasterRequest) {
 	return func(r *CatMasterRequest) {
 		r.V = &v
@@ -240,7 +242,6 @@ func (f CatMaster) WithV(v bool) func(*CatMasterRequest) {
 }
 
 // WithPretty makes the response body pretty-printed.
-//
 func (f CatMaster) WithPretty() func(*CatMasterRequest) {
 	return func(r *CatMasterRequest) {
 		r.Pretty = true
@@ -248,7 +249,6 @@ func (f CatMaster) WithPretty() func(*CatMasterRequest) {
 }
 
 // WithHuman makes statistical values human-readable.
-//
 func (f CatMaster) WithHuman() func(*CatMasterRequest) {
 	return func(r *CatMasterRequest) {
 		r.Human = true
@@ -256,7 +256,6 @@ func (f CatMaster) WithHuman() func(*CatMasterRequest) {
 }
 
 // WithErrorTrace includes the stack trace for errors in the response body.
-//
 func (f CatMaster) WithErrorTrace() func(*CatMasterRequest) {
 	return func(r *CatMasterRequest) {
 		r.ErrorTrace = true
@@ -264,7 +263,6 @@ func (f CatMaster) WithErrorTrace() func(*CatMasterRequest) {
 }
 
 // WithFilterPath filters the properties of the response body.
-//
 func (f CatMaster) WithFilterPath(v ...string) func(*CatMasterRequest) {
 	return func(r *CatMasterRequest) {
 		r.FilterPath = v
@@ -272,7 +270,6 @@ func (f CatMaster) WithFilterPath(v ...string) func(*CatMasterRequest) {
 }
 
 // WithHeader adds the headers to the HTTP request.
-//
 func (f CatMaster) WithHeader(h map[string]string) func(*CatMasterRequest) {
 	return func(r *CatMasterRequest) {
 		if r.Header == nil {
@@ -285,7 +282,6 @@ func (f CatMaster) WithHeader(h map[string]string) func(*CatMasterRequest) {
 }
 
 // WithOpaqueID adds the X-Opaque-Id header to the HTTP request.
-//
 func (f CatMaster) WithOpaqueID(s string) func(*CatMasterRequest) {
 	return func(r *CatMasterRequest) {
 		if r.Header == nil {

--- a/opensearchapi/api.cat.nodeattrs.go
+++ b/opensearchapi/api.cat.nodeattrs.go
@@ -54,13 +54,14 @@ type CatNodeattrs func(o ...func(*CatNodeattrsRequest)) (*Response, error)
 // CatNodeattrsRequest configures the Cat Nodeattrs API request.
 //
 type CatNodeattrsRequest struct {
-	Format        string
-	H             []string
-	Help          *bool
-	Local         *bool
-	MasterTimeout time.Duration
-	S             []string
-	V             *bool
+	Format                string
+	H                     []string
+	Help                  *bool
+	Local                 *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	S                     []string
+	V                     *bool
 
 	Pretty     bool
 	Human      bool
@@ -106,6 +107,10 @@ func (r CatNodeattrsRequest) Do(ctx context.Context, transport Transport) (*Resp
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if len(r.S) > 0 {
@@ -215,11 +220,21 @@ func (f CatNodeattrs) WithLocal(v bool) func(*CatNodeattrsRequest) {
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f CatNodeattrs) WithMasterTimeout(v time.Duration) func(*CatNodeattrsRequest) {
 	return func(r *CatNodeattrsRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f CatNodeattrs) WithClusterManagerTimeout(v time.Duration) func(*CatNodeattrsRequest) {
+	return func(r *CatNodeattrsRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cat.nodeattrs.go
+++ b/opensearchapi/api.cat.nodeattrs.go
@@ -207,7 +207,7 @@ func (f CatNodeattrs) WithHelp(v bool) func(*CatNodeattrsRequest) {
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f CatNodeattrs) WithLocal(v bool) func(*CatNodeattrsRequest) {
 	return func(r *CatNodeattrsRequest) {

--- a/opensearchapi/api.cat.nodes.go
+++ b/opensearchapi/api.cat.nodes.go
@@ -251,7 +251,7 @@ func (f CatNodes) WithIncludeUnloadedSegments(v bool) func(*CatNodesRequest) {
 	}
 }
 
-// WithLocal - calculate the selected nodes using the local cluster state rather than the state from master node (default: false).
+// WithLocal - calculate the selected nodes using the local cluster state rather than the state from cluster-manager node (default: false).
 //
 func (f CatNodes) WithLocal(v bool) func(*CatNodesRequest) {
 	return func(r *CatNodesRequest) {

--- a/opensearchapi/api.cat.nodes.go
+++ b/opensearchapi/api.cat.nodes.go
@@ -62,6 +62,7 @@ type CatNodesRequest struct {
 	IncludeUnloadedSegments *bool
 	Local                   *bool
 	MasterTimeout           time.Duration
+	ClusterManagerTimeout   time.Duration
 	S                       []string
 	Time                    string
 	V                       *bool
@@ -122,6 +123,10 @@ func (r CatNodesRequest) Do(ctx context.Context, transport Transport) (*Response
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if len(r.S) > 0 {
@@ -259,11 +264,21 @@ func (f CatNodes) WithLocal(v bool) func(*CatNodesRequest) {
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f CatNodes) WithMasterTimeout(v time.Duration) func(*CatNodesRequest) {
 	return func(r *CatNodesRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f CatNodes) WithClusterManagerTimeout(v time.Duration) func(*CatNodesRequest) {
+	return func(r *CatNodesRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cat.pending_tasks.go
+++ b/opensearchapi/api.cat.pending_tasks.go
@@ -212,7 +212,7 @@ func (f CatPendingTasks) WithHelp(v bool) func(*CatPendingTasksRequest) {
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f CatPendingTasks) WithLocal(v bool) func(*CatPendingTasksRequest) {
 	return func(r *CatPendingTasksRequest) {

--- a/opensearchapi/api.cat.pending_tasks.go
+++ b/opensearchapi/api.cat.pending_tasks.go
@@ -54,14 +54,15 @@ type CatPendingTasks func(o ...func(*CatPendingTasksRequest)) (*Response, error)
 // CatPendingTasksRequest configures the Cat Pending Tasks API request.
 //
 type CatPendingTasksRequest struct {
-	Format        string
-	H             []string
-	Help          *bool
-	Local         *bool
-	MasterTimeout time.Duration
-	S             []string
-	Time          string
-	V             *bool
+	Format                string
+	H                     []string
+	Help                  *bool
+	Local                 *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	S                     []string
+	Time                  string
+	V                     *bool
 
 	Pretty     bool
 	Human      bool
@@ -107,6 +108,10 @@ func (r CatPendingTasksRequest) Do(ctx context.Context, transport Transport) (*R
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if len(r.S) > 0 {
@@ -220,11 +225,21 @@ func (f CatPendingTasks) WithLocal(v bool) func(*CatPendingTasksRequest) {
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f CatPendingTasks) WithMasterTimeout(v time.Duration) func(*CatPendingTasksRequest) {
 	return func(r *CatPendingTasksRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f CatPendingTasks) WithClusterManagerTimeout(v time.Duration) func(*CatPendingTasksRequest) {
+	return func(r *CatPendingTasksRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cat.plugins.go
+++ b/opensearchapi/api.cat.plugins.go
@@ -220,7 +220,7 @@ func (f CatPlugins) WithIncludeBootstrap(v bool) func(*CatPluginsRequest) {
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f CatPlugins) WithLocal(v bool) func(*CatPluginsRequest) {
 	return func(r *CatPluginsRequest) {

--- a/opensearchapi/api.cat.plugins.go
+++ b/opensearchapi/api.cat.plugins.go
@@ -54,14 +54,15 @@ type CatPlugins func(o ...func(*CatPluginsRequest)) (*Response, error)
 // CatPluginsRequest configures the Cat Plugins API request.
 //
 type CatPluginsRequest struct {
-	Format           string
-	H                []string
-	Help             *bool
-	IncludeBootstrap *bool
-	Local            *bool
-	MasterTimeout    time.Duration
-	S                []string
-	V                *bool
+	Format                string
+	H                     []string
+	Help                  *bool
+	IncludeBootstrap      *bool
+	Local                 *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	S                     []string
+	V                     *bool
 
 	Pretty     bool
 	Human      bool
@@ -111,6 +112,10 @@ func (r CatPluginsRequest) Do(ctx context.Context, transport Transport) (*Respon
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if len(r.S) > 0 {
@@ -228,11 +233,21 @@ func (f CatPlugins) WithLocal(v bool) func(*CatPluginsRequest) {
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f CatPlugins) WithMasterTimeout(v time.Duration) func(*CatPluginsRequest) {
 	return func(r *CatPluginsRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f CatPlugins) WithClusterManagerTimeout(v time.Duration) func(*CatPluginsRequest) {
+	return func(r *CatPluginsRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cat.repositories.go
+++ b/opensearchapi/api.cat.repositories.go
@@ -54,13 +54,14 @@ type CatRepositories func(o ...func(*CatRepositoriesRequest)) (*Response, error)
 // CatRepositoriesRequest configures the Cat Repositories API request.
 //
 type CatRepositoriesRequest struct {
-	Format        string
-	H             []string
-	Help          *bool
-	Local         *bool
-	MasterTimeout time.Duration
-	S             []string
-	V             *bool
+	Format                string
+	H                     []string
+	Help                  *bool
+	Local                 *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	S                     []string
+	V                     *bool
 
 	Pretty     bool
 	Human      bool
@@ -106,6 +107,10 @@ func (r CatRepositoriesRequest) Do(ctx context.Context, transport Transport) (*R
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if len(r.S) > 0 {
@@ -215,11 +220,21 @@ func (f CatRepositories) WithLocal(v bool) func(*CatRepositoriesRequest) {
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f CatRepositories) WithMasterTimeout(v time.Duration) func(*CatRepositoriesRequest) {
 	return func(r *CatRepositoriesRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f CatRepositories) WithClusterManagerTimeout(v time.Duration) func(*CatRepositoriesRequest) {
+	return func(r *CatRepositoriesRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cat.repositories.go
+++ b/opensearchapi/api.cat.repositories.go
@@ -207,7 +207,7 @@ func (f CatRepositories) WithHelp(v bool) func(*CatRepositoriesRequest) {
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node.
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f CatRepositories) WithLocal(v bool) func(*CatRepositoriesRequest) {
 	return func(r *CatRepositoriesRequest) {

--- a/opensearchapi/api.cat.shards.go
+++ b/opensearchapi/api.cat.shards.go
@@ -56,15 +56,16 @@ type CatShards func(o ...func(*CatShardsRequest)) (*Response, error)
 type CatShardsRequest struct {
 	Index []string
 
-	Bytes         string
-	Format        string
-	H             []string
-	Help          *bool
-	Local         *bool
-	MasterTimeout time.Duration
-	S             []string
-	Time          string
-	V             *bool
+	Bytes                 string
+	Format                string
+	H                     []string
+	Help                  *bool
+	Local                 *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	S                     []string
+	Time                  string
+	V                     *bool
 
 	Pretty     bool
 	Human      bool
@@ -121,6 +122,10 @@ func (r CatShardsRequest) Do(ctx context.Context, transport Transport) (*Respons
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if len(r.S) > 0 {
@@ -250,11 +255,21 @@ func (f CatShards) WithLocal(v bool) func(*CatShardsRequest) {
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f CatShards) WithMasterTimeout(v time.Duration) func(*CatShardsRequest) {
 	return func(r *CatShardsRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f CatShards) WithClusterManagerTimeout(v time.Duration) func(*CatShardsRequest) {
+	return func(r *CatShardsRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cat.shards.go
+++ b/opensearchapi/api.cat.shards.go
@@ -242,7 +242,7 @@ func (f CatShards) WithHelp(v bool) func(*CatShardsRequest) {
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f CatShards) WithLocal(v bool) func(*CatShardsRequest) {
 	return func(r *CatShardsRequest) {

--- a/opensearchapi/api.cat.snapshots.go
+++ b/opensearchapi/api.cat.snapshots.go
@@ -56,14 +56,15 @@ type CatSnapshots func(o ...func(*CatSnapshotsRequest)) (*Response, error)
 type CatSnapshotsRequest struct {
 	Repository []string
 
-	Format            string
-	H                 []string
-	Help              *bool
-	IgnoreUnavailable *bool
-	MasterTimeout     time.Duration
-	S                 []string
-	Time              string
-	V                 *bool
+	Format                string
+	H                     []string
+	Help                  *bool
+	IgnoreUnavailable     *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	S                     []string
+	Time                  string
+	V                     *bool
 
 	Pretty     bool
 	Human      bool
@@ -116,6 +117,10 @@ func (r CatSnapshotsRequest) Do(ctx context.Context, transport Transport) (*Resp
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if len(r.S) > 0 {
@@ -237,11 +242,21 @@ func (f CatSnapshots) WithIgnoreUnavailable(v bool) func(*CatSnapshotsRequest) {
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f CatSnapshots) WithMasterTimeout(v time.Duration) func(*CatSnapshotsRequest) {
 	return func(r *CatSnapshotsRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f CatSnapshots) WithClusterManagerTimeout(v time.Duration) func(*CatSnapshotsRequest) {
+	return func(r *CatSnapshotsRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cat.templates.go
+++ b/opensearchapi/api.cat.templates.go
@@ -56,13 +56,14 @@ type CatTemplates func(o ...func(*CatTemplatesRequest)) (*Response, error)
 type CatTemplatesRequest struct {
 	Name string
 
-	Format        string
-	H             []string
-	Help          *bool
-	Local         *bool
-	MasterTimeout time.Duration
-	S             []string
-	V             *bool
+	Format                string
+	H                     []string
+	Help                  *bool
+	Local                 *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	S                     []string
+	V                     *bool
 
 	Pretty     bool
 	Human      bool
@@ -115,6 +116,10 @@ func (r CatTemplatesRequest) Do(ctx context.Context, transport Transport) (*Resp
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if len(r.S) > 0 {
@@ -232,11 +237,21 @@ func (f CatTemplates) WithLocal(v bool) func(*CatTemplatesRequest) {
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f CatTemplates) WithMasterTimeout(v time.Duration) func(*CatTemplatesRequest) {
 	return func(r *CatTemplatesRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f CatTemplates) WithClusterManagerTimeout(v time.Duration) func(*CatTemplatesRequest) {
+	return func(r *CatTemplatesRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cat.templates.go
+++ b/opensearchapi/api.cat.templates.go
@@ -224,7 +224,7 @@ func (f CatTemplates) WithHelp(v bool) func(*CatTemplatesRequest) {
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f CatTemplates) WithLocal(v bool) func(*CatTemplatesRequest) {
 	return func(r *CatTemplatesRequest) {

--- a/opensearchapi/api.cat.thread_pool.go
+++ b/opensearchapi/api.cat.thread_pool.go
@@ -230,7 +230,7 @@ func (f CatThreadPool) WithHelp(v bool) func(*CatThreadPoolRequest) {
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f CatThreadPool) WithLocal(v bool) func(*CatThreadPoolRequest) {
 	return func(r *CatThreadPoolRequest) {

--- a/opensearchapi/api.cat.thread_pool.go
+++ b/opensearchapi/api.cat.thread_pool.go
@@ -57,14 +57,15 @@ type CatThreadPool func(o ...func(*CatThreadPoolRequest)) (*Response, error)
 type CatThreadPoolRequest struct {
 	ThreadPoolPatterns []string
 
-	Format        string
-	H             []string
-	Help          *bool
-	Local         *bool
-	MasterTimeout time.Duration
-	S             []string
-	Size          string
-	V             *bool
+	Format                string
+	H                     []string
+	Help                  *bool
+	Local                 *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	S                     []string
+	Size                  string
+	V                     *bool
 
 	Pretty     bool
 	Human      bool
@@ -117,6 +118,10 @@ func (r CatThreadPoolRequest) Do(ctx context.Context, transport Transport) (*Res
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if len(r.S) > 0 {
@@ -238,11 +243,21 @@ func (f CatThreadPool) WithLocal(v bool) func(*CatThreadPoolRequest) {
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f CatThreadPool) WithMasterTimeout(v time.Duration) func(*CatThreadPoolRequest) {
 	return func(r *CatThreadPoolRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f CatThreadPool) WithClusterManagerTimeout(v time.Duration) func(*CatThreadPoolRequest) {
+	return func(r *CatThreadPoolRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cluster.delete_component_template.go
+++ b/opensearchapi/api.cluster.delete_component_template.go
@@ -55,8 +55,9 @@ type ClusterDeleteComponentTemplate func(name string, o ...func(*ClusterDeleteCo
 type ClusterDeleteComponentTemplateRequest struct {
 	Name string
 
-	MasterTimeout time.Duration
-	Timeout       time.Duration
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -89,6 +90,10 @@ func (r ClusterDeleteComponentTemplateRequest) Do(ctx context.Context, transport
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -162,11 +167,21 @@ func (f ClusterDeleteComponentTemplate) WithContext(v context.Context) func(*Clu
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f ClusterDeleteComponentTemplate) WithMasterTimeout(v time.Duration) func(*ClusterDeleteComponentTemplateRequest) {
 	return func(r *ClusterDeleteComponentTemplateRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f ClusterDeleteComponentTemplate) WithClusterManagerTimeout(v time.Duration) func(*ClusterDeleteComponentTemplateRequest) {
+	return func(r *ClusterDeleteComponentTemplateRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cluster.exists_component_template.go
+++ b/opensearchapi/api.cluster.exists_component_template.go
@@ -163,7 +163,7 @@ func (f ClusterExistsComponentTemplate) WithContext(v context.Context) func(*Clu
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f ClusterExistsComponentTemplate) WithLocal(v bool) func(*ClusterExistsComponentTemplateRequest) {
 	return func(r *ClusterExistsComponentTemplateRequest) {

--- a/opensearchapi/api.cluster.exists_component_template.go
+++ b/opensearchapi/api.cluster.exists_component_template.go
@@ -56,8 +56,9 @@ type ClusterExistsComponentTemplate func(name string, o ...func(*ClusterExistsCo
 type ClusterExistsComponentTemplateRequest struct {
 	Name string
 
-	Local         *bool
-	MasterTimeout time.Duration
+	Local                 *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -94,6 +95,10 @@ func (r ClusterExistsComponentTemplateRequest) Do(ctx context.Context, transport
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Pretty {
@@ -171,11 +176,21 @@ func (f ClusterExistsComponentTemplate) WithLocal(v bool) func(*ClusterExistsCom
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f ClusterExistsComponentTemplate) WithMasterTimeout(v time.Duration) func(*ClusterExistsComponentTemplateRequest) {
 	return func(r *ClusterExistsComponentTemplateRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f ClusterExistsComponentTemplate) WithClusterManagerTimeout(v time.Duration) func(*ClusterExistsComponentTemplateRequest) {
+	return func(r *ClusterExistsComponentTemplateRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cluster.get_component_template.go
+++ b/opensearchapi/api.cluster.get_component_template.go
@@ -173,7 +173,7 @@ func (f ClusterGetComponentTemplate) WithName(v ...string) func(*ClusterGetCompo
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f ClusterGetComponentTemplate) WithLocal(v bool) func(*ClusterGetComponentTemplateRequest) {
 	return func(r *ClusterGetComponentTemplateRequest) {

--- a/opensearchapi/api.cluster.get_component_template.go
+++ b/opensearchapi/api.cluster.get_component_template.go
@@ -56,8 +56,9 @@ type ClusterGetComponentTemplate func(o ...func(*ClusterGetComponentTemplateRequ
 type ClusterGetComponentTemplateRequest struct {
 	Name []string
 
-	Local         *bool
-	MasterTimeout time.Duration
+	Local                 *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -96,6 +97,10 @@ func (r ClusterGetComponentTemplateRequest) Do(ctx context.Context, transport Tr
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Pretty {
@@ -181,11 +186,21 @@ func (f ClusterGetComponentTemplate) WithLocal(v bool) func(*ClusterGetComponent
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f ClusterGetComponentTemplate) WithMasterTimeout(v time.Duration) func(*ClusterGetComponentTemplateRequest) {
 	return func(r *ClusterGetComponentTemplateRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f ClusterGetComponentTemplate) WithClusterManagerTimeout(v time.Duration) func(*ClusterGetComponentTemplateRequest) {
+	return func(r *ClusterGetComponentTemplateRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cluster.get_settings.go
+++ b/opensearchapi/api.cluster.get_settings.go
@@ -54,10 +54,11 @@ type ClusterGetSettings func(o ...func(*ClusterGetSettingsRequest)) (*Response, 
 // ClusterGetSettingsRequest configures the Cluster Get Settings API request.
 //
 type ClusterGetSettingsRequest struct {
-	FlatSettings    *bool
-	IncludeDefaults *bool
-	MasterTimeout   time.Duration
-	Timeout         time.Duration
+	FlatSettings          *bool
+	IncludeDefaults       *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -95,6 +96,10 @@ func (r ClusterGetSettingsRequest) Do(ctx context.Context, transport Transport) 
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -184,11 +189,21 @@ func (f ClusterGetSettings) WithIncludeDefaults(v bool) func(*ClusterGetSettings
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f ClusterGetSettings) WithMasterTimeout(v time.Duration) func(*ClusterGetSettingsRequest) {
 	return func(r *ClusterGetSettingsRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f ClusterGetSettings) WithClusterManagerTimeout(v time.Duration) func(*ClusterGetSettingsRequest) {
+	return func(r *ClusterGetSettingsRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cluster.health.go
+++ b/opensearchapi/api.cluster.health.go
@@ -236,7 +236,7 @@ func (f ClusterHealth) WithLevel(v string) func(*ClusterHealthRequest) {
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f ClusterHealth) WithLocal(v bool) func(*ClusterHealthRequest) {
 	return func(r *ClusterHealthRequest) {

--- a/opensearchapi/api.cluster.health.go
+++ b/opensearchapi/api.cluster.health.go
@@ -60,6 +60,7 @@ type ClusterHealthRequest struct {
 	Level                       string
 	Local                       *bool
 	MasterTimeout               time.Duration
+	ClusterManagerTimeout       time.Duration
 	Timeout                     time.Duration
 	WaitForActiveShards         string
 	WaitForEvents               string
@@ -115,6 +116,10 @@ func (r ClusterHealthRequest) Do(ctx context.Context, transport Transport) (*Res
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -244,11 +249,21 @@ func (f ClusterHealth) WithLocal(v bool) func(*ClusterHealthRequest) {
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f ClusterHealth) WithMasterTimeout(v time.Duration) func(*ClusterHealthRequest) {
 	return func(r *ClusterHealthRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f ClusterHealth) WithClusterManagerTimeout(v time.Duration) func(*ClusterHealthRequest) {
+	return func(r *ClusterHealthRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cluster.pending_tasks.go
+++ b/opensearchapi/api.cluster.pending_tasks.go
@@ -159,7 +159,7 @@ func (f ClusterPendingTasks) WithContext(v context.Context) func(*ClusterPending
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f ClusterPendingTasks) WithLocal(v bool) func(*ClusterPendingTasksRequest) {
 	return func(r *ClusterPendingTasksRequest) {

--- a/opensearchapi/api.cluster.pending_tasks.go
+++ b/opensearchapi/api.cluster.pending_tasks.go
@@ -55,8 +55,9 @@ type ClusterPendingTasks func(o ...func(*ClusterPendingTasksRequest)) (*Response
 // ClusterPendingTasksRequest configures the Cluster Pending Tasks API request.
 //
 type ClusterPendingTasksRequest struct {
-	Local         *bool
-	MasterTimeout time.Duration
+	Local                 *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -90,6 +91,10 @@ func (r ClusterPendingTasksRequest) Do(ctx context.Context, transport Transport)
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Pretty {
@@ -167,11 +172,21 @@ func (f ClusterPendingTasks) WithLocal(v bool) func(*ClusterPendingTasksRequest)
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f ClusterPendingTasks) WithMasterTimeout(v time.Duration) func(*ClusterPendingTasksRequest) {
 	return func(r *ClusterPendingTasksRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f ClusterPendingTasks) WithClusterManagerTimeout(v time.Duration) func(*ClusterPendingTasksRequest) {
+	return func(r *ClusterPendingTasksRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cluster.put_component_template.go
+++ b/opensearchapi/api.cluster.put_component_template.go
@@ -59,9 +59,10 @@ type ClusterPutComponentTemplateRequest struct {
 
 	Name string
 
-	Create        *bool
-	MasterTimeout time.Duration
-	Timeout       time.Duration
+	Create                *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -98,6 +99,10 @@ func (r ClusterPutComponentTemplateRequest) Do(ctx context.Context, transport Tr
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -183,11 +188,21 @@ func (f ClusterPutComponentTemplate) WithCreate(v bool) func(*ClusterPutComponen
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f ClusterPutComponentTemplate) WithMasterTimeout(v time.Duration) func(*ClusterPutComponentTemplateRequest) {
 	return func(r *ClusterPutComponentTemplateRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f ClusterPutComponentTemplate) WithClusterManagerTimeout(v time.Duration) func(*ClusterPutComponentTemplateRequest) {
+	return func(r *ClusterPutComponentTemplateRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cluster.put_settings.go
+++ b/opensearchapi/api.cluster.put_settings.go
@@ -57,9 +57,10 @@ type ClusterPutSettings func(body io.Reader, o ...func(*ClusterPutSettingsReques
 type ClusterPutSettingsRequest struct {
 	Body io.Reader
 
-	FlatSettings  *bool
-	MasterTimeout time.Duration
-	Timeout       time.Duration
+	FlatSettings          *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -93,6 +94,10 @@ func (r ClusterPutSettingsRequest) Do(ctx context.Context, transport Transport) 
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -178,11 +183,21 @@ func (f ClusterPutSettings) WithFlatSettings(v bool) func(*ClusterPutSettingsReq
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f ClusterPutSettings) WithMasterTimeout(v time.Duration) func(*ClusterPutSettingsRequest) {
 	return func(r *ClusterPutSettingsRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f ClusterPutSettings) WithClusterManagerTimeout(v time.Duration) func(*ClusterPutSettingsRequest) {
+	return func(r *ClusterPutSettingsRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cluster.reroute.go
+++ b/opensearchapi/api.cluster.reroute.go
@@ -57,12 +57,13 @@ type ClusterReroute func(o ...func(*ClusterRerouteRequest)) (*Response, error)
 type ClusterRerouteRequest struct {
 	Body io.Reader
 
-	DryRun        *bool
-	Explain       *bool
-	MasterTimeout time.Duration
-	Metric        []string
-	RetryFailed   *bool
-	Timeout       time.Duration
+	DryRun                *bool
+	Explain               *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Metric                []string
+	RetryFailed           *bool
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -100,6 +101,10 @@ func (r ClusterRerouteRequest) Do(ctx context.Context, transport Transport) (*Re
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if len(r.Metric) > 0 {
@@ -209,11 +214,21 @@ func (f ClusterReroute) WithExplain(v bool) func(*ClusterRerouteRequest) {
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f ClusterReroute) WithMasterTimeout(v time.Duration) func(*ClusterRerouteRequest) {
 	return func(r *ClusterRerouteRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f ClusterReroute) WithClusterManagerTimeout(v time.Duration) func(*ClusterRerouteRequest) {
+	return func(r *ClusterRerouteRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cluster.state.go
+++ b/opensearchapi/api.cluster.state.go
@@ -64,6 +64,7 @@ type ClusterStateRequest struct {
 	IgnoreUnavailable      *bool
 	Local                  *bool
 	MasterTimeout          time.Duration
+	ClusterManagerTimeout  time.Duration
 	WaitForMetadataVersion *int
 	WaitForTimeout         time.Duration
 
@@ -126,6 +127,10 @@ func (r ClusterStateRequest) Do(ctx context.Context, transport Transport) (*Resp
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.WaitForMetadataVersion != nil {
@@ -259,11 +264,21 @@ func (f ClusterState) WithLocal(v bool) func(*ClusterStateRequest) {
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f ClusterState) WithMasterTimeout(v time.Duration) func(*ClusterStateRequest) {
 	return func(r *ClusterStateRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f ClusterState) WithClusterManagerTimeout(v time.Duration) func(*ClusterStateRequest) {
+	return func(r *ClusterStateRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.cluster.state.go
+++ b/opensearchapi/api.cluster.state.go
@@ -251,7 +251,7 @@ func (f ClusterState) WithIgnoreUnavailable(v bool) func(*ClusterStateRequest) {
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f ClusterState) WithLocal(v bool) func(*ClusterStateRequest) {
 	return func(r *ClusterStateRequest) {

--- a/opensearchapi/api.dangling_indices.delete_dangling_index.go
+++ b/opensearchapi/api.dangling_indices.delete_dangling_index.go
@@ -56,9 +56,10 @@ type DanglingIndicesDeleteDanglingIndex func(index_uuid string, o ...func(*Dangl
 type DanglingIndicesDeleteDanglingIndexRequest struct {
 	IndexUUID string
 
-	AcceptDataLoss *bool
-	MasterTimeout  time.Duration
-	Timeout        time.Duration
+	AcceptDataLoss        *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -95,6 +96,10 @@ func (r DanglingIndicesDeleteDanglingIndexRequest) Do(ctx context.Context, trans
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -176,11 +181,21 @@ func (f DanglingIndicesDeleteDanglingIndex) WithAcceptDataLoss(v bool) func(*Dan
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f DanglingIndicesDeleteDanglingIndex) WithMasterTimeout(v time.Duration) func(*DanglingIndicesDeleteDanglingIndexRequest) {
 	return func(r *DanglingIndicesDeleteDanglingIndexRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f DanglingIndicesDeleteDanglingIndex) WithClusterManagerTimeout(v time.Duration) func(*DanglingIndicesDeleteDanglingIndexRequest) {
+	return func(r *DanglingIndicesDeleteDanglingIndexRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.dangling_indices.import_dangling_index.go
+++ b/opensearchapi/api.dangling_indices.import_dangling_index.go
@@ -56,9 +56,10 @@ type DanglingIndicesImportDanglingIndex func(index_uuid string, o ...func(*Dangl
 type DanglingIndicesImportDanglingIndexRequest struct {
 	IndexUUID string
 
-	AcceptDataLoss *bool
-	MasterTimeout  time.Duration
-	Timeout        time.Duration
+	AcceptDataLoss        *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -95,6 +96,10 @@ func (r DanglingIndicesImportDanglingIndexRequest) Do(ctx context.Context, trans
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -176,11 +181,21 @@ func (f DanglingIndicesImportDanglingIndex) WithAcceptDataLoss(v bool) func(*Dan
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f DanglingIndicesImportDanglingIndex) WithMasterTimeout(v time.Duration) func(*DanglingIndicesImportDanglingIndexRequest) {
 	return func(r *DanglingIndicesImportDanglingIndexRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f DanglingIndicesImportDanglingIndex) WithClusterManagerTimeout(v time.Duration) func(*DanglingIndicesImportDanglingIndexRequest) {
+	return func(r *DanglingIndicesImportDanglingIndexRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.delete_script.go
+++ b/opensearchapi/api.delete_script.go
@@ -55,8 +55,9 @@ type DeleteScript func(id string, o ...func(*DeleteScriptRequest)) (*Response, e
 type DeleteScriptRequest struct {
 	ScriptID string
 
-	MasterTimeout time.Duration
-	Timeout       time.Duration
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -89,6 +90,10 @@ func (r DeleteScriptRequest) Do(ctx context.Context, transport Transport) (*Resp
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -162,11 +167,21 @@ func (f DeleteScript) WithContext(v context.Context) func(*DeleteScriptRequest) 
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f DeleteScript) WithMasterTimeout(v time.Duration) func(*DeleteScriptRequest) {
 	return func(r *DeleteScriptRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f DeleteScript) WithClusterManagerTimeout(v time.Duration) func(*DeleteScriptRequest) {
+	return func(r *DeleteScriptRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.get_script.go
+++ b/opensearchapi/api.get_script.go
@@ -55,7 +55,8 @@ type GetScript func(id string, o ...func(*GetScriptRequest)) (*Response, error)
 type GetScriptRequest struct {
 	ScriptID string
 
-	MasterTimeout time.Duration
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -88,6 +89,10 @@ func (r GetScriptRequest) Do(ctx context.Context, transport Transport) (*Respons
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Pretty {
@@ -157,11 +162,21 @@ func (f GetScript) WithContext(v context.Context) func(*GetScriptRequest) {
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f GetScript) WithMasterTimeout(v time.Duration) func(*GetScriptRequest) {
 	return func(r *GetScriptRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f GetScript) WithClusterManagerTimeout(v time.Duration) func(*GetScriptRequest) {
+	return func(r *GetScriptRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.add_block.go
+++ b/opensearchapi/api.indices.add_block.go
@@ -58,11 +58,12 @@ type IndicesAddBlockRequest struct {
 
 	Block string
 
-	AllowNoIndices    *bool
-	ExpandWildcards   string
-	IgnoreUnavailable *bool
-	MasterTimeout     time.Duration
-	Timeout           time.Duration
+	AllowNoIndices        *bool
+	ExpandWildcards       string
+	IgnoreUnavailable     *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -109,6 +110,10 @@ func (r IndicesAddBlockRequest) Do(ctx context.Context, transport Transport) (*R
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -206,11 +211,21 @@ func (f IndicesAddBlock) WithIgnoreUnavailable(v bool) func(*IndicesAddBlockRequ
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesAddBlock) WithMasterTimeout(v time.Duration) func(*IndicesAddBlockRequest) {
 	return func(r *IndicesAddBlockRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesAddBlock) WithClusterManagerTimeout(v time.Duration) func(*IndicesAddBlockRequest) {
+	return func(r *IndicesAddBlockRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.clone.go
+++ b/opensearchapi/api.indices.clone.go
@@ -60,9 +60,10 @@ type IndicesCloneRequest struct {
 
 	Target string
 
-	MasterTimeout       time.Duration
-	Timeout             time.Duration
-	WaitForActiveShards string
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
+	WaitForActiveShards   string
 
 	Pretty     bool
 	Human      bool
@@ -97,6 +98,10 @@ func (r IndicesCloneRequest) Do(ctx context.Context, transport Transport) (*Resp
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -186,11 +191,21 @@ func (f IndicesClone) WithBody(v io.Reader) func(*IndicesCloneRequest) {
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesClone) WithMasterTimeout(v time.Duration) func(*IndicesCloneRequest) {
 	return func(r *IndicesCloneRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesClone) WithClusterManagerTimeout(v time.Duration) func(*IndicesCloneRequest) {
+	return func(r *IndicesCloneRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.close.go
+++ b/opensearchapi/api.indices.close.go
@@ -56,12 +56,13 @@ type IndicesClose func(index []string, o ...func(*IndicesCloseRequest)) (*Respon
 type IndicesCloseRequest struct {
 	Index []string
 
-	AllowNoIndices      *bool
-	ExpandWildcards     string
-	IgnoreUnavailable   *bool
-	MasterTimeout       time.Duration
-	Timeout             time.Duration
-	WaitForActiveShards string
+	AllowNoIndices        *bool
+	ExpandWildcards       string
+	IgnoreUnavailable     *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
+	WaitForActiveShards   string
 
 	Pretty     bool
 	Human      bool
@@ -106,6 +107,10 @@ func (r IndicesCloseRequest) Do(ctx context.Context, transport Transport) (*Resp
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -207,11 +212,21 @@ func (f IndicesClose) WithIgnoreUnavailable(v bool) func(*IndicesCloseRequest) {
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesClose) WithMasterTimeout(v time.Duration) func(*IndicesCloseRequest) {
 	return func(r *IndicesCloseRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesClose) WithClusterManagerTimeout(v time.Duration) func(*IndicesCloseRequest) {
+	return func(r *IndicesCloseRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.create.go
+++ b/opensearchapi/api.indices.create.go
@@ -58,9 +58,10 @@ type IndicesCreateRequest struct {
 
 	Body io.Reader
 
-	MasterTimeout       time.Duration
-	Timeout             time.Duration
-	WaitForActiveShards string
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
+	WaitForActiveShards   string
 
 	Pretty     bool
 	Human      bool
@@ -91,6 +92,10 @@ func (r IndicesCreateRequest) Do(ctx context.Context, transport Transport) (*Res
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -180,11 +185,21 @@ func (f IndicesCreate) WithBody(v io.Reader) func(*IndicesCreateRequest) {
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesCreate) WithMasterTimeout(v time.Duration) func(*IndicesCreateRequest) {
 	return func(r *IndicesCreateRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesCreate) WithClusterManagerTimeout(v time.Duration) func(*IndicesCreateRequest) {
+	return func(r *IndicesCreateRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.delete.go
+++ b/opensearchapi/api.indices.delete.go
@@ -56,11 +56,12 @@ type IndicesDelete func(index []string, o ...func(*IndicesDeleteRequest)) (*Resp
 type IndicesDeleteRequest struct {
 	Index []string
 
-	AllowNoIndices    *bool
-	ExpandWildcards   string
-	IgnoreUnavailable *bool
-	MasterTimeout     time.Duration
-	Timeout           time.Duration
+	AllowNoIndices        *bool
+	ExpandWildcards       string
+	IgnoreUnavailable     *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -103,6 +104,10 @@ func (r IndicesDeleteRequest) Do(ctx context.Context, transport Transport) (*Res
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -200,11 +205,21 @@ func (f IndicesDelete) WithIgnoreUnavailable(v bool) func(*IndicesDeleteRequest)
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesDelete) WithMasterTimeout(v time.Duration) func(*IndicesDeleteRequest) {
 	return func(r *IndicesDeleteRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesDelete) WithClusterManagerTimeout(v time.Duration) func(*IndicesDeleteRequest) {
+	return func(r *IndicesDeleteRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.delete_alias.go
+++ b/opensearchapi/api.indices.delete_alias.go
@@ -57,8 +57,9 @@ type IndicesDeleteAliasRequest struct {
 
 	Name []string
 
-	MasterTimeout time.Duration
-	Timeout       time.Duration
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -93,6 +94,10 @@ func (r IndicesDeleteAliasRequest) Do(ctx context.Context, transport Transport) 
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -166,11 +171,21 @@ func (f IndicesDeleteAlias) WithContext(v context.Context) func(*IndicesDeleteAl
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesDeleteAlias) WithMasterTimeout(v time.Duration) func(*IndicesDeleteAliasRequest) {
 	return func(r *IndicesDeleteAliasRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesDeleteAlias) WithClusterManagerTimeout(v time.Duration) func(*IndicesDeleteAliasRequest) {
+	return func(r *IndicesDeleteAliasRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.delete_index_template.go
+++ b/opensearchapi/api.indices.delete_index_template.go
@@ -55,8 +55,9 @@ type IndicesDeleteIndexTemplate func(name string, o ...func(*IndicesDeleteIndexT
 type IndicesDeleteIndexTemplateRequest struct {
 	Name string
 
-	MasterTimeout time.Duration
-	Timeout       time.Duration
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -89,6 +90,10 @@ func (r IndicesDeleteIndexTemplateRequest) Do(ctx context.Context, transport Tra
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -162,11 +167,21 @@ func (f IndicesDeleteIndexTemplate) WithContext(v context.Context) func(*Indices
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesDeleteIndexTemplate) WithMasterTimeout(v time.Duration) func(*IndicesDeleteIndexTemplateRequest) {
 	return func(r *IndicesDeleteIndexTemplateRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesDeleteIndexTemplate) WithClusterManagerTimeout(v time.Duration) func(*IndicesDeleteIndexTemplateRequest) {
+	return func(r *IndicesDeleteIndexTemplateRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.delete_template.go
+++ b/opensearchapi/api.indices.delete_template.go
@@ -55,8 +55,9 @@ type IndicesDeleteTemplate func(name string, o ...func(*IndicesDeleteTemplateReq
 type IndicesDeleteTemplateRequest struct {
 	Name string
 
-	MasterTimeout time.Duration
-	Timeout       time.Duration
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -89,6 +90,10 @@ func (r IndicesDeleteTemplateRequest) Do(ctx context.Context, transport Transpor
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -162,11 +167,21 @@ func (f IndicesDeleteTemplate) WithContext(v context.Context) func(*IndicesDelet
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesDeleteTemplate) WithMasterTimeout(v time.Duration) func(*IndicesDeleteTemplateRequest) {
 	return func(r *IndicesDeleteTemplateRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesDeleteTemplate) WithClusterManagerTimeout(v time.Duration) func(*IndicesDeleteTemplateRequest) {
+	return func(r *IndicesDeleteTemplateRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.exists.go
+++ b/opensearchapi/api.indices.exists.go
@@ -220,7 +220,7 @@ func (f IndicesExists) WithIncludeDefaults(v bool) func(*IndicesExistsRequest) {
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f IndicesExists) WithLocal(v bool) func(*IndicesExistsRequest) {
 	return func(r *IndicesExistsRequest) {

--- a/opensearchapi/api.indices.exists_alias.go
+++ b/opensearchapi/api.indices.exists_alias.go
@@ -210,7 +210,7 @@ func (f IndicesExistsAlias) WithIgnoreUnavailable(v bool) func(*IndicesExistsAli
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f IndicesExistsAlias) WithLocal(v bool) func(*IndicesExistsAliasRequest) {
 	return func(r *IndicesExistsAliasRequest) {

--- a/opensearchapi/api.indices.exists_index_template.go
+++ b/opensearchapi/api.indices.exists_index_template.go
@@ -176,7 +176,7 @@ func (f IndicesExistsIndexTemplate) WithFlatSettings(v bool) func(*IndicesExists
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f IndicesExistsIndexTemplate) WithLocal(v bool) func(*IndicesExistsIndexTemplateRequest) {
 	return func(r *IndicesExistsIndexTemplateRequest) {

--- a/opensearchapi/api.indices.exists_index_template.go
+++ b/opensearchapi/api.indices.exists_index_template.go
@@ -56,9 +56,10 @@ type IndicesExistsIndexTemplate func(name string, o ...func(*IndicesExistsIndexT
 type IndicesExistsIndexTemplateRequest struct {
 	Name string
 
-	FlatSettings  *bool
-	Local         *bool
-	MasterTimeout time.Duration
+	FlatSettings          *bool
+	Local                 *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -99,6 +100,10 @@ func (r IndicesExistsIndexTemplateRequest) Do(ctx context.Context, transport Tra
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Pretty {
@@ -184,11 +189,21 @@ func (f IndicesExistsIndexTemplate) WithLocal(v bool) func(*IndicesExistsIndexTe
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesExistsIndexTemplate) WithMasterTimeout(v time.Duration) func(*IndicesExistsIndexTemplateRequest) {
 	return func(r *IndicesExistsIndexTemplateRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesExistsIndexTemplate) WithClusterManagerTimeout(v time.Duration) func(*IndicesExistsIndexTemplateRequest) {
+	return func(r *IndicesExistsIndexTemplateRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.exists_template.go
+++ b/opensearchapi/api.indices.exists_template.go
@@ -176,7 +176,7 @@ func (f IndicesExistsTemplate) WithFlatSettings(v bool) func(*IndicesExistsTempl
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f IndicesExistsTemplate) WithLocal(v bool) func(*IndicesExistsTemplateRequest) {
 	return func(r *IndicesExistsTemplateRequest) {

--- a/opensearchapi/api.indices.exists_template.go
+++ b/opensearchapi/api.indices.exists_template.go
@@ -56,9 +56,10 @@ type IndicesExistsTemplate func(name []string, o ...func(*IndicesExistsTemplateR
 type IndicesExistsTemplateRequest struct {
 	Name []string
 
-	FlatSettings  *bool
-	Local         *bool
-	MasterTimeout time.Duration
+	FlatSettings          *bool
+	Local                 *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -99,6 +100,10 @@ func (r IndicesExistsTemplateRequest) Do(ctx context.Context, transport Transpor
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Pretty {
@@ -184,11 +189,21 @@ func (f IndicesExistsTemplate) WithLocal(v bool) func(*IndicesExistsTemplateRequ
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesExistsTemplate) WithMasterTimeout(v time.Duration) func(*IndicesExistsTemplateRequest) {
 	return func(r *IndicesExistsTemplateRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesExistsTemplate) WithClusterManagerTimeout(v time.Duration) func(*IndicesExistsTemplateRequest) {
+	return func(r *IndicesExistsTemplateRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.get.go
+++ b/opensearchapi/api.indices.get.go
@@ -226,7 +226,7 @@ func (f IndicesGet) WithIncludeDefaults(v bool) func(*IndicesGetRequest) {
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f IndicesGet) WithLocal(v bool) func(*IndicesGetRequest) {
 	return func(r *IndicesGetRequest) {

--- a/opensearchapi/api.indices.get.go
+++ b/opensearchapi/api.indices.get.go
@@ -56,13 +56,14 @@ type IndicesGet func(index []string, o ...func(*IndicesGetRequest)) (*Response, 
 type IndicesGetRequest struct {
 	Index []string
 
-	AllowNoIndices    *bool
-	ExpandWildcards   string
-	FlatSettings      *bool
-	IgnoreUnavailable *bool
-	IncludeDefaults   *bool
-	Local             *bool
-	MasterTimeout     time.Duration
+	AllowNoIndices        *bool
+	ExpandWildcards       string
+	FlatSettings          *bool
+	IgnoreUnavailable     *bool
+	IncludeDefaults       *bool
+	Local                 *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -117,6 +118,10 @@ func (r IndicesGetRequest) Do(ctx context.Context, transport Transport) (*Respon
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Pretty {
@@ -234,11 +239,21 @@ func (f IndicesGet) WithLocal(v bool) func(*IndicesGetRequest) {
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesGet) WithMasterTimeout(v time.Duration) func(*IndicesGetRequest) {
 	return func(r *IndicesGetRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesGet) WithClusterManagerTimeout(v time.Duration) func(*IndicesGetRequest) {
+	return func(r *IndicesGetRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.get_alias.go
+++ b/opensearchapi/api.indices.get_alias.go
@@ -220,7 +220,7 @@ func (f IndicesGetAlias) WithIgnoreUnavailable(v bool) func(*IndicesGetAliasRequ
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f IndicesGetAlias) WithLocal(v bool) func(*IndicesGetAliasRequest) {
 	return func(r *IndicesGetAliasRequest) {

--- a/opensearchapi/api.indices.get_field_mapping.go
+++ b/opensearchapi/api.indices.get_field_mapping.go
@@ -225,7 +225,7 @@ func (f IndicesGetFieldMapping) WithIncludeDefaults(v bool) func(*IndicesGetFiel
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f IndicesGetFieldMapping) WithLocal(v bool) func(*IndicesGetFieldMappingRequest) {
 	return func(r *IndicesGetFieldMappingRequest) {

--- a/opensearchapi/api.indices.get_index_template.go
+++ b/opensearchapi/api.indices.get_index_template.go
@@ -186,7 +186,7 @@ func (f IndicesGetIndexTemplate) WithFlatSettings(v bool) func(*IndicesGetIndexT
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f IndicesGetIndexTemplate) WithLocal(v bool) func(*IndicesGetIndexTemplateRequest) {
 	return func(r *IndicesGetIndexTemplateRequest) {

--- a/opensearchapi/api.indices.get_index_template.go
+++ b/opensearchapi/api.indices.get_index_template.go
@@ -56,9 +56,10 @@ type IndicesGetIndexTemplate func(o ...func(*IndicesGetIndexTemplateRequest)) (*
 type IndicesGetIndexTemplateRequest struct {
 	Name []string
 
-	FlatSettings  *bool
-	Local         *bool
-	MasterTimeout time.Duration
+	FlatSettings          *bool
+	Local                 *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -101,6 +102,10 @@ func (r IndicesGetIndexTemplateRequest) Do(ctx context.Context, transport Transp
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Pretty {
@@ -194,11 +199,21 @@ func (f IndicesGetIndexTemplate) WithLocal(v bool) func(*IndicesGetIndexTemplate
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesGetIndexTemplate) WithMasterTimeout(v time.Duration) func(*IndicesGetIndexTemplateRequest) {
 	return func(r *IndicesGetIndexTemplateRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesGetIndexTemplate) WithClusterManagerTimeout(v time.Duration) func(*IndicesGetIndexTemplateRequest) {
+	return func(r *IndicesGetIndexTemplateRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.get_mapping.go
+++ b/opensearchapi/api.indices.get_mapping.go
@@ -54,13 +54,14 @@ type IndicesGetMapping func(o ...func(*IndicesGetMappingRequest)) (*Response, er
 // IndicesGetMappingRequest configures the Indices Get Mapping API request.
 //
 type IndicesGetMappingRequest struct {
-	Index        []string
+	Index []string
 
-	AllowNoIndices    *bool
-	ExpandWildcards   string
-	IgnoreUnavailable *bool
-	Local             *bool
-	MasterTimeout     time.Duration
+	AllowNoIndices        *bool
+	ExpandWildcards       string
+	IgnoreUnavailable     *bool
+	Local                 *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -110,6 +111,10 @@ func (r IndicesGetMappingRequest) Do(ctx context.Context, transport Transport) (
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Pretty {
@@ -219,11 +224,21 @@ func (f IndicesGetMapping) WithLocal(v bool) func(*IndicesGetMappingRequest) {
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesGetMapping) WithMasterTimeout(v time.Duration) func(*IndicesGetMappingRequest) {
 	return func(r *IndicesGetMappingRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesGetMapping) WithClusterManagerTimeout(v time.Duration) func(*IndicesGetMappingRequest) {
+	return func(r *IndicesGetMappingRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.get_mapping.go
+++ b/opensearchapi/api.indices.get_mapping.go
@@ -211,7 +211,7 @@ func (f IndicesGetMapping) WithIgnoreUnavailable(v bool) func(*IndicesGetMapping
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f IndicesGetMapping) WithLocal(v bool) func(*IndicesGetMappingRequest) {
 	return func(r *IndicesGetMappingRequest) {

--- a/opensearchapi/api.indices.get_settings.go
+++ b/opensearchapi/api.indices.get_settings.go
@@ -252,7 +252,7 @@ func (f IndicesGetSettings) WithIncludeDefaults(v bool) func(*IndicesGetSettings
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f IndicesGetSettings) WithLocal(v bool) func(*IndicesGetSettingsRequest) {
 	return func(r *IndicesGetSettingsRequest) {

--- a/opensearchapi/api.indices.get_settings.go
+++ b/opensearchapi/api.indices.get_settings.go
@@ -58,13 +58,14 @@ type IndicesGetSettingsRequest struct {
 
 	Name []string
 
-	AllowNoIndices    *bool
-	ExpandWildcards   string
-	FlatSettings      *bool
-	IgnoreUnavailable *bool
-	IncludeDefaults   *bool
-	Local             *bool
-	MasterTimeout     time.Duration
+	AllowNoIndices        *bool
+	ExpandWildcards       string
+	FlatSettings          *bool
+	IgnoreUnavailable     *bool
+	IncludeDefaults       *bool
+	Local                 *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -127,6 +128,10 @@ func (r IndicesGetSettingsRequest) Do(ctx context.Context, transport Transport) 
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Pretty {
@@ -260,11 +265,21 @@ func (f IndicesGetSettings) WithLocal(v bool) func(*IndicesGetSettingsRequest) {
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesGetSettings) WithMasterTimeout(v time.Duration) func(*IndicesGetSettingsRequest) {
 	return func(r *IndicesGetSettingsRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesGetSettings) WithClusterManagerTimeout(v time.Duration) func(*IndicesGetSettingsRequest) {
+	return func(r *IndicesGetSettingsRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.get_template.go
+++ b/opensearchapi/api.indices.get_template.go
@@ -56,9 +56,10 @@ type IndicesGetTemplate func(o ...func(*IndicesGetTemplateRequest)) (*Response, 
 type IndicesGetTemplateRequest struct {
 	Name []string
 
-	FlatSettings    *bool
-	Local           *bool
-	MasterTimeout   time.Duration
+	FlatSettings          *bool
+	Local                 *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -101,6 +102,10 @@ func (r IndicesGetTemplateRequest) Do(ctx context.Context, transport Transport) 
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Pretty {
@@ -194,11 +199,21 @@ func (f IndicesGetTemplate) WithLocal(v bool) func(*IndicesGetTemplateRequest) {
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesGetTemplate) WithMasterTimeout(v time.Duration) func(*IndicesGetTemplateRequest) {
 	return func(r *IndicesGetTemplateRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesGetTemplate) WithClusterManagerTimeout(v time.Duration) func(*IndicesGetTemplateRequest) {
+	return func(r *IndicesGetTemplateRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.get_template.go
+++ b/opensearchapi/api.indices.get_template.go
@@ -186,7 +186,7 @@ func (f IndicesGetTemplate) WithFlatSettings(v bool) func(*IndicesGetTemplateReq
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f IndicesGetTemplate) WithLocal(v bool) func(*IndicesGetTemplateRequest) {
 	return func(r *IndicesGetTemplateRequest) {

--- a/opensearchapi/api.indices.open.go
+++ b/opensearchapi/api.indices.open.go
@@ -56,12 +56,13 @@ type IndicesOpen func(index []string, o ...func(*IndicesOpenRequest)) (*Response
 type IndicesOpenRequest struct {
 	Index []string
 
-	AllowNoIndices      *bool
-	ExpandWildcards     string
-	IgnoreUnavailable   *bool
-	MasterTimeout       time.Duration
-	Timeout             time.Duration
-	WaitForActiveShards string
+	AllowNoIndices        *bool
+	ExpandWildcards       string
+	IgnoreUnavailable     *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
+	WaitForActiveShards   string
 
 	Pretty     bool
 	Human      bool
@@ -106,6 +107,10 @@ func (r IndicesOpenRequest) Do(ctx context.Context, transport Transport) (*Respo
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -207,11 +212,21 @@ func (f IndicesOpen) WithIgnoreUnavailable(v bool) func(*IndicesOpenRequest) {
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesOpen) WithMasterTimeout(v time.Duration) func(*IndicesOpenRequest) {
 	return func(r *IndicesOpenRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesOpen) WithClusterManagerTimeout(v time.Duration) func(*IndicesOpenRequest) {
+	return func(r *IndicesOpenRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.put_alias.go
+++ b/opensearchapi/api.indices.put_alias.go
@@ -60,8 +60,9 @@ type IndicesPutAliasRequest struct {
 
 	Name string
 
-	MasterTimeout time.Duration
-	Timeout       time.Duration
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -96,6 +97,10 @@ func (r IndicesPutAliasRequest) Do(ctx context.Context, transport Transport) (*R
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -181,11 +186,21 @@ func (f IndicesPutAlias) WithBody(v io.Reader) func(*IndicesPutAliasRequest) {
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesPutAlias) WithMasterTimeout(v time.Duration) func(*IndicesPutAliasRequest) {
 	return func(r *IndicesPutAliasRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesPutAlias) WithClusterManagerTimeout(v time.Duration) func(*IndicesPutAliasRequest) {
+	return func(r *IndicesPutAliasRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.put_index_template.go
+++ b/opensearchapi/api.indices.put_index_template.go
@@ -59,9 +59,10 @@ type IndicesPutIndexTemplateRequest struct {
 
 	Name string
 
-	Cause         string
-	Create        *bool
-	MasterTimeout time.Duration
+	Cause                 string
+	Create                *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +103,10 @@ func (r IndicesPutIndexTemplateRequest) Do(ctx context.Context, transport Transp
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Pretty {
@@ -191,11 +196,21 @@ func (f IndicesPutIndexTemplate) WithCreate(v bool) func(*IndicesPutIndexTemplat
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesPutIndexTemplate) WithMasterTimeout(v time.Duration) func(*IndicesPutIndexTemplateRequest) {
 	return func(r *IndicesPutIndexTemplateRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesPutIndexTemplate) WithClusterManagerTimeout(v time.Duration) func(*IndicesPutIndexTemplateRequest) {
+	return func(r *IndicesPutIndexTemplateRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.put_mapping.go
+++ b/opensearchapi/api.indices.put_mapping.go
@@ -55,16 +55,17 @@ type IndicesPutMapping func(body io.Reader, o ...func(*IndicesPutMappingRequest)
 // IndicesPutMappingRequest configures the Indices Put Mapping API request.
 //
 type IndicesPutMappingRequest struct {
-	Index        []string
+	Index []string
 
 	Body io.Reader
 
-	AllowNoIndices    *bool
-	ExpandWildcards   string
-	IgnoreUnavailable *bool
-	MasterTimeout     time.Duration
-	Timeout           time.Duration
-	WriteIndexOnly    *bool
+	AllowNoIndices        *bool
+	ExpandWildcards       string
+	IgnoreUnavailable     *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
+	WriteIndexOnly        *bool
 
 	Pretty     bool
 	Human      bool
@@ -111,6 +112,10 @@ func (r IndicesPutMappingRequest) Do(ctx context.Context, transport Transport) (
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -224,11 +229,21 @@ func (f IndicesPutMapping) WithIgnoreUnavailable(v bool) func(*IndicesPutMapping
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesPutMapping) WithMasterTimeout(v time.Duration) func(*IndicesPutMappingRequest) {
 	return func(r *IndicesPutMappingRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesPutMapping) WithClusterManagerTimeout(v time.Duration) func(*IndicesPutMappingRequest) {
+	return func(r *IndicesPutMappingRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.put_settings.go
+++ b/opensearchapi/api.indices.put_settings.go
@@ -59,13 +59,14 @@ type IndicesPutSettingsRequest struct {
 
 	Body io.Reader
 
-	AllowNoIndices    *bool
-	ExpandWildcards   string
-	FlatSettings      *bool
-	IgnoreUnavailable *bool
-	MasterTimeout     time.Duration
-	PreserveExisting  *bool
-	Timeout           time.Duration
+	AllowNoIndices        *bool
+	ExpandWildcards       string
+	FlatSettings          *bool
+	IgnoreUnavailable     *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	PreserveExisting      *bool
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -116,6 +117,10 @@ func (r IndicesPutSettingsRequest) Do(ctx context.Context, transport Transport) 
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.PreserveExisting != nil {
@@ -237,11 +242,21 @@ func (f IndicesPutSettings) WithIgnoreUnavailable(v bool) func(*IndicesPutSettin
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesPutSettings) WithMasterTimeout(v time.Duration) func(*IndicesPutSettingsRequest) {
 	return func(r *IndicesPutSettingsRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesPutSettings) WithClusterManagerTimeout(v time.Duration) func(*IndicesPutSettingsRequest) {
+	return func(r *IndicesPutSettingsRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.put_template.go
+++ b/opensearchapi/api.indices.put_template.go
@@ -59,9 +59,10 @@ type IndicesPutTemplateRequest struct {
 
 	Name string
 
-	Create          *bool
-	MasterTimeout   time.Duration
-	Order           *int
+	Create                *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Order                 *int
 
 	Pretty     bool
 	Human      bool
@@ -98,6 +99,10 @@ func (r IndicesPutTemplateRequest) Do(ctx context.Context, transport Transport) 
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Order != nil {
@@ -183,11 +188,21 @@ func (f IndicesPutTemplate) WithCreate(v bool) func(*IndicesPutTemplateRequest) 
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesPutTemplate) WithMasterTimeout(v time.Duration) func(*IndicesPutTemplateRequest) {
 	return func(r *IndicesPutTemplateRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesPutTemplate) WithClusterManagerTimeout(v time.Duration) func(*IndicesPutTemplateRequest) {
+	return func(r *IndicesPutTemplateRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.rollover.go
+++ b/opensearchapi/api.indices.rollover.go
@@ -61,10 +61,11 @@ type IndicesRolloverRequest struct {
 	Alias    string
 	NewIndex string
 
-	DryRun              *bool
-	MasterTimeout       time.Duration
-	Timeout             time.Duration
-	WaitForActiveShards string
+	DryRun                *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
+	WaitForActiveShards   string
 
 	Pretty     bool
 	Human      bool
@@ -105,6 +106,10 @@ func (r IndicesRolloverRequest) Do(ctx context.Context, transport Transport) (*R
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -210,11 +215,21 @@ func (f IndicesRollover) WithDryRun(v bool) func(*IndicesRolloverRequest) {
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesRollover) WithMasterTimeout(v time.Duration) func(*IndicesRolloverRequest) {
 	return func(r *IndicesRolloverRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesRollover) WithClusterManagerTimeout(v time.Duration) func(*IndicesRolloverRequest) {
+	return func(r *IndicesRolloverRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.shrink.go
+++ b/opensearchapi/api.indices.shrink.go
@@ -61,10 +61,11 @@ type IndicesShrinkRequest struct {
 
 	Target string
 
-	CopySettings        *bool
-	MasterTimeout       time.Duration
-	Timeout             time.Duration
-	WaitForActiveShards string
+	CopySettings          *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
+	WaitForActiveShards   string
 
 	Pretty     bool
 	Human      bool
@@ -103,6 +104,10 @@ func (r IndicesShrinkRequest) Do(ctx context.Context, transport Transport) (*Res
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -200,11 +205,21 @@ func (f IndicesShrink) WithCopySettings(v bool) func(*IndicesShrinkRequest) {
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesShrink) WithMasterTimeout(v time.Duration) func(*IndicesShrinkRequest) {
 	return func(r *IndicesShrinkRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesShrink) WithClusterManagerTimeout(v time.Duration) func(*IndicesShrinkRequest) {
+	return func(r *IndicesShrinkRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.simulate_index_template.go
+++ b/opensearchapi/api.indices.simulate_index_template.go
@@ -59,9 +59,10 @@ type IndicesSimulateIndexTemplateRequest struct {
 
 	Name string
 
-	Cause         string
-	Create        *bool
-	MasterTimeout time.Duration
+	Cause                 string
+	Create                *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -104,6 +105,10 @@ func (r IndicesSimulateIndexTemplateRequest) Do(ctx context.Context, transport T
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Pretty {
@@ -201,11 +206,21 @@ func (f IndicesSimulateIndexTemplate) WithCreate(v bool) func(*IndicesSimulateIn
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesSimulateIndexTemplate) WithMasterTimeout(v time.Duration) func(*IndicesSimulateIndexTemplateRequest) {
 	return func(r *IndicesSimulateIndexTemplateRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesSimulateIndexTemplate) WithClusterManagerTimeout(v time.Duration) func(*IndicesSimulateIndexTemplateRequest) {
+	return func(r *IndicesSimulateIndexTemplateRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.simulate_template.go
+++ b/opensearchapi/api.indices.simulate_template.go
@@ -59,9 +59,10 @@ type IndicesSimulateTemplateRequest struct {
 
 	Name string
 
-	Cause         string
-	Create        *bool
-	MasterTimeout time.Duration
+	Cause                 string
+	Create                *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -106,6 +107,10 @@ func (r IndicesSimulateTemplateRequest) Do(ctx context.Context, transport Transp
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Pretty {
@@ -211,11 +216,21 @@ func (f IndicesSimulateTemplate) WithCreate(v bool) func(*IndicesSimulateTemplat
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesSimulateTemplate) WithMasterTimeout(v time.Duration) func(*IndicesSimulateTemplateRequest) {
 	return func(r *IndicesSimulateTemplateRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesSimulateTemplate) WithClusterManagerTimeout(v time.Duration) func(*IndicesSimulateTemplateRequest) {
+	return func(r *IndicesSimulateTemplateRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.split.go
+++ b/opensearchapi/api.indices.split.go
@@ -61,10 +61,11 @@ type IndicesSplitRequest struct {
 
 	Target string
 
-	CopySettings        *bool
-	MasterTimeout       time.Duration
-	Timeout             time.Duration
-	WaitForActiveShards string
+	CopySettings          *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
+	WaitForActiveShards   string
 
 	Pretty     bool
 	Human      bool
@@ -103,6 +104,10 @@ func (r IndicesSplitRequest) Do(ctx context.Context, transport Transport) (*Resp
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -200,11 +205,21 @@ func (f IndicesSplit) WithCopySettings(v bool) func(*IndicesSplitRequest) {
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesSplit) WithMasterTimeout(v time.Duration) func(*IndicesSplitRequest) {
 	return func(r *IndicesSplitRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesSplit) WithClusterManagerTimeout(v time.Duration) func(*IndicesSplitRequest) {
+	return func(r *IndicesSplitRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.indices.update_aliases.go
+++ b/opensearchapi/api.indices.update_aliases.go
@@ -56,8 +56,9 @@ type IndicesUpdateAliases func(body io.Reader, o ...func(*IndicesUpdateAliasesRe
 type IndicesUpdateAliasesRequest struct {
 	Body io.Reader
 
-	MasterTimeout time.Duration
-	Timeout       time.Duration
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -87,6 +88,10 @@ func (r IndicesUpdateAliasesRequest) Do(ctx context.Context, transport Transport
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -164,11 +169,21 @@ func (f IndicesUpdateAliases) WithContext(v context.Context) func(*IndicesUpdate
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IndicesUpdateAliases) WithMasterTimeout(v time.Duration) func(*IndicesUpdateAliasesRequest) {
 	return func(r *IndicesUpdateAliasesRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IndicesUpdateAliases) WithClusterManagerTimeout(v time.Duration) func(*IndicesUpdateAliasesRequest) {
+	return func(r *IndicesUpdateAliasesRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.ingest.delete_pipeline.go
+++ b/opensearchapi/api.ingest.delete_pipeline.go
@@ -55,8 +55,9 @@ type IngestDeletePipeline func(id string, o ...func(*IngestDeletePipelineRequest
 type IngestDeletePipelineRequest struct {
 	PipelineID string
 
-	MasterTimeout time.Duration
-	Timeout       time.Duration
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -91,6 +92,10 @@ func (r IngestDeletePipelineRequest) Do(ctx context.Context, transport Transport
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -164,11 +169,21 @@ func (f IngestDeletePipeline) WithContext(v context.Context) func(*IngestDeleteP
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IngestDeletePipeline) WithMasterTimeout(v time.Duration) func(*IngestDeletePipelineRequest) {
 	return func(r *IngestDeletePipelineRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IngestDeletePipeline) WithClusterManagerTimeout(v time.Duration) func(*IngestDeletePipelineRequest) {
+	return func(r *IngestDeletePipelineRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.ingest.get_pipeline.go
+++ b/opensearchapi/api.ingest.get_pipeline.go
@@ -56,8 +56,9 @@ type IngestGetPipeline func(o ...func(*IngestGetPipelineRequest)) (*Response, er
 type IngestGetPipelineRequest struct {
 	PipelineID string
 
-	MasterTimeout time.Duration
-	Summary       *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Summary               *bool
 
 	Pretty     bool
 	Human      bool
@@ -94,6 +95,10 @@ func (r IngestGetPipelineRequest) Do(ctx context.Context, transport Transport) (
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Summary != nil {
@@ -175,11 +180,21 @@ func (f IngestGetPipeline) WithPipelineID(v string) func(*IngestGetPipelineReque
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IngestGetPipeline) WithMasterTimeout(v time.Duration) func(*IngestGetPipelineRequest) {
 	return func(r *IngestGetPipelineRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IngestGetPipeline) WithClusterManagerTimeout(v time.Duration) func(*IngestGetPipelineRequest) {
+	return func(r *IngestGetPipelineRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.ingest.put_pipeline.go
+++ b/opensearchapi/api.ingest.put_pipeline.go
@@ -58,8 +58,9 @@ type IngestPutPipelineRequest struct {
 
 	Body io.Reader
 
-	MasterTimeout time.Duration
-	Timeout       time.Duration
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -94,6 +95,10 @@ func (r IngestPutPipelineRequest) Do(ctx context.Context, transport Transport) (
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -171,11 +176,21 @@ func (f IngestPutPipeline) WithContext(v context.Context) func(*IngestPutPipelin
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f IngestPutPipeline) WithMasterTimeout(v time.Duration) func(*IngestPutPipelineRequest) {
 	return func(r *IngestPutPipelineRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f IngestPutPipeline) WithClusterManagerTimeout(v time.Duration) func(*IngestPutPipelineRequest) {
+	return func(r *IngestPutPipelineRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.put_script.go
+++ b/opensearchapi/api.put_script.go
@@ -60,8 +60,9 @@ type PutScriptRequest struct {
 
 	ScriptContext string
 
-	MasterTimeout time.Duration
-	Timeout       time.Duration
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +103,10 @@ func (r PutScriptRequest) Do(ctx context.Context, transport Transport) (*Respons
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -187,11 +192,21 @@ func (f PutScript) WithScriptContext(v string) func(*PutScriptRequest) {
 	}
 }
 
-// WithMasterTimeout - specify timeout for connection to master.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f PutScript) WithMasterTimeout(v time.Duration) func(*PutScriptRequest) {
 	return func(r *PutScriptRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f PutScript) WithClusterManagerTimeout(v time.Duration) func(*PutScriptRequest) {
+	return func(r *PutScriptRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.search_shards.go
+++ b/opensearchapi/api.search_shards.go
@@ -216,7 +216,7 @@ func (f SearchShards) WithIgnoreUnavailable(v bool) func(*SearchShardsRequest) {
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f SearchShards) WithLocal(v bool) func(*SearchShardsRequest) {
 	return func(r *SearchShardsRequest) {

--- a/opensearchapi/api.snapshot.cleanup_repository.go
+++ b/opensearchapi/api.snapshot.cleanup_repository.go
@@ -55,8 +55,9 @@ type SnapshotCleanupRepository func(repository string, o ...func(*SnapshotCleanu
 type SnapshotCleanupRepositoryRequest struct {
 	Repository string
 
-	MasterTimeout time.Duration
-	Timeout       time.Duration
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -91,6 +92,10 @@ func (r SnapshotCleanupRepositoryRequest) Do(ctx context.Context, transport Tran
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -164,11 +169,21 @@ func (f SnapshotCleanupRepository) WithContext(v context.Context) func(*Snapshot
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f SnapshotCleanupRepository) WithMasterTimeout(v time.Duration) func(*SnapshotCleanupRepositoryRequest) {
 	return func(r *SnapshotCleanupRepositoryRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f SnapshotCleanupRepository) WithClusterManagerTimeout(v time.Duration) func(*SnapshotCleanupRepositoryRequest) {
+	return func(r *SnapshotCleanupRepositoryRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.snapshot.clone.go
+++ b/opensearchapi/api.snapshot.clone.go
@@ -60,7 +60,8 @@ type SnapshotCloneRequest struct {
 	Snapshot       string
 	TargetSnapshot string
 
-	MasterTimeout time.Duration
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -99,6 +100,10 @@ func (r SnapshotCloneRequest) Do(ctx context.Context, transport Transport) (*Res
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Pretty {
@@ -172,11 +177,21 @@ func (f SnapshotClone) WithContext(v context.Context) func(*SnapshotCloneRequest
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f SnapshotClone) WithMasterTimeout(v time.Duration) func(*SnapshotCloneRequest) {
 	return func(r *SnapshotCloneRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f SnapshotClone) WithClusterManagerTimeout(v time.Duration) func(*SnapshotCloneRequest) {
+	return func(r *SnapshotCloneRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.snapshot.create.go
+++ b/opensearchapi/api.snapshot.create.go
@@ -60,8 +60,9 @@ type SnapshotCreateRequest struct {
 	Repository string
 	Snapshot   string
 
-	MasterTimeout     time.Duration
-	WaitForCompletion *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	WaitForCompletion     *bool
 
 	Pretty     bool
 	Human      bool
@@ -96,6 +97,10 @@ func (r SnapshotCreateRequest) Do(ctx context.Context, transport Transport) (*Re
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.WaitForCompletion != nil {
@@ -181,11 +186,21 @@ func (f SnapshotCreate) WithBody(v io.Reader) func(*SnapshotCreateRequest) {
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f SnapshotCreate) WithMasterTimeout(v time.Duration) func(*SnapshotCreateRequest) {
 	return func(r *SnapshotCreateRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f SnapshotCreate) WithClusterManagerTimeout(v time.Duration) func(*SnapshotCreateRequest) {
+	return func(r *SnapshotCreateRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.snapshot.create_repository.go
+++ b/opensearchapi/api.snapshot.create_repository.go
@@ -59,9 +59,10 @@ type SnapshotCreateRepositoryRequest struct {
 
 	Repository string
 
-	MasterTimeout time.Duration
-	Timeout       time.Duration
-	Verify        *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
+	Verify                *bool
 
 	Pretty     bool
 	Human      bool
@@ -94,6 +95,10 @@ func (r SnapshotCreateRepositoryRequest) Do(ctx context.Context, transport Trans
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -175,11 +180,21 @@ func (f SnapshotCreateRepository) WithContext(v context.Context) func(*SnapshotC
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f SnapshotCreateRepository) WithMasterTimeout(v time.Duration) func(*SnapshotCreateRepositoryRequest) {
 	return func(r *SnapshotCreateRepositoryRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f SnapshotCreateRepository) WithClusterManagerTimeout(v time.Duration) func(*SnapshotCreateRepositoryRequest) {
+	return func(r *SnapshotCreateRepositoryRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.snapshot.delete.go
+++ b/opensearchapi/api.snapshot.delete.go
@@ -56,7 +56,8 @@ type SnapshotDeleteRequest struct {
 	Repository string
 	Snapshot   string
 
-	MasterTimeout time.Duration
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -91,6 +92,10 @@ func (r SnapshotDeleteRequest) Do(ctx context.Context, transport Transport) (*Re
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Pretty {
@@ -160,11 +165,21 @@ func (f SnapshotDelete) WithContext(v context.Context) func(*SnapshotDeleteReque
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f SnapshotDelete) WithMasterTimeout(v time.Duration) func(*SnapshotDeleteRequest) {
 	return func(r *SnapshotDeleteRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f SnapshotDelete) WithClusterManagerTimeout(v time.Duration) func(*SnapshotDeleteRequest) {
+	return func(r *SnapshotDeleteRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.snapshot.delete_repository.go
+++ b/opensearchapi/api.snapshot.delete_repository.go
@@ -55,8 +55,9 @@ type SnapshotDeleteRepository func(repository []string, o ...func(*SnapshotDelet
 type SnapshotDeleteRepositoryRequest struct {
 	Repository []string
 
-	MasterTimeout time.Duration
-	Timeout       time.Duration
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -89,6 +90,10 @@ func (r SnapshotDeleteRepositoryRequest) Do(ctx context.Context, transport Trans
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -162,11 +167,21 @@ func (f SnapshotDeleteRepository) WithContext(v context.Context) func(*SnapshotD
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f SnapshotDeleteRepository) WithMasterTimeout(v time.Duration) func(*SnapshotDeleteRepositoryRequest) {
 	return func(r *SnapshotDeleteRepositoryRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f SnapshotDeleteRepository) WithClusterManagerTimeout(v time.Duration) func(*SnapshotDeleteRepositoryRequest) {
+	return func(r *SnapshotDeleteRepositoryRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.snapshot.get.go
+++ b/opensearchapi/api.snapshot.get.go
@@ -57,11 +57,12 @@ type SnapshotGetRequest struct {
 	Repository string
 	Snapshot   []string
 
-	IgnoreUnavailable *bool
-	IncludeRepository *bool
-	IndexDetails      *bool
-	MasterTimeout     time.Duration
-	Verbose           *bool
+	IgnoreUnavailable     *bool
+	IncludeRepository     *bool
+	IndexDetails          *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Verbose               *bool
 
 	Pretty     bool
 	Human      bool
@@ -108,6 +109,10 @@ func (r SnapshotGetRequest) Do(ctx context.Context, transport Transport) (*Respo
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Verbose != nil {
@@ -205,11 +210,21 @@ func (f SnapshotGet) WithIndexDetails(v bool) func(*SnapshotGetRequest) {
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f SnapshotGet) WithMasterTimeout(v time.Duration) func(*SnapshotGetRequest) {
 	return func(r *SnapshotGetRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f SnapshotGet) WithClusterManagerTimeout(v time.Duration) func(*SnapshotGetRequest) {
+	return func(r *SnapshotGetRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.snapshot.get_repository.go
+++ b/opensearchapi/api.snapshot.get_repository.go
@@ -173,7 +173,7 @@ func (f SnapshotGetRepository) WithRepository(v ...string) func(*SnapshotGetRepo
 	}
 }
 
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
+// WithLocal - return local information, do not retrieve the state from cluster-manager node (default: false).
 //
 func (f SnapshotGetRepository) WithLocal(v bool) func(*SnapshotGetRepositoryRequest) {
 	return func(r *SnapshotGetRepositoryRequest) {

--- a/opensearchapi/api.snapshot.get_repository.go
+++ b/opensearchapi/api.snapshot.get_repository.go
@@ -56,8 +56,9 @@ type SnapshotGetRepository func(o ...func(*SnapshotGetRepositoryRequest)) (*Resp
 type SnapshotGetRepositoryRequest struct {
 	Repository []string
 
-	Local         *bool
-	MasterTimeout time.Duration
+	Local                 *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -96,6 +97,10 @@ func (r SnapshotGetRepositoryRequest) Do(ctx context.Context, transport Transpor
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Pretty {
@@ -181,11 +186,21 @@ func (f SnapshotGetRepository) WithLocal(v bool) func(*SnapshotGetRepositoryRequ
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f SnapshotGetRepository) WithMasterTimeout(v time.Duration) func(*SnapshotGetRepositoryRequest) {
 	return func(r *SnapshotGetRepositoryRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f SnapshotGetRepository) WithClusterManagerTimeout(v time.Duration) func(*SnapshotGetRepositoryRequest) {
+	return func(r *SnapshotGetRepositoryRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.snapshot.restore.go
+++ b/opensearchapi/api.snapshot.restore.go
@@ -60,8 +60,9 @@ type SnapshotRestoreRequest struct {
 	Repository string
 	Snapshot   string
 
-	MasterTimeout     time.Duration
-	WaitForCompletion *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	WaitForCompletion     *bool
 
 	Pretty     bool
 	Human      bool
@@ -98,6 +99,10 @@ func (r SnapshotRestoreRequest) Do(ctx context.Context, transport Transport) (*R
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.WaitForCompletion != nil {
@@ -183,11 +188,21 @@ func (f SnapshotRestore) WithBody(v io.Reader) func(*SnapshotRestoreRequest) {
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f SnapshotRestore) WithMasterTimeout(v time.Duration) func(*SnapshotRestoreRequest) {
 	return func(r *SnapshotRestoreRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f SnapshotRestore) WithClusterManagerTimeout(v time.Duration) func(*SnapshotRestoreRequest) {
+	return func(r *SnapshotRestoreRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.snapshot.status.go
+++ b/opensearchapi/api.snapshot.status.go
@@ -57,8 +57,9 @@ type SnapshotStatusRequest struct {
 	Repository string
 	Snapshot   []string
 
-	IgnoreUnavailable *bool
-	MasterTimeout     time.Duration
+	IgnoreUnavailable     *bool
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -103,6 +104,10 @@ func (r SnapshotStatusRequest) Do(ctx context.Context, transport Transport) (*Re
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Pretty {
@@ -196,11 +201,21 @@ func (f SnapshotStatus) WithIgnoreUnavailable(v bool) func(*SnapshotStatusReques
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f SnapshotStatus) WithMasterTimeout(v time.Duration) func(*SnapshotStatusRequest) {
 	return func(r *SnapshotStatusRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f SnapshotStatus) WithClusterManagerTimeout(v time.Duration) func(*SnapshotStatusRequest) {
+	return func(r *SnapshotStatusRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchapi/api.snapshot.verify_repository.go
+++ b/opensearchapi/api.snapshot.verify_repository.go
@@ -55,8 +55,9 @@ type SnapshotVerifyRepository func(repository string, o ...func(*SnapshotVerifyR
 type SnapshotVerifyRepositoryRequest struct {
 	Repository string
 
-	MasterTimeout time.Duration
-	Timeout       time.Duration
+	MasterTimeout         time.Duration
+	ClusterManagerTimeout time.Duration
+	Timeout               time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -91,6 +92,10 @@ func (r SnapshotVerifyRepositoryRequest) Do(ctx context.Context, transport Trans
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.ClusterManagerTimeout != 0 {
+		params["cluster_manager_timeout"] = formatDuration(r.ClusterManagerTimeout)
 	}
 
 	if r.Timeout != 0 {
@@ -164,11 +169,21 @@ func (f SnapshotVerifyRepository) WithContext(v context.Context) func(*SnapshotV
 	}
 }
 
-// WithMasterTimeout - explicit operation timeout for connection to master node.
+// WithMasterTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+// Deprecated: To promote inclusive language, use WithClusterManagerTimeout instead.
 //
 func (f SnapshotVerifyRepository) WithMasterTimeout(v time.Duration) func(*SnapshotVerifyRepositoryRequest) {
 	return func(r *SnapshotVerifyRepositoryRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithClusterManagerTimeout - explicit operation timeout for connection to cluster-manager node.
+//
+func (f SnapshotVerifyRepository) WithClusterManagerTimeout(v time.Duration) func(*SnapshotVerifyRepositoryRequest) {
+	return func(r *SnapshotVerifyRepositoryRequest) {
+		r.ClusterManagerTimeout = v
 	}
 }
 

--- a/opensearchtransport/discovery.go
+++ b/opensearchtransport/discovery.go
@@ -72,27 +72,27 @@ func (c *Client) DiscoverNodes() error {
 
 	for _, node := range nodes {
 		var (
-			isMasterOnlyNode bool
+			isClusterManagerOnlyNode bool
 		)
 
 		roles := append(node.Roles[:0:0], node.Roles...)
 		sort.Strings(roles)
 
-		if len(roles) == 1 && roles[0] == "master" {
-			isMasterOnlyNode = true
+		if len(roles) == 1 && (roles[0] == "master" || roles[0] == "cluster_manager") {
+			isClusterManagerOnlyNode = true
 		}
 
 		if debugLogger != nil {
 			var skip string
-			if isMasterOnlyNode {
+			if isClusterManagerOnlyNode {
 				skip = "; [SKIP]"
 			}
 			debugLogger.Logf("Discovered node [%s]; %s; roles=%s%s\n", node.Name, node.URL, node.Roles, skip)
 		}
 
-		// Skip master only nodes
+		// Skip cluster_manager only nodes
 		// TODO: Move logic to Selector?
-		if isMasterOnlyNode {
+		if isClusterManagerOnlyNode {
 			continue
 		}
 

--- a/opensearchtransport/discovery_internal_test.go
+++ b/opensearchtransport/discovery_internal_test.go
@@ -232,6 +232,138 @@ func TestDiscovery(t *testing.T) {
 								"data_hot",
 								"data_warm",
 								"ingest",
+								"cluster_manager",
+								"ml",
+								"remote_cluster_client",
+								"transform",
+							},
+						},
+						"es2": {
+							URL: "http://es2:9200",
+							Roles: []string{
+								"data",
+								"data_cold",
+								"data_content",
+								"data_frozen",
+								"data_hot",
+								"data_warm",
+								"ingest",
+								"cluster_manager",
+								"ml",
+								"remote_cluster_client",
+								"transform",
+							},
+						},
+						"es3": {
+							URL: "http://es3:9200",
+							Roles: []string{
+								"data",
+								"data_cold",
+								"data_content",
+								"data_frozen",
+								"data_hot",
+								"data_warm",
+								"ingest",
+								"cluster_manager",
+								"ml",
+								"remote_cluster_client",
+								"transform",
+							},
+						},
+					},
+				},
+				wants{
+					false, 3,
+				},
+			},
+			{
+				"Cluster manager only node should not be selected",
+				fields{
+					Nodes: map[string]Node{
+						"es1": {
+							URL: "http://es1:9200",
+							Roles: []string{
+								"cluster_manager",
+							},
+						},
+						"es2": {
+							URL: "http://es2:9200",
+							Roles: []string{
+								"data",
+								"data_cold",
+								"data_content",
+								"data_frozen",
+								"data_hot",
+								"data_warm",
+								"ingest",
+								"cluster_manager",
+								"ml",
+								"remote_cluster_client",
+								"transform",
+							},
+						},
+						"es3": {
+							URL: "http://es3:9200",
+							Roles: []string{
+								"data",
+								"data_cold",
+								"data_content",
+								"data_frozen",
+								"data_hot",
+								"data_warm",
+								"ingest",
+								"cluster_manager",
+								"ml",
+								"remote_cluster_client",
+								"transform",
+							},
+						},
+					},
+				},
+
+				wants{
+					false, 2,
+				},
+			},
+			{
+				"Cluster manager and data only nodes should be selected",
+				fields{
+					Nodes: map[string]Node{
+						"es1": {
+							URL: "http://es1:9200",
+							Roles: []string{
+								"data",
+								"cluster_manager",
+							},
+						},
+						"es2": {
+							URL: "http://es2:9200",
+							Roles: []string{
+								"data",
+								"cluster_manager",
+							},
+						},
+					},
+				},
+
+				wants{
+					false, 2,
+				},
+			},
+			{
+				"Default roles should allow every node to be selected",
+				fields{
+					Nodes: map[string]Node{
+						"es1": {
+							URL: "http://es1:9200",
+							Roles: []string{
+								"data",
+								"data_cold",
+								"data_content",
+								"data_frozen",
+								"data_hot",
+								"data_warm",
+								"ingest",
 								"master",
 								"ml",
 								"remote_cluster_client",

--- a/opensearchtransport/testdata/nodes.info.json
+++ b/opensearchtransport/testdata/nodes.info.json
@@ -15,7 +15,7 @@
       "build_flavor": "oss",
       "build_type": "tar",
       "build_hash": "2f90bbf7b93631e52bafb59b3b049cb44ec25e96",
-      "roles": ["ingest", "master", "data"],
+      "roles": ["ingest", "cluster_manager", "data"],
       "http": {
         "bound_address": [
           "[::1]:10001",
@@ -34,7 +34,7 @@
       "build_flavor": "oss",
       "build_type": "tar",
       "build_hash": "2f90bbf7b93631e52bafb59b3b049cb44ec25e96",
-      "roles": ["ingest", "master", "data"],
+      "roles": ["ingest", "cluster_manager", "data"],
       "http": {
         "bound_address": [
           "127.0.0.1:10002",
@@ -54,7 +54,7 @@
       "build_flavor": "oss",
       "build_type": "tar",
       "build_hash": "2f90bbf7b93631e52bafb59b3b049cb44ec25e96",
-      "roles": ["master"],
+      "roles": ["cluster_manager"],
       "http": {
         "bound_address": [
           "[::1]:10003",


### PR DESCRIPTION
### Description
- Adds the `cluster_manager_timeout` parameter, deprecating `master_timeout`
- Adds the `/_cat/cluster_manager` endpoint, deprecating `/_cat/master`
- Correctly handle the `cluster_manager` node role in the discovery logic
- Updates the documentation of the `WithLocal` methods to use cluster-manager terminology.

### Issues Resolved
Resolves #121 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
