### PR TITLE
Add an introduction to utility function NewJSONReader in USER_GUIDE

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -86,13 +86,13 @@ func example() error {
 
 	// When using a structure, the conversion process to io.Reader can be omitted using utility functions.
 	document := struct {
-	    Title    string `json:"title"`
-        Director string `json:"director"`
-        Year     string `json:"year"`
-    }{
-        Title:    "Moneyball",
-        Director: "Bennett Miller",
-        Year:     "2011",
+		Title    string `json:"title"`
+		Director string `json:"director"`
+		Year     string `json:"year"`
+	}{
+		Title:    "Moneyball",
+		Director: "Bennett Miller",
+		Year:     "2011",
 	}
 
 	docId := "1"

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -25,6 +25,7 @@ import (
 
 	opensearch "github.com/opensearch-project/opensearch-go/v2"
 	opensearchapi "github.com/opensearch-project/opensearch-go/v2/opensearchapi"
+	opensearchutil "github.com/opensearch-project/opensearch-go/v2/opensearchutil"
 )
 
 const IndexName = "go-test-index1"
@@ -83,18 +84,22 @@ func example() error {
 	}
 	fmt.Println(createIndexResponse)
 
-	// Add a document to the index.
-	document := strings.NewReader(`{
-	    "title": "Moneyball",
-	    "director": "Bennett Miller",
-	    "year": "2011"
-	}`)
+	// When using a structure, the conversion process to io.Reader can be omitted using utility functions.
+	document := struct {
+	    Title    string `json:"title"`
+        Director string `json:"director"`
+        Year     string `json:"year"`
+    }{
+        Title:    "Moneyball",
+        Director: "Bennett Miller",
+        Year:     "2011",
+	}
 
 	docId := "1"
 	req := opensearchapi.IndexRequest{
 		Index:      IndexName,
 		DocumentID: docId,
-		Body:       document,
+		Body:       opensearchutil.NewJSONReader(&document),
 	}
 	insertResponse, err := req.Do(ctx, client)
 	if err != nil {


### PR DESCRIPTION
### Description

There is a common case where a structure is used in the Body of an API request, which requires conversion to io.Reader. There is a useful utility function available for this use case, but it is not often noticed, so it is included in the user guide.

ref. https://github.com/opensearch-project/opensearch-go/issues/331#issuecomment-1608111897

### Issues Resolved

There is no Issue to be resolved, but the related Issue is https://github.com/opensearch-project/opensearch-go/issues/331

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
