### PR TITLE
opensearchapi: Fix handling of errors without error response body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Adds InfoResp type ([#253](https://github.com/opensearch-project/opensearch-go/pull/253))
 - Adds markdown linter ([#261](https://github.com/opensearch-project/opensearch-go/pull/261))
 - Adds testcases to check upsert functionality ([#207](https://github.com/opensearch-project/opensearch-go/issues/207))
-- Added @Jakob3xD to co-maintainers ([#270](https://github.com/opensearch-project/opensearch-go/pull/270))
+- Adds @Jakob3xD to co-maintainers ([#270](https://github.com/opensearch-project/opensearch-go/pull/270))
 
 ### Changed
 
@@ -42,6 +42,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Renames the sequence number struct tag to `if_seq_no` to fix optimistic concurrency control ([#166](https://github.com/opensearch-project/opensearch-go/pull/166))
 - Fixes `RetryOnConflict` on bulk indexer ([#215](https://github.com/opensearch-project/opensearch-go/pull/215))
 - Corrects curl logging to emit the correct URL destination ([#101](https://github.com/opensearch-project/opensearch-go/pull/101))
+- Corrects handling of errors without an error response body ([#286](https://github.com/opensearch-project/opensearch-go/pull/286))
 
 ### Security
 

--- a/opensearchapi/opensearchapi.error.go
+++ b/opensearchapi/opensearchapi.error.go
@@ -49,5 +49,5 @@ type RootCause struct {
 
 // Error returns a string.
 func (e *Error) Error() string {
-	return fmt.Sprintf("error: %s, status: %d", e.Err, e.Status)
+	return fmt.Sprintf("status: %d, type: %s, reason: %s, root_cause: %s", e.Status, e.Err.Type, e.Err.Reason, e.Err.RootCause)
 }

--- a/opensearchapi/opensearchapi.response.go
+++ b/opensearchapi/opensearchapi.response.go
@@ -33,6 +33,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 	"strconv"
 	"strings"
 )
@@ -120,7 +121,7 @@ func (r *Response) Err() error {
 		}
 		var e *Error
 		err = json.Unmarshal(body, &e)
-		if err == nil {
+		if err == nil && !reflect.ValueOf(e.Err).IsZero() {
 			return e
 		}
 		return fmt.Errorf("status: %d, error: %s", r.StatusCode, string(body))


### PR DESCRIPTION
### Description
- Check if parsed error is empty
- Improve error string output
- Adds test for errors without an error response body

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-go/issues/281

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
