### PR TITLE
fix:When using the opensearch-go library to access an opensearch cluster deployed with IPV6, an access error will occur when calling other APIs after calling the DiscoverNodes method.ter deployed with IPV6, an access error will occur when calling other APIs after calling the DiscoverNodes method.

### DIFF
--- a/opensearchtransport/discovery.go
+++ b/opensearchtransport/discovery.go
@@ -33,7 +33,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync"
 	"time"
 )
@@ -176,24 +175,9 @@ func (c *Client) getNodesInfo() ([]nodeInfo, error) {
 }
 
 func (c *Client) getNodeURL(node nodeInfo, scheme string) *url.URL {
-	var (
-		host string
-		port string
-
-		addrs = strings.Split(node.HTTP.PublishAddress, "/")
-		ports = strings.Split(node.HTTP.PublishAddress, ":")
-	)
-
-	if len(addrs) > 1 {
-		host = addrs[0]
-	} else {
-		host = strings.Split(addrs[0], ":")[0]
-	}
-
-	port = ports[len(ports)-1]
 	u := &url.URL{
 		Scheme: scheme,
-		Host:   host + ":" + port,
+		Host:   node.HTTP.PublishAddress,
 	}
 
 	return u


### PR DESCRIPTION
### Description
ipv6 is supported for DiscoverNodes

### Issues Resolved
https://github.com/opensearch-project/opensearch-go/issues/458

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
