### PR TITLE
bugfix: adjusts to use retry_on_conflict on bulk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
  - Renamed the sequence number struct tag to if_seq_no to fix optimistic concurrency control ([#166](https://github.com/opensearch-project/opensearch-go/pull/166))
+ - Fix `RetryOnConflict` on bulk indexer ([#215](https://github.com/opensearch-project/opensearch-go/pull/215))
 
 ### Security
 

--- a/opensearchutil/bulk_indexer.go
+++ b/opensearchutil/bulk_indexer.go
@@ -138,6 +138,7 @@ type bulkActionMetadata struct {
 	WaitForActiveShards interface{} `json:"wait_for_active_shards,omitempty"`
 	Refresh             *string     `json:"refresh,omitempty"`
 	RequireAlias        *bool       `json:"require_alias,omitempty"`
+	RetryOnConflict     *int        `json:"retry_on_conflict,omitempty"`
 }
 
 // BulkIndexerResponse represents the OpenSearch response.
@@ -447,6 +448,7 @@ func (w *worker) writeMeta(item BulkIndexerItem) error {
 		WaitForActiveShards: item.WaitForActiveShards,
 		Refresh:             item.Refresh,
 		RequireAlias:        item.RequireAlias,
+		RetryOnConflict:     item.RetryOnConflict,
 	}
 	// Can not specify version or seq num if no document ID is passed
 	if meta.DocumentID == "" {

--- a/opensearchutil/bulk_indexer_internal_test.go
+++ b/opensearchutil/bulk_indexer_internal_test.go
@@ -742,6 +742,18 @@ func TestBulkIndexer(t *testing.T) {
 				}},
 				`{"index":{"_index":"test","_id":"42","version":25,"version_type":"external","wait_for_active_shards":"all"}}` + "\n",
 			},
+			{
+				"with retry_on_conflict",
+				args{BulkIndexerItem{
+					Action:          "index",
+					DocumentID:      "42",
+					Index:           "test",
+					Version:         int64Pointer(25),
+					VersionType:     strPointer("external"),
+					RetryOnConflict: intPointer(5),
+				}},
+				`{"index":{"_index":"test","_id":"42","version":25,"version_type":"external","retry_on_conflict":5}}` + "\n",
+			},
 		}
 		for _, tt := range tests {
 			tt := tt
@@ -775,5 +787,9 @@ func strPointer(s string) *string {
 }
 
 func int64Pointer(i int64) *int64 {
+	return &i
+}
+
+func intPointer(i int) *int {
 	return &i
 }


### PR DESCRIPTION
### Description

Bug fix.

Adjust to set `retry_on_conflict` when using bulk indexer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
