### PR TITLE
Add prettier formatting to dependabot prs

### DIFF
--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -33,6 +33,9 @@ jobs:
         uses: dangoslen/dependabot-changelog-helper@v2
         with:
           version: 'Unreleased'
+      
+      - name: Format markdown files with prettier
+        run: prettier --prose-wrap never --write **/*.md
 
       - name: Commit the changes
         uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
### Description
Dependabot PRs add a Changelog line which fails the recent prettier check. See https://github.com/opensearch-project/opensearch-go/actions/runs/4662363358/jobs/8252624135?pr=294

This PR adds a prettier formatting in the dependabot PR workflow.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
