### PR TITLE
add note about effect of settings in serverless

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -56,6 +56,8 @@ func example() error {
 	fmt.Println(client.Info())
 
 	// Define index mapping.
+        // Note: these particular settings (eg, shards/replicas)
+        // will have no effect in AWS OpenSearch Serverless
 	mapping := strings.NewReader(`{
 	    "settings": {
 	        "index": {


### PR DESCRIPTION
### Description
Settings for shards and replicas have no effect in the AWS OpenSearch Serverless, so this PR mentions that explicitly in the example in case users were not aware.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
