### PR TITLE
developer-guide: corrects go version in summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Corrects AWSv4 signature on DataStream Stats with no index name specified ([#338](https://github.com/opensearch-project/opensearch-go/pull/338))
 - Fixed GetSourceRequest `Source` field and deprecated the `Source` parameter ([#402](https://github.com/opensearch-project/opensearch-go/pull/402))
+- Corrects developer guide summary with golang version 1.20 ([#434](https://github.com/opensearch-project/opensearch-go/pull/434))
 
 ### Security
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -2,7 +2,7 @@
   - [Getting Started](#getting-started)
     - [Git Clone OpenSearch Go Client Repository](#git-clone-opensearch-go-client-repository)
     - [Install Prerequisites](#install-prerequisites)
-      - [Go 1.11](#go-111)
+      - [Go 1.20](#go-120)
       - [Docker](#docker)
       - [Windows](#windows)
     - [Unit Testing](#unit-testing)


### PR DESCRIPTION
### Description
Corrects developer guide with current go 1.20 in summary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
