### PR TITLE
changelog: changed unreleased version back for Dependabot PR to work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
-## [Unreleased 3.0.1]
+## [Unreleased]
 ### Dependencies
 ### Added
 ### Changed


### PR DESCRIPTION
### Description
Change the changelog version back to `Unreleased` as the verify-changelog job matches on the regexp `Version Pattern: ^## \[((v|V)?\d*\.\d*\.\d*-?\w*|unreleased|Unreleased|UNRELEASED)\]`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
