### PR TITLE
golangci-lint: Solve Complains for opensearchtransport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Moved @svencowart to emeritus maintainers ([#270](https://github.com/opensearch-project/opensearch-go/pull/270))
 - Read, close and replace the http Reponse Body ([#300](https://github.com/opensearch-project/opensearch-go/pull/300))
 - Updated and adjusted golangci-lint, solve linting complains for signer ([#352](https://github.com/opensearch-project/opensearch-go/pull/352))
+- Solve linting complains for opensearchtransport ([#353](https://github.com/opensearch-project/opensearch-go/pull/353))
 
 ### Deprecated
 

--- a/opensearchtransport/connection_integration_test.go
+++ b/opensearchtransport/connection_integration_test.go
@@ -24,7 +24,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build integration
+//go:build integration
 
 package opensearchtransport
 
@@ -42,9 +42,6 @@ func NewServer(addr string, handler http.Handler) *http.Server {
 }
 
 func TestStatusConnectionPool(t *testing.T) {
-	defaultResurrectTimeoutInitial = time.Second
-	defer func() { defaultResurrectTimeoutInitial = 60 * time.Second }()
-
 	var (
 		server      *http.Server
 		servers     []*http.Server
@@ -88,6 +85,7 @@ func TestStatusConnectionPool(t *testing.T) {
 	transport, _ := New(cfg)
 
 	pool := transport.pool.(*statusConnectionPool)
+	pool.resurrectTimeoutInitial = time.Second
 
 	for i := 1; i <= 9; i++ {
 		req, _ := http.NewRequest("GET", "/", nil)

--- a/opensearchtransport/doc.go
+++ b/opensearchtransport/doc.go
@@ -37,7 +37,7 @@ response status codes (by default 502, 503, 504). Use the RetryOnStatus option t
 The transport will not retry a timeout network error, unless enabled by setting EnableRetryOnTimeout to true.
 
 Use the MaxRetries option to configure the number of retries, and set DisableRetry to true
-to disable the retry behaviour altogether.
+to disable the retry behavior altogether.
 
 By default, the retry will be performed without any delay; to configure a backoff interval,
 implement the RetryBackoff option function; see an example in the package unit tests for information.
@@ -45,7 +45,7 @@ implement the RetryBackoff option function; see an example in the package unit t
 When multiple addresses are passed in configuration, the package will use them in a round-robin fashion,
 and will keep track of live and dead nodes. The status of dead nodes is checked periodically.
 
-To customize the node selection behaviour, provide a Selector implementation in the configuration.
+To customize the node selection behavior, provide a Selector implementation in the configuration.
 To replace the connection pool entirely, provide a custom ConnectionPool implementation via
 the ConnectionPoolFunc option.
 

--- a/opensearchtransport/logger.go
+++ b/opensearchtransport/logger.go
@@ -32,7 +32,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -43,7 +42,6 @@ import (
 var debugLogger DebuggingLogger
 
 // Logger defines an interface for logging request and response.
-//
 type Logger interface {
 	// LogRoundTrip should not modify the request or response, except for consuming and closing the body.
 	// Implementations have to check for nil values in request and response.
@@ -55,14 +53,12 @@ type Logger interface {
 }
 
 // DebuggingLogger defines the interface for a debugging logger.
-//
 type DebuggingLogger interface {
 	Log(a ...interface{}) error
 	Logf(format string, a ...interface{}) error
 }
 
 // TextLogger prints the log message in plain text.
-//
 type TextLogger struct {
 	Output             io.Writer
 	EnableRequestBody  bool
@@ -70,7 +66,6 @@ type TextLogger struct {
 }
 
 // ColorLogger prints the log message in a terminal-optimized plain text.
-//
 type ColorLogger struct {
 	Output             io.Writer
 	EnableRequestBody  bool
@@ -78,7 +73,6 @@ type ColorLogger struct {
 }
 
 // CurlLogger prints the log message as a runnable curl command.
-//
 type CurlLogger struct {
 	Output             io.Writer
 	EnableRequestBody  bool
@@ -86,7 +80,6 @@ type CurlLogger struct {
 }
 
 // JSONLogger prints the log message as JSON.
-//
 type JSONLogger struct {
 	Output             io.Writer
 	EnableRequestBody  bool
@@ -94,13 +87,11 @@ type JSONLogger struct {
 }
 
 // debuggingLogger prints debug messages as plain text.
-//
 type debuggingLogger struct {
 	Output io.Writer
 }
 
 // LogRoundTrip prints the information about request and response.
-//
 func (l *TextLogger) LogRoundTrip(req *http.Request, res *http.Response, err error, start time.Time, dur time.Duration) error {
 	fmt.Fprintf(l.Output, "%s %s %s [status:%d request:%s]\n",
 		start.Format(time.RFC3339),
@@ -138,8 +129,7 @@ func (l *TextLogger) RequestBodyEnabled() bool { return l.EnableRequestBody }
 func (l *TextLogger) ResponseBodyEnabled() bool { return l.EnableResponseBody }
 
 // LogRoundTrip prints the information about request and response.
-//
-func (l *ColorLogger) LogRoundTrip(req *http.Request, res *http.Response, err error, start time.Time, dur time.Duration) error {
+func (l *ColorLogger) LogRoundTrip(req *http.Request, res *http.Response, err error, _ time.Time, dur time.Duration) error {
 	query, _ := url.QueryUnescape(req.URL.RawQuery)
 	if query != "" {
 		query = "?" + query
@@ -213,8 +203,7 @@ func (l *ColorLogger) RequestBodyEnabled() bool { return l.EnableRequestBody }
 func (l *ColorLogger) ResponseBodyEnabled() bool { return l.EnableResponseBody }
 
 // LogRoundTrip prints the information about request and response.
-//
-func (l *CurlLogger) LogRoundTrip(req *http.Request, res *http.Response, err error, start time.Time, dur time.Duration) error {
+func (l *CurlLogger) LogRoundTrip(req *http.Request, res *http.Response, _ error, start time.Time, dur time.Duration) error {
 	var b bytes.Buffer
 
 	var query string
@@ -232,7 +221,7 @@ func (l *CurlLogger) LogRoundTrip(req *http.Request, res *http.Response, err err
 	}
 
 	b.WriteString(`curl`)
-	if req.Method == "HEAD" {
+	if req.Method == http.MethodHead {
 		b.WriteString(" --head")
 	} else {
 		fmt.Fprintf(&b, " -X %s", req.Method)
@@ -277,8 +266,7 @@ func (l *CurlLogger) LogRoundTrip(req *http.Request, res *http.Response, err err
 
 	b.WriteRune('\n')
 
-	var status string
-	status = res.Status
+	status := res.Status
 
 	fmt.Fprintf(&b, "# => %s [%s] %s\n", start.UTC().Format(time.RFC3339), status, dur.Truncate(time.Millisecond))
 	if l.ResponseBodyEnabled() && res != nil && res.Body != nil && res.Body != http.NoBody {
@@ -307,13 +295,12 @@ func (l *CurlLogger) RequestBodyEnabled() bool { return l.EnableRequestBody }
 func (l *CurlLogger) ResponseBodyEnabled() bool { return l.EnableResponseBody }
 
 // LogRoundTrip prints the information about request and response.
-//
 func (l *JSONLogger) LogRoundTrip(req *http.Request, res *http.Response, err error, start time.Time, dur time.Duration) error {
 	// TODO: Research performance optimization of using sync.Pool
 
 	bsize := 200
-	var b = bytes.NewBuffer(make([]byte, 0, bsize))
-	var v = make([]byte, 0, bsize)
+	b := bytes.NewBuffer(make([]byte, 0, bsize))
+	v := make([]byte, 0, bsize)
 
 	appendTime := func(t time.Time) {
 		v = v[:0]
@@ -333,8 +320,6 @@ func (l *JSONLogger) LogRoundTrip(req *http.Request, res *http.Response, err err
 		b.Write(v)
 	}
 
-	port := req.URL.Port()
-
 	b.WriteRune('{')
 	// -- Timestamp
 	b.WriteString(`"@timestamp":"`)
@@ -351,7 +336,7 @@ func (l *JSONLogger) LogRoundTrip(req *http.Request, res *http.Response, err err
 	appendQuote(req.URL.Scheme)
 	b.WriteString(`,"domain":`)
 	appendQuote(req.URL.Hostname())
-	if port != "" {
+	if port := req.URL.Port(); port != "" {
 		b.WriteString(`,"port":`)
 		b.WriteString(port)
 	}
@@ -415,14 +400,12 @@ func (l *JSONLogger) RequestBodyEnabled() bool { return l.EnableRequestBody }
 func (l *JSONLogger) ResponseBodyEnabled() bool { return l.EnableResponseBody }
 
 // Log prints the arguments to output in default format.
-//
 func (l *debuggingLogger) Log(a ...interface{}) error {
 	_, err := fmt.Fprint(l.Output, a...)
 	return err
 }
 
 // Logf prints formats the arguments and prints them to output.
-//
 func (l *debuggingLogger) Logf(format string, a ...interface{}) error {
 	_, err := fmt.Fprintf(l.Output, format, a...)
 	return err
@@ -444,13 +427,14 @@ func duplicateBody(body io.ReadCloser) (io.ReadCloser, io.ReadCloser, error) {
 		b2 bytes.Buffer
 		tr = io.TeeReader(body, &b2)
 	)
-	_, err := b1.ReadFrom(tr)
-	if err != nil {
-		return ioutil.NopCloser(io.MultiReader(&b1, errorReader{err: err})), ioutil.NopCloser(io.MultiReader(&b2, errorReader{err: err})), err
+
+	if _, err := b1.ReadFrom(tr); err != nil {
+		return io.NopCloser(io.MultiReader(&b1, errorReader{err: err})), io.NopCloser(io.MultiReader(&b2, errorReader{err: err})), err
 	}
+
 	defer func() { body.Close() }()
 
-	return ioutil.NopCloser(&b1), ioutil.NopCloser(&b2), nil
+	return io.NopCloser(&b1), io.NopCloser(&b2), nil
 }
 
 func resStatusCode(res *http.Response) int {
@@ -462,4 +446,4 @@ func resStatusCode(res *http.Response) int {
 
 type errorReader struct{ err error }
 
-func (r errorReader) Read(p []byte) (int, error) { return 0, r.err }
+func (r errorReader) Read(_ []byte) (int, error) { return 0, r.err }

--- a/opensearchtransport/metrics.go
+++ b/opensearchtransport/metrics.go
@@ -36,19 +36,16 @@ import (
 )
 
 // Measurable defines the interface for transports supporting metrics.
-//
 type Measurable interface {
 	Metrics() (Metrics, error)
 }
 
 // connectionable defines the interface for transports returning a list of connections.
-//
 type connectionable interface {
 	connections() []*Connection
 }
 
 // Metrics represents the transport metrics.
-//
 type Metrics struct {
 	Requests  int         `json:"requests"`
 	Failures  int         `json:"failures"`
@@ -58,7 +55,6 @@ type Metrics struct {
 }
 
 // ConnectionMetric represents metric information for a connection.
-//
 type ConnectionMetric struct {
 	URL       string     `json:"url"`
 	Failures  int        `json:"failures,omitempty"`
@@ -73,19 +69,15 @@ type ConnectionMetric struct {
 }
 
 // metrics represents the inner state of metrics.
-//
 type metrics struct {
 	sync.RWMutex
 
 	requests  int
 	failures  int
 	responses map[int]int
-
-	connections []*Connection
 }
 
 // Metrics returns the transport metrics.
-//
 func (c *Client) Metrics() (Metrics, error) {
 	if c.metrics == nil {
 		return Metrics{}, errors.New("transport metrics not enabled")
@@ -139,7 +131,6 @@ func (c *Client) Metrics() (Metrics, error) {
 }
 
 // String returns the metrics as a string.
-//
 func (m Metrics) String() string {
 	var (
 		i int
@@ -175,7 +166,6 @@ func (m Metrics) String() string {
 		if i+1 < len(m.Connections) {
 			b.WriteString(", ")
 		}
-		i++
 	}
 	b.WriteString("]")
 
@@ -184,7 +174,6 @@ func (m Metrics) String() string {
 }
 
 // String returns the connection information as a string.
-//
 func (cm ConnectionMetric) String() string {
 	var b strings.Builder
 	b.WriteString("{")

--- a/opensearchtransport/metrics_internal_test.go
+++ b/opensearchtransport/metrics_internal_test.go
@@ -24,7 +24,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build !integration
+//go:build !integration
 
 package opensearchtransport
 
@@ -56,8 +56,11 @@ func TestMetrics(t *testing.T) {
 		tp.metrics.responses[200] = 1
 		tp.metrics.responses[404] = 2
 
-		req, _ := http.NewRequest("HEAD", "/", nil)
-		tp.Perform(req)
+		req, _ := http.NewRequest(http.MethodHead, "/", nil)
+		resp, err := tp.Perform(req)
+		if err == nil {
+			defer resp.Body.Close()
+		}
 
 		m, err := tp.Metrics()
 		if err != nil {

--- a/opensearchtransport/opensearchtransport.go
+++ b/opensearchtransport/opensearchtransport.go
@@ -33,46 +33,27 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"regexp"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/opensearch-project/opensearch-go/v2/signer"
-
 	"github.com/opensearch-project/opensearch-go/v2/internal/version"
+	"github.com/opensearch-project/opensearch-go/v2/signer"
 )
 
 const (
 	// Version returns the package version as a string.
-	Version = version.Client
-
-	// esCompatHeader defines the env var for Compatibility header.
-	esCompatHeader = "ELASTIC_CLIENT_APIVERSIONING"
+	Version           = version.Client
+	defaultMaxRetries = 3
 )
 
-var (
-	userAgent           string
-	compatibilityHeader bool
-	reGoVersion         = regexp.MustCompile(`go(\d+\.\d+\..+)`)
-
-	defaultMaxRetries    = 3
-	defaultRetryOnStatus = [...]int{502, 503, 504}
-)
-
-func init() {
-	userAgent = initUserAgent()
-
-	compatHeaderEnv := os.Getenv(esCompatHeader)
-	compatibilityHeader, _ = strconv.ParseBool(compatHeaderEnv)
-}
+var reGoVersion = regexp.MustCompile(`go(\d+\.\d+\..+)`)
 
 // Interface defines the interface for HTTP client.
 type Interface interface {
@@ -114,10 +95,11 @@ type Config struct {
 type Client struct {
 	sync.Mutex
 
-	urls     []*url.URL
-	username string
-	password string
-	header   http.Header
+	urls      []*url.URL
+	username  string
+	password  string
+	header    http.Header
+	userAgent string
 
 	signer signer.Signer
 
@@ -164,17 +146,17 @@ func New(cfg Config) (*Client, error) {
 		cfg.Transport = httpTransport
 	}
 
-	if len(cfg.RetryOnStatus) == 0 {
-		cfg.RetryOnStatus = defaultRetryOnStatus[:]
+	if len(cfg.RetryOnStatus) == 0 && cfg.RetryOnStatus == nil {
+		cfg.RetryOnStatus = []int{502, 503, 504}
 	}
 
 	if cfg.MaxRetries == 0 {
 		cfg.MaxRetries = defaultMaxRetries
 	}
 
-	var conns []*Connection
-	for _, u := range cfg.URLs {
-		conns = append(conns, &Connection{URL: u})
+	conns := make([]*Connection, len(cfg.URLs))
+	for idx, u := range cfg.URLs {
+		conns[idx] = &Connection{URL: u}
 	}
 
 	client := Client{
@@ -200,10 +182,12 @@ func New(cfg Config) (*Client, error) {
 		poolFunc:  cfg.ConnectionPoolFunc,
 	}
 
+	client.userAgent = initUserAgent()
+
 	if client.poolFunc != nil {
 		client.pool = client.poolFunc(conns, client.selector)
 	} else {
-		client.pool, _ = NewConnectionPool(conns, client.selector)
+		client.pool = NewConnectionPool(conns, client.selector)
 	}
 
 	if cfg.EnableDebugLogger {
@@ -223,7 +207,7 @@ func New(cfg Config) (*Client, error) {
 
 	if client.discoverNodesInterval > 0 {
 		time.AfterFunc(client.discoverNodesInterval, func() {
-			client.scheduleDiscoverNodes(client.discoverNodesInterval)
+			client.scheduleDiscoverNodes()
 		})
 	}
 
@@ -236,14 +220,6 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 		res *http.Response
 		err error
 	)
-
-	// Compatibility Header
-	if compatibilityHeader {
-		if req.Body != nil {
-			req.Header.Set("Content-Type", "application/vnd.elasticsearch+json;compatible-with=7")
-		}
-		req.Header.Set("Accept", "application/vnd.elasticsearch+json;compatible-with=7")
-	}
 
 	// Record metrics, when enabled
 	if c.metrics != nil {
@@ -261,30 +237,31 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 			var buf bytes.Buffer
 			zw := gzip.NewWriter(&buf)
 			if _, err := io.Copy(zw, req.Body); err != nil {
-				return nil, fmt.Errorf("failed to compress request body: %s", err)
+				return nil, fmt.Errorf("failed to compress request body: %w", err)
 			}
 			if err := zw.Close(); err != nil {
-				return nil, fmt.Errorf("failed to compress request body (during close): %s", err)
+				return nil, fmt.Errorf("failed to compress request body (during close): %w", err)
 			}
 
 			req.GetBody = func() (io.ReadCloser, error) {
 				r := buf
-				return ioutil.NopCloser(&r), nil
+				return io.NopCloser(&r), nil
 			}
+			//nolint:errcheck // error is always nil
 			req.Body, _ = req.GetBody()
 
 			req.Header.Set("Content-Encoding", "gzip")
 			req.ContentLength = int64(buf.Len())
-
 		} else if req.GetBody == nil {
 			if !c.disableRetry || (c.logger != nil && c.logger.RequestBodyEnabled()) {
 				var buf bytes.Buffer
+				//nolint:errcheck // ignored as this is only for logging
 				buf.ReadFrom(req.Body)
-
 				req.GetBody = func() (io.ReadCloser, error) {
 					r := buf
-					return ioutil.NopCloser(&r), nil
+					return io.NopCloser(&r), nil
 				}
+				//nolint:errcheck // error is always nil
 				req.Body, _ = req.GetBody()
 			}
 		}
@@ -305,7 +282,7 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 			if c.logger != nil {
 				c.logRoundTrip(req, nil, err, time.Time{}, time.Duration(0))
 			}
-			return nil, fmt.Errorf("cannot get connection: %s", err)
+			return nil, fmt.Errorf("cannot get connection: %w", err)
 		}
 
 		// Update request
@@ -313,13 +290,13 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 		c.setReqAuth(conn.URL, req)
 
 		if err = c.signRequest(req); err != nil {
-			return nil, fmt.Errorf("failed to sign request: %s", err)
+			return nil, fmt.Errorf("failed to sign request: %w", err)
 		}
 
 		if !c.disableRetry && i > 0 && req.Body != nil && req.Body != http.NoBody {
 			body, err := req.GetBody()
 			if err != nil {
-				return nil, fmt.Errorf("cannot get request body: %s", err)
+				return nil, fmt.Errorf("cannot get request body: %w", err)
 			}
 			req.Body = body
 		}
@@ -332,6 +309,7 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 		// Log request and response
 		if c.logger != nil {
 			if c.logger.RequestBodyEnabled() && req.Body != nil && req.Body != http.NoBody {
+				//nolint:errcheck // ignored as this is only for logging
 				req.Body, _ = req.GetBody()
 			}
 			c.logRoundTrip(req, res, err, start, dur)
@@ -347,17 +325,19 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 
 			// Report the connection as unsuccessful
 			c.Lock()
+			//nolint:errcheck // Questionable if the function even returns an error
 			c.pool.OnFailure(conn)
 			c.Unlock()
 
 			// Retry on EOF errors
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				shouldRetry = true
 			}
 
 			// Retry on network errors, but not on timeout errors, unless configured
-			if err, ok := err.(net.Error); ok {
-				if (!err.Timeout() || c.enableRetryOnTimeout) && !c.disableRetry {
+			var netError net.Error
+			if errors.As(err, &netError) {
+				if (!netError.Timeout() || c.enableRetryOnTimeout) && !c.disableRetry {
 					shouldRetry = true
 				}
 			}
@@ -392,7 +372,8 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 		// Drain and close body when retrying after response
 		if shouldCloseBody && i < c.maxRetries {
 			if res.Body != nil {
-				io.Copy(ioutil.Discard, res.Body)
+				//nolint:errcheck // undexpected but okay if it failes
+				io.Copy(io.Discard, res.Body)
 				res.Body.Close()
 			}
 		}
@@ -402,7 +383,7 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 			time.Sleep(c.retryBackoff(i + 1))
 		}
 	}
-	// Read, close and replace the http reponse body to close the connection
+	// Read, close and replace the http response body to close the connection
 	if res != nil && res.Body != nil {
 		body, err := io.ReadAll(res.Body)
 		res.Body.Close()
@@ -420,7 +401,7 @@ func (c *Client) URLs() []*url.URL {
 	return c.pool.URLs()
 }
 
-func (c *Client) setReqURL(u *url.URL, req *http.Request) *http.Request {
+func (c *Client) setReqURL(u *url.URL, req *http.Request) {
 	req.URL.Scheme = u.Scheme
 	req.URL.Host = u.Host
 
@@ -431,25 +412,21 @@ func (c *Client) setReqURL(u *url.URL, req *http.Request) *http.Request {
 		b.WriteString(req.URL.Path)
 		req.URL.Path = b.String()
 	}
-
-	return req
 }
 
-func (c *Client) setReqAuth(u *url.URL, req *http.Request) *http.Request {
+func (c *Client) setReqAuth(u *url.URL, req *http.Request) {
 	if _, ok := req.Header["Authorization"]; !ok {
 		if u.User != nil {
 			password, _ := u.User.Password()
 			req.SetBasicAuth(u.User.Username(), password)
-			return req
+			return
 		}
 
 		if c.username != "" && c.password != "" {
 			req.SetBasicAuth(c.username, c.password)
-			return req
+			return
 		}
 	}
-
-	return req
 }
 
 func (c *Client) signRequest(req *http.Request) error {
@@ -459,12 +436,11 @@ func (c *Client) signRequest(req *http.Request) error {
 	return nil
 }
 
-func (c *Client) setReqUserAgent(req *http.Request) *http.Request {
-	req.Header.Set("User-Agent", userAgent)
-	return req
+func (c *Client) setReqUserAgent(req *http.Request) {
+	req.Header.Set("User-Agent", c.userAgent)
 }
 
-func (c *Client) setReqGlobalHeader(req *http.Request) *http.Request {
+func (c *Client) setReqGlobalHeader(req *http.Request) {
 	if len(c.header) > 0 {
 		for k, v := range c.header {
 			if req.Header.Get(k) != k {
@@ -474,7 +450,6 @@ func (c *Client) setReqGlobalHeader(req *http.Request) *http.Request {
 			}
 		}
 	}
-	return req
 }
 
 func (c *Client) logRoundTrip(
@@ -488,14 +463,18 @@ func (c *Client) logRoundTrip(
 	if res != nil {
 		dupRes = *res
 	}
+
 	if c.logger.ResponseBodyEnabled() {
 		if res != nil && res.Body != nil && res.Body != http.NoBody {
+			//nolint:errcheck // ignored as this is only for logging
 			b1, b2, _ := duplicateBody(res.Body)
 			dupRes.Body = b1
 			res.Body = b2
 		}
 	}
-	c.logger.LogRoundTrip(req, &dupRes, err, start, dur) // errcheck exclude
+
+	//nolint:errcheck // ignored as this is only for logging
+	c.logger.LogRoundTrip(req, &dupRes, err, start, dur)
 }
 
 func initUserAgent() string {

--- a/opensearchtransport/opensearchtransport_integration_multinode_test.go
+++ b/opensearchtransport/opensearchtransport_integration_multinode_test.go
@@ -24,7 +24,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build integration,multinode
+//go:build integration && multinode
 
 package opensearchtransport_test
 

--- a/opensearchtransport/opensearchtransport_integration_test.go
+++ b/opensearchtransport/opensearchtransport_integration_test.go
@@ -25,7 +25,6 @@
 // under the License.
 
 //go:build integration
-// +build integration
 
 package opensearchtransport_test
 


### PR DESCRIPTION
### Description
Once #352 is merged I'll rebase this MR.
Update golangci-lint config and bump its version.
Solve linting complains inside opensearchtransport folder.
This is a side product of my current refactoring. I fixed all linting complains in my feature branch and I want to merge some of those fixes upstream to reduce the files changed by my feature branch.

### Issues Resolved
There is not open issue for linting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
