### PR TITLE
Replaced if_seq_num to if_seq_no

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+ - Renamed the sequence number struct tag to if_seq_no to fix optimistic concurrency control ([#166](https://github.com/opensearch-project/opensearch-go/pull/166))
 
 ### Security
 

--- a/opensearchutil/bulk_indexer.go
+++ b/opensearchutil/bulk_indexer.go
@@ -133,7 +133,7 @@ type bulkActionMetadata struct {
 	Routing             *string     `json:"routing,omitempty"`
 	Version             *int64      `json:"version,omitempty"`
 	VersionType         *string     `json:"version_type,omitempty"`
-	IfSeqNum            *int64      `json:"if_seq_num,omitempty"`
+	IfSeqNum            *int64      `json:"if_seq_no,omitempty"`
 	IfPrimaryTerm       *int64      `json:"if_primary_term,omitempty"`
 	WaitForActiveShards interface{} `json:"wait_for_active_shards,omitempty"`
 	Refresh             *string     `json:"refresh,omitempty"`

--- a/opensearchutil/bulk_indexer_internal_test.go
+++ b/opensearchutil/bulk_indexer_internal_test.go
@@ -678,7 +678,18 @@ func TestBulkIndexer(t *testing.T) {
 				`{"index":{"_index":"test","_id":"42"}}` + "\n",
 			},
 			{
-				"with version and no document",
+				"with if_seq_no and if_primary_term",
+				args{BulkIndexerItem{
+					Action:        "index",
+					DocumentID:    "42",
+					Index:         "test",
+					IfSeqNum:      int64Pointer(5),
+					IfPrimaryTerm: int64Pointer(1),
+				}},
+				`{"index":{"_index":"test","_id":"42","if_seq_no":5,"if_primary_term":1}}` + "\n",
+			},
+			{
+				"with version and no document, if_seq_no, and if_primary_term",
 				args{BulkIndexerItem{
 					Action:  "index",
 					Index:   "test",


### PR DESCRIPTION
Signed-off by: Kyle Darryl Aguilar <aguilarkyledarryl@gmail.com>

### Description
Renamed the sequence number struct tag to resolve issues when performing optimistic concurrency control

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-go/issues/165

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
