### PR TITLE
Fix search request missing a slash when no indices are given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- Fix search request missing a slash when no indices are given ([#470](https://github.com/opensearch-project/opensearch-go/pull/469))
 
 ### Security
 

--- a/opensearchapi/api_search.go
+++ b/opensearchapi/api_search.go
@@ -49,7 +49,7 @@ func (r SearchReq) GetRequest() (*http.Request, error) {
 	if len(r.Indices) > 0 {
 		path = fmt.Sprintf("/%s/_search", strings.Join(r.Indices, ","))
 	} else {
-		path = "_search"
+		path = "/_search"
 	}
 
 	return opensearch.BuildRequest(

--- a/opensearchapi/api_search_test.go
+++ b/opensearchapi/api_search_test.go
@@ -9,6 +9,7 @@
 package opensearchapi_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -73,19 +74,39 @@ func TestSearch(t *testing.T) {
 	})
 
 	t.Run("request with retrieve specific fields", func(t *testing.T) {
-		resp, err := client.Search(nil, &opensearchapi.SearchReq{Indices: []string{index}, Body: strings.NewReader(`{
-		  "query": {
-			"match": {
-			  "foo": "bar"
-			}
-		  },
-		  "fields": [
-			"foo"
-		  ],
-		  "_source": false
-		}`)})
+		resp, err := client.Search(
+			nil,
+			&opensearchapi.SearchReq{
+				Indices: []string{index},
+				Body: strings.NewReader(`{
+				"query": {
+					"match": {
+						"foo": "bar"
+					}
+				},
+				"fields": [
+					"foo"
+				],
+			"_source": false
+			}`),
+			},
+		)
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp.Hits.Hits)
 		assert.NotEmpty(t, resp.Hits.Hits[0].Fields)
+	})
+
+	t.Run("url path", func(t *testing.T) {
+		req := &opensearchapi.SearchReq{}
+		httpReq, err := req.GetRequest()
+		assert.Nil(t, err)
+		require.NotNil(t, httpReq)
+		assert.Equal(t, "/_search", httpReq.URL.Path)
+
+		req = &opensearchapi.SearchReq{Indices: []string{index}}
+		httpReq, err = req.GetRequest()
+		assert.Nil(t, err)
+		require.NotNil(t, httpReq)
+		assert.Equal(t, fmt.Sprintf("/%s/_search", index), httpReq.URL.Path)
 	})
 }


### PR DESCRIPTION
### Description
Add missing `/ ` for search requests when not searching specific indices.

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-go/issues/470

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
