### PR TITLE
fix:Clusters deployed using IPV6 do not support the DiscoverNodes method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Test adjusted to new opensearchapi functions and structs ([#421](https://github.com/opensearch-project/opensearch-go/pull/421))
 - Change codecov to comment code coverage to each PR ([#410](https://github.com/opensearch-project/opensearch-go/pull/410))
 - Change module version from v2 to v3 ([#444](https://github.com/opensearch-project/opensearch-go/pull/444))
+- Clusters deployed using IPV6 do not support the DiscoverNodes method.([#458](https://github.com/opensearch-project/opensearch-go/issues/458))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Test adjusted to new opensearchapi functions and structs ([#421](https://github.com/opensearch-project/opensearch-go/pull/421))
 - Change codecov to comment code coverage to each PR ([#410](https://github.com/opensearch-project/opensearch-go/pull/410))
 - Change module version from v2 to v3 ([#444](https://github.com/opensearch-project/opensearch-go/pull/444))
-- Clusters deployed using IPV6 do not support the DiscoverNodes method.([#458](https://github.com/opensearch-project/opensearch-go/issues/458))
+- Support IPV6 in the DiscoverNodes method ([#458](https://github.com/opensearch-project/opensearch-go/issues/458))
 
 ### Deprecated
 

--- a/opensearchtransport/discovery.go
+++ b/opensearchtransport/discovery.go
@@ -33,7 +33,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync"
 	"time"
 )
@@ -176,24 +175,9 @@ func (c *Client) getNodesInfo() ([]nodeInfo, error) {
 }
 
 func (c *Client) getNodeURL(node nodeInfo, scheme string) *url.URL {
-	var (
-		host string
-		port string
-
-		addrs = strings.Split(node.HTTP.PublishAddress, "/")
-		ports = strings.Split(node.HTTP.PublishAddress, ":")
-	)
-
-	if len(addrs) > 1 {
-		host = addrs[0]
-	} else {
-		host = strings.Split(addrs[0], ":")[0]
-	}
-
-	port = ports[len(ports)-1]
 	u := &url.URL{
 		Scheme: scheme,
-		Host:   host + ":" + port,
+		Host:   node.HTTP.PublishAddress,
 	}
 
 	return u

--- a/opensearchtransport/discovery.go
+++ b/opensearchtransport/discovery.go
@@ -189,15 +189,12 @@ func (c *Client) getNodeURL(node nodeInfo, scheme string) *url.URL {
 	if len(addrs) > 1 {
 		host = addrs[0]
 	} else {
-		host, port, err = net.SplitHostPort(addrs[0])
+		host, _, err = net.SplitHostPort(addrs[0])
 		if err != nil {
 			host = strings.Split(addrs[0], ":")[0]
 		}
 	}
-	if len(port) == 0 {
-		port = ports[len(ports)-1]
-	}
-	
+	port = ports[len(ports)-1]
 	u := &url.URL{
 		Scheme: scheme,
 		Host:   net.JoinHostPort(host, port),

--- a/opensearchtransport/discovery.go
+++ b/opensearchtransport/discovery.go
@@ -31,6 +31,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"

--- a/opensearchtransport/discovery.go
+++ b/opensearchtransport/discovery.go
@@ -194,8 +194,10 @@ func (c *Client) getNodeURL(node nodeInfo, scheme string) *url.URL {
 			host = strings.Split(addrs[0], ":")[0]
 		}
 	}
-
-	port = ports[len(ports)-1]
+	if len(port) == 0 {
+		port = ports[len(ports)-1]
+	}
+	
 	u := &url.URL{
 		Scheme: scheme,
 		Host:   net.JoinHostPort(host, port),

--- a/opensearchtransport/discovery.go
+++ b/opensearchtransport/discovery.go
@@ -180,6 +180,7 @@ func (c *Client) getNodeURL(node nodeInfo, scheme string) *url.URL {
 	var (
 		host string
 		port string
+		err  error
 
 		addrs = strings.Split(node.HTTP.PublishAddress, "/")
 		ports = strings.Split(node.HTTP.PublishAddress, ":")
@@ -188,7 +189,10 @@ func (c *Client) getNodeURL(node nodeInfo, scheme string) *url.URL {
 	if len(addrs) > 1 {
 		host = addrs[0]
 	} else {
-		host, _, _ = net.SplitHostPort(addrs[0])
+		host, port, err = net.SplitHostPort(addrs[0])
+		if err != nil {
+			host = strings.Split(addrs[0], ":")[0]
+		}
 	}
 
 	port = ports[len(ports)-1]

--- a/opensearchtransport/discovery.go
+++ b/opensearchtransport/discovery.go
@@ -33,6 +33,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 )
@@ -175,9 +176,24 @@ func (c *Client) getNodesInfo() ([]nodeInfo, error) {
 }
 
 func (c *Client) getNodeURL(node nodeInfo, scheme string) *url.URL {
+	var (
+		host string
+		port string
+
+		addrs = strings.Split(node.HTTP.PublishAddress, "/")
+		ports = strings.Split(node.HTTP.PublishAddress, ":")
+	)
+
+	if len(addrs) > 1 {
+		host = addrs[0]
+	} else {
+		host, _, _ = net.SplitHostPort(addrs[0])
+	}
+
+	port = ports[len(ports)-1]
 	u := &url.URL{
 		Scheme: scheme,
-		Host:   node.HTTP.PublishAddress,
+		Host:   net.JoinHostPort(host, port),
 	}
 
 	return u

--- a/opensearchtransport/discovery_internal_test.go
+++ b/opensearchtransport/discovery_internal_test.go
@@ -82,7 +82,7 @@ func TestDiscovery(t *testing.T) {
 		}
 		fmt.Printf("NodesInfo: %+v\n", nodes)
 
-		if len(nodes) != 3 {
+		if len(nodes) != 4 {
 			t.Errorf("Unexpected number of nodes, want=3, got=%d", len(nodes))
 		}
 
@@ -98,6 +98,10 @@ func TestDiscovery(t *testing.T) {
 				}
 			case "es3":
 				if node.URL.String() != "http://127.0.0.1:10003" {
+					t.Errorf("Unexpected URL: %s", node.URL.String())
+				}
+			case "es4":
+				if node.URL.String() != "http://[fc99:3528::a04:812c]:10004" {
 					t.Errorf("Unexpected URL: %s", node.URL.String())
 				}
 			}

--- a/opensearchtransport/discovery_internal_test.go
+++ b/opensearchtransport/discovery_internal_test.go
@@ -83,7 +83,7 @@ func TestDiscovery(t *testing.T) {
 		fmt.Printf("NodesInfo: %+v\n", nodes)
 
 		if len(nodes) != 4 {
-			t.Errorf("Unexpected number of nodes, want=3, got=%d", len(nodes))
+			t.Errorf("Unexpected number of nodes, want=4, got=%d", len(nodes))
 		}
 
 		for _, node := range nodes {

--- a/opensearchtransport/testdata/nodes.info.json
+++ b/opensearchtransport/testdata/nodes.info.json
@@ -63,6 +63,25 @@
         "publish_address": "127.0.0.1:10003",
         "max_content_length_in_bytes": 104857600
       }
+    },
+    "4uJ-108zTz27ISgkmAQgfw": {
+      "name": "es4",
+      "transport_address": "[fc99:3528::a04:812c]:9303",
+      "host": "fc99:3528:0:0:0:0:a04:812c",
+      "ip": "fc99:3528::a04:812c",
+      "version": "7.4.2",
+      "build_flavor": "oss",
+      "build_type": "tar",
+      "build_hash": "2f90bbf7b93631e52bafb59b3b049cb44ec25e96",
+      "roles": ["cluster_manager"],
+      "http": {
+        "bound_address": [
+          "[::1]:10004",
+          "[fc99:3528::a04:812c]:10004"
+        ],
+        "publish_address": "[fc99:3528::a04:812c]:10004",
+        "max_content_length_in_bytes": 104857600
+      }
     }
   }
 }


### PR DESCRIPTION
### Description
When using the opensearch-go library to access an opensearch cluster deployed with IPV6, an access error will occur when calling other APIs after calling the DiscoverNodes method.

### Issues Resolved
[_List any issues this PR will resolve, e.g. Closes [...]._ ](https://github.com/opensearch-project/opensearch-go/issues/458)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
