### PR TITLE
Preparing for next developer iteration, 3.0.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased 3.0.1]
+### Dependencies
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
 ## [3.0.0]
 ### Dependencies
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,9 +33,11 @@ Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v
 
 The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [MAINTAINERS](MAINTAINERS.md).
 
-1. Adjust the [CHANGELOG](CHANGELOG.md) by Replacing the `Unreleased` section with the new version.
-2. Add a comparison link to the new version at the bottom of the [CHANGELOG](CHANGELOG.md).
-3. Adjust the internal client version in the [internal/version/version.go](internal/version/version.go) file.
-4. Create a PR with the changes and merge it into main.
-5. Create a tag, e.g. `v3.0.1`, and push it to the GitHub repo. This makes the new version available on https://pkg.go.dev/github.com/opensearch-project/opensearch-go/v3.
-6. Create a new `Unreleased` section in the [CHANGELOG](CHANGELOG.md) and merge it into main.
+1. Ensure that the version in [version.go](internal/version/version.go) is correct for the next release. 
+2. For major version releases, ensure that all references are up-to-date, e.g. `github.com/opensearch-project/opensearch-go/v3`, see [opensearch-go#444](https://github.com/opensearch-project/opensearch-go/pull/444).
+3. Edit the [CHANGELOG](CHANGELOG.md) and replace the `Unreleased` section with the version about to be released.
+4. Add a comparison link to the new version at the bottom of the [CHANGELOG](CHANGELOG.md).
+5. Create a pull request with the changes into `main`, e.g. [opensearch-go#443](https://github.com/opensearch-project/opensearch-go/pull/443).
+6. Create a tag, e.g. `v3.0.1`, and push it to the GitHub repo. This [makes the new version available](https://go.dev/doc/modules/publishing) on [pkg.go.dev](https://pkg.go.dev/github.com/opensearch-project/opensearch-go).
+7. Draft and publish a [new GitHub release](https://github.com/opensearch-project/opensearch-go/releases/new) from the newly created tag.
+8. Create a new `Unreleased` section in the [CHANGELOG](CHANGELOG.md), increment version in [version.go](internal/version/version.go) to the next developer iteration (e.g. `3.0.2`), and make a pull request with this change into `main`, e.g. [opensearch-go#448](https://github.com/opensearch-project/opensearch-go/pull/448).

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -27,4 +27,4 @@
 package version
 
 // Client returns the client version as a string.
-const Client = "3.0.0"
+const Client = "3.0.1"


### PR DESCRIPTION
### Description

- Increments to next developer iteration.
- Updates CHANGELOG with Unreleased.
- Updates RELEASING with info about how to do this.

Note that the first time we take a pull request with a new feature we should be asking the requester to change the version to 3.1.0.

### Issues Resolved

Closes #264.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
