### PR TITLE
Add opensearch 2.6.0, 2.7.0, 2.8.0 to compatibility test

### DIFF
--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -19,6 +19,9 @@ jobs:
           - { opensearch_version: 2.3.0 }
           - { opensearch_version: 2.4.1 }
           - { opensearch_version: 2.5.0 }
+          - { opensearch_version: 2.6.0 }
+          - { opensearch_version: 2.7.0 }
+          - { opensearch_version: 2.8.0 }
     steps:
       - uses: actions/checkout@v3
         with: { fetch-depth: 1 }


### PR DESCRIPTION
### Description
Add opensearch 2.6.0, 2.7.0, 2.8.0 to compatibility test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
