### PR TITLE
Remove references to the default credentials of admin:admin

### DIFF
--- a/.ci/opensearch/Dockerfile.opensearch
+++ b/.ci/opensearch/Dockerfile.opensearch
@@ -7,7 +7,9 @@ ENV SECURE_INTEGRATION=$SECURE_INTEGRATION
 
 # Starting in 2.12.0 security demo requires an initial admin password, which is set as myStrongPassword123!
 ENV password="admin"
-RUN if [$OPENSEARCH_VERSION="latest"]; then password="myStrongPassword123!" fi
+RUN if [ "$OPENSEARCH_VERSION" = "latest" ]; then \
+        export password="myStrongPassword123!"; \
+    fi
 
 RUN if [ "$SECURE_INTEGRATION" != "true" ] ; then $opensearch_path/bin/opensearch-plugin remove opensearch-security; fi
 

--- a/.ci/opensearch/Dockerfile.opensearch
+++ b/.ci/opensearch/Dockerfile.opensearch
@@ -9,5 +9,5 @@ RUN if [ "$SECURE_INTEGRATION" != "true" ] ; then $opensearch_path/bin/opensearc
 
 HEALTHCHECK --start-period=20s --interval=30s \
   CMD curl -sf -retry 5 --max-time 5 --retry-delay 5 --retry-max-time 30 \
-  $(if $SECURE_INTEGRATION; then echo "-u admin:admin -k https://"; fi)"localhost:9200" \
+  $(if $SECURE_INTEGRATION; then echo "-u admin:myStrongPassword123! -k https://"; fi)"localhost:9200" \
   || bash -c 'kill -s 15 -1 && (sleep 10; kill -s 9 -1)'

--- a/.ci/opensearch/Dockerfile.opensearch
+++ b/.ci/opensearch/Dockerfile.opensearch
@@ -5,9 +5,12 @@ ARG opensearch_path=/usr/share/opensearch
 ARG SECURE_INTEGRATION
 ENV SECURE_INTEGRATION=$SECURE_INTEGRATION
 
+# Starting in 2.12.0 security demo requires an initial admin password, which is set as myStrongPassword123!
+RUN export password=$(if $OPENSEARCH_VERSION="latest"; then echo "myStrongPassword123!"; else echo "admin" fi)
+
 RUN if [ "$SECURE_INTEGRATION" != "true" ] ; then $opensearch_path/bin/opensearch-plugin remove opensearch-security; fi
 
 HEALTHCHECK --start-period=20s --interval=30s \
   CMD curl -sf -retry 5 --max-time 5 --retry-delay 5 --retry-max-time 30 \
-  $(if $SECURE_INTEGRATION; then echo "-u admin:myStrongPassword123! -k https://"; fi)"localhost:9200" \
+  $(if $SECURE_INTEGRATION; then echo "-u admin:$password -k https://"; fi)"localhost:9200" \
   || bash -c 'kill -s 15 -1 && (sleep 10; kill -s 9 -1)'

--- a/.ci/opensearch/Dockerfile.opensearch
+++ b/.ci/opensearch/Dockerfile.opensearch
@@ -6,7 +6,8 @@ ARG SECURE_INTEGRATION
 ENV SECURE_INTEGRATION=$SECURE_INTEGRATION
 
 # Starting in 2.12.0 security demo requires an initial admin password, which is set as myStrongPassword123!
-RUN export password=$(if $OPENSEARCH_VERSION="latest"; then echo "myStrongPassword123!"; else echo "admin" fi)
+ENV password="admin"
+RUN if [$OPENSEARCH_VERSION="latest"]; then password="myStrongPassword123!" fi
 
 RUN if [ "$SECURE_INTEGRATION" != "true" ] ; then $opensearch_path/bin/opensearch-plugin remove opensearch-security; fi
 

--- a/.ci/opensearch/Dockerfile.opensearch
+++ b/.ci/opensearch/Dockerfile.opensearch
@@ -1,19 +1,25 @@
 ARG OPENSEARCH_VERSION
 FROM opensearchproject/opensearch:${OPENSEARCH_VERSION}
 
+ARG OPENSEARCH_VERSION
 ARG opensearch_path=/usr/share/opensearch
 ARG SECURE_INTEGRATION
 ENV SECURE_INTEGRATION=$SECURE_INTEGRATION
 
 # Starting in 2.12.0 security demo requires an initial admin password, which is set as myStrongPassword123!
-ENV password="admin"
-RUN if [ "$OPENSEARCH_VERSION" = "latest" ]; then \
-        export password="myStrongPassword123!"; \
-    fi
-
-RUN if [ "$SECURE_INTEGRATION" != "true" ] ; then $opensearch_path/bin/opensearch-plugin remove opensearch-security; fi
+# https://apple.stackexchange.com/a/123408/11374
+RUN if [ "$SECURE_INTEGRATION" != "true" ] ; then \
+      $opensearch_path/bin/opensearch-plugin remove opensearch-security; \
+      else \
+        function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }; \
+        if [ $(version $OPENSEARCH_VERSION) -ge $(version "2.12.0") ] || [ $OPENSEARCH_VERSION == "latest" ]; then \
+          echo user admin:myStrongPassword123! > curl.conf ; \
+        else \
+          echo user admin:admin > curl.conf ; \
+        fi\
+      fi
 
 HEALTHCHECK --start-period=20s --interval=30s \
   CMD curl -sf -retry 5 --max-time 5 --retry-delay 5 --retry-max-time 30 \
-  $(if $SECURE_INTEGRATION; then echo "-u admin:$password -k https://"; fi)"localhost:9200" \
+  $(if $SECURE_INTEGRATION; then echo "-K curl.conf -k https://"; fi)"localhost:9200" \
   || bash -c 'kill -s 15 -1 && (sleep 10; kill -s 9 -1)'

--- a/.ci/opensearch/docker-compose.yml
+++ b/.ci/opensearch/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - discovery.type=single-node
       - bootstrap.memory_lock=true
       - path.repo=/usr/share/opensearch/mnt
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!
     ports:
       - "9200:9200"
     user: opensearch

--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -47,7 +47,7 @@ jobs:
           export SECURE_INTEGRATION=${{ matrix.secured }}
           make cluster.clean cluster.build cluster.start
           for attempt in `seq 25`; do sleep 5; \
-          if curl -s $(if $SECURE_INTEGRATION; then echo "-ku admin:admin https://"; fi)localhost:9200; \
+          if curl -s $(if $SECURE_INTEGRATION; then echo "-ku admin:myStrongPassword123! https://"; fi)localhost:9200; \
           then echo '=====> ready'; break; fi; if [ $attempt == 25 ]; then exit 1; fi; echo '=====> waiting...'; done
 
       - name: Integration test without security

--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -47,7 +47,7 @@ jobs:
           export SECURE_INTEGRATION=${{ matrix.secured }}
           make cluster.clean cluster.build cluster.start
           for attempt in `seq 25`; do sleep 5; \
-          if curl -s $(if $SECURE_INTEGRATION; then echo "-ku admin:myStrongPassword123! https://"; fi)localhost:9200; \
+          if curl -s $(if $SECURE_INTEGRATION; then echo "-ku admin:admin https://"; fi)localhost:9200; \
           then echo '=====> ready'; break; fi; if [ $attempt == 25 ]; then exit 1; fi; echo '=====> waiting...'; done
 
       - name: Integration test without security

--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -25,6 +25,7 @@ jobs:
           - { opensearch_version: 2.9.0 }
           - { opensearch_version: 2.10.0 }
           - { opensearch_version: 2.11.0 }
+          - { opensearch_version: 2.12.0 }
     steps:
       - uses: actions/checkout@v3
         with: { fetch-depth: 1 }

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -54,6 +54,6 @@ jobs:
         run: |
           make cluster.clean cluster.build cluster.start
           for attempt in `seq 25`; do sleep 5; \
-          if curl -s -ku admin:admin https://localhost:9200; \
+          if curl -s -ku admin:myStrongPassword123! https://localhost:9200; \
           then echo '=====> ready'; break; fi; if [ $attempt == 25 ]; then exit 1; fi; echo '=====> waiting...'; done
       - run: make test-integ-secure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `github.com/aws/aws-sdk-go-v2/config` from 1.25.11 to 1.27.0
 ### Added
 - Added new struct fields introduced by opensearch 2.12 ([#482](https://github.com/opensearch-project/opensearch-go/pull/482))
+- Adds initial admin password environment variable and CI changes to support 2.12.0 release ([#449](https://github.com/opensearch-project/opensearch-go/pull/449))
 ### Changed
 - Changed field opensearch_version of type NodesInfoPlugin to json.RawMessage as opensearch 3.0.0 uses an array instead of string ([#482](https://github.com/opensearch-project/opensearch-go/pull/482))
 ### Deprecated

--- a/guides/index_lifecycle.md
+++ b/guides/index_lifecycle.md
@@ -4,7 +4,7 @@ This guide covers OpenSearch Golang Client API actions for Index Lifecycle. You'
 
 ## Setup
 
-In this guide, we will need an OpenSearch cluster with more than one node. Let's use the sample [docker-compose.yml](https://opensearch.org/samples/docker-compose.yml) to start a cluster with two nodes. The cluster's API will be available at `localhost:9200` with basic authentication enabled with default username and password of `admin:< Admin password >`.
+In this guide, we will need an OpenSearch cluster with more than one node. Let's use the sample [docker-compose.yml](https://opensearch.org/samples/docker-compose.yml) to start a cluster with two nodes. The cluster's API will be available at `localhost:9200` with basic authentication enabled with default username and password of `admin:< admin password >`.
 
 To start the cluster, run the following command:
 
@@ -46,7 +46,7 @@ func example() error {
 				},
 				Addresses: []string{"https://localhost:9200"},
 				Username:  "admin", // For testing only. Don't store credentials in code.
-				Password:  "< Admin password >",
+				Password:  "< admin password >",
 			},
 		},
 	)

--- a/guides/index_lifecycle.md
+++ b/guides/index_lifecycle.md
@@ -4,7 +4,7 @@ This guide covers OpenSearch Golang Client API actions for Index Lifecycle. You'
 
 ## Setup
 
-In this guide, we will need an OpenSearch cluster with more than one node. Let's use the sample [docker-compose.yml](https://opensearch.org/samples/docker-compose.yml) to start a cluster with two nodes. The cluster's API will be available at `localhost:9200` with basic authentication enabled with default username and password of `admin:admin`.
+In this guide, we will need an OpenSearch cluster with more than one node. Let's use the sample [docker-compose.yml](https://opensearch.org/samples/docker-compose.yml) to start a cluster with two nodes. The cluster's API will be available at `localhost:9200` with basic authentication enabled with default username and password of `admin:< Admin password >`.
 
 To start the cluster, run the following command:
 
@@ -46,7 +46,7 @@ func example() error {
 				},
 				Addresses: []string{"https://localhost:9200"},
 				Username:  "admin", // For testing only. Don't store credentials in code.
-				Password:  "admin",
+				Password:  "< Admin password >",
 			},
 		},
 	)

--- a/opensearch_secure_integration_test.go
+++ b/opensearch_secure_integration_test.go
@@ -28,10 +28,10 @@ import (
 	"crypto/tls"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
-	"os"
 
 	"github.com/stretchr/testify/assert"
 
@@ -42,8 +42,8 @@ import (
 func getSecuredClient() (*opensearchapi.Client, error) {
 	version := os.Getenv("OPENSEARCH_VERSION")
 	parts := strings.Split(version, ".")
-	first, err := strconv.Atoi(parts[0])
-	second, err := strconv.Atoi(parts[1])
+	first, _ := strconv.Atoi(parts[0])
+	second, _ := strconv.Atoi(parts[1])
 	var password string
 	if first > 2 || (first == 2 && second >= 12) {
 		password = "myStrongPassword123!"

--- a/opensearch_secure_integration_test.go
+++ b/opensearch_secure_integration_test.go
@@ -28,6 +28,8 @@ import (
 	"crypto/tls"
 	"log"
 	"net/http"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,11 +39,22 @@ import (
 )
 
 func getSecuredClient() (*opensearchapi.Client, error) {
+	version := os.Getenv("OPENSEARCH_VERSION")
+	parts := strings.Split(version, ".")
+	first, err := strconv.Atoi(parts[0])
+	second, err := strconv.Atoi(parts[1])
+	var password string
+	if first > 2 || (first == 2 && second >= 12) {
+		password = "myStrongPassword123!"
+	} else {
+		password = "admin"
+	}
+
 	return opensearchapi.NewClient(
 		opensearchapi.Config{
 			Client: opensearch.Config{
 				Username:  "admin",
-				Password:  "admin",
+				Password:  password,
 				Addresses: []string{"https://localhost:9200"},
 				Transport: &http.Transport{
 					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},

--- a/opensearch_secure_integration_test.go
+++ b/opensearch_secure_integration_test.go
@@ -26,11 +26,9 @@ package opensearch_test
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"log"
 	"net/http"
-	"os"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,40 +38,29 @@ import (
 )
 
 func getSecuredClient() (*opensearchapi.Client, error) {
-	version := os.Getenv("OPENSEARCH_VERSION")
-	parts := strings.Split(version, ".")
-	first, _ := strconv.Atoi(parts[0])
-	second, _ := strconv.Atoi(parts[1])
-	var password string
-	if first > 2 || (first == 2 && second >= 12) {
-		password = "myStrongPassword123!"
-	} else {
-		password = "admin"
-	}
-
-	return opensearchapi.NewClient(
-		opensearchapi.Config{
-			Client: opensearch.Config{
-				Username:  "admin",
-				Password:  password,
-				Addresses: []string{"https://localhost:9200"},
-				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	errs := make([]error, 0)
+	for _, password := range []string{"admin", "myStrongPassword123!"} {
+		client, _ := opensearchapi.NewClient(
+			opensearchapi.Config{
+				Client: opensearch.Config{
+					Username:  "admin",
+					Password:  password,
+					Addresses: []string{"https://localhost:9200"},
+					Transport: &http.Transport{
+						TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+					},
 				},
 			},
-		},
-	)
-}
+		)
+		_, err := client.Info(nil, nil)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		return client, nil
+	}
+	return nil, errors.Join(errs...)
 
-type clusterVersion struct {
-	Number       string `json:"number"`
-	BuildFlavor  string `json:"build_flavor"`
-	Distribution string `json:"distribution"`
-}
-
-type Info struct {
-	Version clusterVersion `json:"version"`
-	Tagline string         `json:"tagline"`
 }
 
 func TestSecuredClientAPI(t *testing.T) {

--- a/opensearch_secure_integration_test.go
+++ b/opensearch_secure_integration_test.go
@@ -31,6 +31,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"os"
 
 	"github.com/stretchr/testify/assert"
 


### PR DESCRIPTION
### Description
Remove references to the default credentials of admin:admin and changes the CI according to default admin credentials changes for the 2.12.0 release.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
