### PR TITLE
Adding warning for upcoming major version upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ OpenSearch Go Client
 - [License](#license)
 - [Copyright](#copyright)
 
+> **Warning**
+> 
+> `2.3.0` is the last minor version for the 2.x line for the OpenSearch Go client. All new features will now be added to the upcoming major version 3.0.0 being developed in the [`main`](https://github.com/opensearch-project/opensearch-go) branch of this client. To upgrade to the next major version,see [UPGRADING](https://github.com/opensearch-project/opensearch-go/blob/main/UPGRADING.md). The 2.3.x line will be managed and supported for security fixes.
+
 ## Welcome!
 
 **opensearch-go** is [a community-driven, open source fork](https://aws.amazon.com/blogs/opensource/introducing-opensearch/) of go-elasticsearch licensed under the [Apache v2.0 License](LICENSE.txt). For more information, see [opensearch.org](https://opensearch.org/).


### PR DESCRIPTION
### Description
Coming from https://github.com/opensearch-project/opensearch-go/pull/322#issuecomment-1556211279, adding a warning for 2.3.0  being the last version of the 2.x line and moving to 3.0.0.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
