### PR TITLE
Ensure Dependabot PR workflow retriggers on label change

### DIFF
--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -1,5 +1,12 @@
 name: Dependabot PR actions
-on: pull_request
+on: 
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
 
 jobs:
   dependabot:
@@ -18,7 +25,7 @@ jobs:
           installation_id: 22958780
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ steps.github_app_token.outputs.token }}
 


### PR DESCRIPTION
### Description
Solves a race condition when PR is created but not yet labeled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
