### PR TITLE
[Feature] Add healthcheck to docker container

### DIFF
--- a/.ci/opensearch/Dockerfile.opensearch
+++ b/.ci/opensearch/Dockerfile.opensearch
@@ -3,5 +3,11 @@ FROM opensearchproject/opensearch:${OPENSEARCH_VERSION}
 
 ARG opensearch_path=/usr/share/opensearch
 ARG SECURE_INTEGRATION
+ENV SECURE_INTEGRATION=$SECURE_INTEGRATION
 
 RUN if [ "$SECURE_INTEGRATION" != "true" ] ; then $opensearch_path/bin/opensearch-plugin remove opensearch-security; fi
+
+HEALTHCHECK --start-period=20s --interval=30s \
+  CMD curl -sf -retry 5 --max-time 5 --retry-delay 5 --retry-max-time 30 \
+  $(if $SECURE_INTEGRATION; then echo "-u admin:admin -k https://"; fi)"localhost:9200" \
+  || bash -c 'kill -s 15 -1 && (sleep 10; kill -s 9 -1)'

--- a/.ci/opensearch/docker-compose.yml
+++ b/.ci/opensearch/docker-compose.yml
@@ -1,8 +1,10 @@
 version: '3'
 
 services:
-
   opensearch:
+    deploy:
+      restart_policy:
+        condition: any
     build:
       context: .
       dockerfile: Dockerfile.opensearch

--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -40,6 +40,9 @@ jobs:
           export OPENSEARCH_VERSION=${{ matrix.entry.opensearch_version }}
           export SECURE_INTEGRATION=${{ matrix.secured }}
           make cluster.clean cluster.build cluster.start
+          for attempt in `seq 25`; do sleep 5; \
+          if curl -s $(if $SECURE_INTEGRATION; then echo "-ku admin:admin https://"; fi)localhost:9200; \
+          then echo '=====> ready'; break; fi; if [ $attempt == 25 ]; then exit 1; fi; echo '=====> waiting...'; done
 
       - name: Integration test without security
         if: ${{ matrix.secured == 'false'}}

--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -40,9 +40,6 @@ jobs:
           export OPENSEARCH_VERSION=${{ matrix.entry.opensearch_version }}
           export SECURE_INTEGRATION=${{ matrix.secured }}
           make cluster.clean cluster.build cluster.start
-      - name: Check Opensearch cluster health
-        run: |
-          make cluster.check SECURE_INTEGRATION=${{ matrix.secured }} NUM_CHECKS=30 CHECK_INTERVAL=1
 
       - name: Integration test without security
         if: ${{ matrix.secured == 'false'}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Adds `advanced_index_actions` guide ([#288](https://github.com/opensearch-project/opensearch-go/pull/288))
 - Adds testcases to check UpdateByQuery functionality ([#304](https://github.com/opensearch-project/opensearch-go/pull/304))
 - Adds additional timeout after cluster start ([##303](https://github.com/opensearch-project/opensearch-go/pull/303))
+- Adds docker healthcheck to auto restart the container ([#315](https://github.com/opensearch-project/opensearch-go/pull/315))
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,6 @@ cluster.build:
 
 cluster.start:
 	docker-compose --project-directory .ci/opensearch up -d ;
-	sleep 20;
 
 cluster.stop:
 	docker-compose --project-directory .ci/opensearch down ;


### PR DESCRIPTION
### Description
- Add a healthcheck to the docker container that kills it self, forcing it to restart the container
- Add a bash for loop to wait for the cluster to be ready

### Issues Resolved
 Closes #296 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
