### PR TITLE
Bump client version to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,25 +6,22 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Dependencies
 
-- Bumps `github.com/aws/aws-sdk-go` from 1.44.45 to 1.44.263
-- Bumps `github.com/aws/aws-sdk-go-v2` from 1.17.1 to 1.18.0
+- Bumps `github.com/aws/aws-sdk-go` from 1.44.180 to 1.44.263
+- Bumps `github.com/aws/aws-sdk-go-v2` from 1.17.4 to 1.18.0
 - Bumps `github.com/aws/aws-sdk-go-v2/config` from 1.18.8 to 1.18.25
-- Bumps `github.com/stretchr/testify` from 1.8.0 to 1.8.2
+- Bumps `github.com/stretchr/testify` from 1.8.1 to 1.8.2
 
 ### Added
 
-- Adds support for Amazon OpenSearch Serverless ([#216](https://github.com/opensearch-project/opensearch-go/pull/216), [#259](https://github.com/opensearch-project/opensearch-go/pull/259))
-- Adds Github workflow for changelog verification ([#172](https://github.com/opensearch-project/opensearch-go/pull/172))
-- Adds Go Documentation link for the client ([#182](https://github.com/opensearch-project/opensearch-go/pull/182))
-- Adds implementation of Data Streams API ([#257](https://github.com/opensearch-project/opensearch-go/pull/257)
+- Adds implementation of Data Streams API ([#257](https://github.com/opensearch-project/opensearch-go/pull/257))
 - Adds `Err()` function to Response for detailed errors ([#246](https://github.com/opensearch-project/opensearch-go/pull/246))
 - Adds Point In Time API ([#253](https://github.com/opensearch-project/opensearch-go/pull/253))
 - Adds InfoResp type ([#253](https://github.com/opensearch-project/opensearch-go/pull/253))
 - Adds markdown linter ([#261](https://github.com/opensearch-project/opensearch-go/pull/261))
-- Adds testcases to check upsert functionality ([#207](https://github.com/opensearch-project/opensearch-go/issues/207))
+- Adds testcases to check upsert functionality ([#269](https://github.com/opensearch-project/opensearch-go/pull/269))
 - Adds @Jakob3xD to co-maintainers ([#270](https://github.com/opensearch-project/opensearch-go/pull/270))
-- Adds dynamic type to \_source field ([#158](https://github.com/opensearch-project/opensearch-go/issues/158))
-- Adds testcases for Document API ([#280](https://github.com/opensearch-project/opensearch-go/issues/280))
+- Adds dynamic type to \_source field ([#285](https://github.com/opensearch-project/opensearch-go/pull/285))
+- Adds testcases for Document API ([#285](https://github.com/opensearch-project/opensearch-go/pull/285))
 - Adds `index_lifecycle` guide ([#287](https://github.com/opensearch-project/opensearch-go/pull/287))
 - Adds `bulk` guide ([#292](https://github.com/opensearch-project/opensearch-go/pull/292))
 - Adds `search` guide ([#291](https://github.com/opensearch-project/opensearch-go/pull/291))
@@ -32,7 +29,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Adds `index_template` guide ([#289](https://github.com/opensearch-project/opensearch-go/pull/289))
 - Adds `advanced_index_actions` guide ([#288](https://github.com/opensearch-project/opensearch-go/pull/288))
 - Adds testcases to check UpdateByQuery functionality ([#304](https://github.com/opensearch-project/opensearch-go/pull/304))
-- Adds additional timeout after cluster start ([##303](https://github.com/opensearch-project/opensearch-go/pull/303))
+- Adds additional timeout after cluster start ([#303](https://github.com/opensearch-project/opensearch-go/pull/303))
 - Adds docker healthcheck to auto restart the container ([#315](https://github.com/opensearch-project/opensearch-go/pull/315))
 
 ### Changed
@@ -47,15 +44,11 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Removed
 
-- Removes info call before performing every request ([#219](https://github.com/opensearch-project/opensearch-go/pull/219))
-
 ### Fixed
 
-- Renames the sequence number struct tag to `if_seq_no` to fix optimistic concurrency control ([#166](https://github.com/opensearch-project/opensearch-go/pull/166))
-- Fixes `RetryOnConflict` on bulk indexer ([#215](https://github.com/opensearch-project/opensearch-go/pull/215))
 - Corrects curl logging to emit the correct URL destination ([#101](https://github.com/opensearch-project/opensearch-go/pull/101))
 - Corrects handling of errors without an error response body ([#286](https://github.com/opensearch-project/opensearch-go/pull/286))
 
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/opensearch-go/compare/2.1...HEAD
+[Unreleased]: https://github.com/opensearch-project/opensearch-go/compare/v2.2.0...HEAD

--- a/internal/build/go.mod
+++ b/internal/build/go.mod
@@ -7,7 +7,7 @@ replace github.com/opensearch-project/opensearch-go/v2 => ../../
 require (
 	github.com/alecthomas/chroma v0.8.2
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/opensearch-project/opensearch-go/v2 v2.2.0
+	github.com/opensearch-project/opensearch-go/v2 v2.3.0
 	github.com/spf13/cobra v1.6.1
 	golang.org/x/crypto v0.1.0
 	golang.org/x/tools v0.1.12

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -28,4 +28,4 @@ package version
 
 // Client returns the client version as a string.
 //
-const Client = "2.2.0"
+const Client = "2.3.0"

--- a/opensearchapi/test/go.mod
+++ b/opensearchapi/test/go.mod
@@ -5,7 +5,7 @@ go 1.11
 replace github.com/opensearch-project/opensearch-go/v2 => ../../
 
 require (
-	github.com/opensearch-project/opensearch-go/v2 v2.2.0
+	github.com/opensearch-project/opensearch-go/v2 v2.3.0
 
 	gopkg.in/yaml.v2 v2.4.0
 )


### PR DESCRIPTION
### Description
* Bumps client version to 2.3.0.
* Cleaning up changelog.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
