### PR TITLE
Removing info call before performing requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 
 ### Removed
+- Remove info call before performing every request ([#]())
 
 ### Fixed
  - Renamed the sequence number struct tag to if_seq_no to fix optimistic concurrency control ([#166](https://github.com/opensearch-project/opensearch-go/pull/166))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 
 ### Removed
-- Remove info call before performing every request ([#]())
+- Remove info call before performing every request ([#219](https://github.com/opensearch-project/opensearch-go/pull/219))
 
 ### Fixed
  - Renamed the sequence number struct tag to if_seq_no to fix optimistic concurrency control ([#166](https://github.com/opensearch-project/opensearch-go/pull/166))

--- a/internal/build/go.mod
+++ b/internal/build/go.mod
@@ -7,7 +7,7 @@ replace github.com/opensearch-project/opensearch-go/v2 => ../../
 require (
 	github.com/alecthomas/chroma v0.8.2
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/opensearch-project/opensearch-go/v2 v2.1.0
+	github.com/opensearch-project/opensearch-go/v2 v2.2.0
 	github.com/spf13/cobra v1.6.1
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	golang.org/x/tools v0.1.12

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -28,4 +28,4 @@ package version
 
 // Client returns the client version as a string.
 //
-const Client = "2.1.0"
+const Client = "2.2.0"

--- a/opensearchapi/test/go.mod
+++ b/opensearchapi/test/go.mod
@@ -5,7 +5,7 @@ go 1.11
 replace github.com/opensearch-project/opensearch-go/v2 => ../../
 
 require (
-	github.com/opensearch-project/opensearch-go/v2 v2.1.0
+	github.com/opensearch-project/opensearch-go/v2 v2.2.0
 
 	gopkg.in/yaml.v2 v2.4.0
 )


### PR DESCRIPTION
### Description
Removing the version check before performing every request.
Also increments to next version.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-go/pull/216#pullrequestreview-1262798295

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
