### PR TITLE
Add and update maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the team set up in https://github.com/orgs/opensearch-project/teams and include any additional contributors
-*   @opensearch-project/clients @svencowart @robcowart
+*   @dblock @VijayanB @svencowart @VachaShah

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,14 +6,15 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 | Maintainer              | GitHub ID                                   | Affiliation |
 | ----------------------- | ------------------------------------------- | ----------- |
-| Jack Mazanec            | [jmazanec15](https://github.com/jmazanec15) | Amazon      |
-| Vamshi Vijay Nakkirtha  | [vamshin](https://github.com/vamshin)       | Amazon      |
+| Daniel Doubrovkine      | [dblock](https://github.com/dblock)         | Amazon      |
 | Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)     | Amazon      |
 | Sven Cowart             | [svencowart](https://github.com/svencowart) |             |
 | Vacha Shah              | [VachaShah](https://github.com/VachaShah)   | Amazon      |
 
 ## Emeritus
 
-| Maintainer | GitHub ID                                 | Affiliation |
-| ---------- | ----------------------------------------- | ----------- |
-| Rob Cowart | [robcowart](https://github.com/robcowart) | ElastiFlow  |
+| Maintainer              | GitHub ID                                   | Affiliation |
+| ----------------------- | ------------------------------------------- | ----------- |
+| Jack Mazanec            | [jmazanec15](https://github.com/jmazanec15) | Amazon      |
+| Vamshi Vijay Nakkirtha  | [vamshin](https://github.com/vamshin)       | Amazon      |
+| Rob Cowart              | [robcowart](https://github.com/robcowart)   | ElastiFlow  |


### PR DESCRIPTION
### Description
Adding @dblock to maintainers. Moving @jmazanec15 and @vamshin to Emeritus. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
