### PR TITLE
Adjust tests to work with secure cluster

### DIFF
--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -8,7 +8,7 @@ jobs:
   verify-changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -25,7 +25,7 @@ jobs:
           installation_id: 22958780
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ steps.github_app_token.outputs.token }}
 

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check license headers
         run: |

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: lychee Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v1.9.3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,10 +10,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with: { fetch-depth: 1 }
-      - uses: actions/setup-go@v3
-        with: { go-version: '1.x' }
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version-file: 'go.mod' }
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -25,8 +24,7 @@ jobs:
     name: Prettify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with: { fetch-depth: 1 }
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: npm i -g npm@8 && npm i -g prettier
       - name: Check markdown files

--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -12,7 +12,7 @@ jobs:
         entry:
           - { opensearch_version: 1.1.0 }
           - { opensearch_version: 1.2.4 }
-          - { opensearch_version: 1.3.8 }
+          - { opensearch_version: 1.3.15 }
           - { opensearch_version: 2.0.1 }
           - { opensearch_version: 2.1.0 }
           - { opensearch_version: 2.2.1 }
@@ -24,7 +24,7 @@ jobs:
           - { opensearch_version: 2.8.0 }
           - { opensearch_version: 2.9.0 }
           - { opensearch_version: 2.10.0 }
-          - { opensearch_version: 2.11.0 }
+          - { opensearch_version: 2.11.1 }
           - { opensearch_version: 2.12.0 }
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -27,11 +27,10 @@ jobs:
           - { opensearch_version: 2.11.0 }
           - { opensearch_version: 2.12.0 }
     steps:
-      - uses: actions/checkout@v3
-        with: { fetch-depth: 1 }
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v3
-        with: { go-version: '1.x' }
+      - uses: actions/setup-go@v5
+        with: { go-version-file: 'go.mod' }
 
       - run: go version
 
@@ -51,14 +50,11 @@ jobs:
           if curl -s $(if $SECURE_INTEGRATION; then echo "-ku admin:admin https://"; fi)localhost:9200; \
           then echo '=====> ready'; break; fi; if [ $attempt == 25 ]; then exit 1; fi; echo '=====> waiting...'; done
 
-      - name: Integration test without security
-        if: ${{ matrix.secured == 'false'}}
+      - name: Integration test
         run: |
+          export OPENSEARCH_VERSION=${{ matrix.entry.opensearch_version }}
+          export SECURE_INTEGRATION=${{ matrix.secured }}
           make test-integ race=true
-
-      - name: Integration test with security
-        if: ${{ matrix.secured == 'true'}}
-        run: make test-integ-secure
 
       - name: Stop the OpenSearch cluster
         run: |

--- a/.github/workflows/test-integration-unreleased.yml
+++ b/.github/workflows/test-integration-unreleased.yml
@@ -17,7 +17,7 @@ jobs:
         opensearch_ref: [ '1.x', '2.x', 'main' ]
     steps:
       - name: Checkout OpenSearch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: opensearch-project/OpenSearch
           ref: ${{ matrix.entry.opensearch_ref }}
@@ -30,7 +30,7 @@ jobs:
 
       - name: Restore cached build
         id: cache-restore
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: opensearch/distribution/archives/linux-tar/build/distributions
           key: ${{ steps.get-key.outputs.key }}
@@ -42,7 +42,7 @@ jobs:
 
       - name: Save cached build
         if: steps.cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: opensearch/distribution/archives/linux-tar/build/distributions
           key: ${{ steps.get-key.outputs.key }}
@@ -55,13 +55,13 @@ jobs:
           for attempt in {1..20}; do sleep 5; if curl -s localhost:9200; then echo '=====> ready'; break; fi; echo '=====> waiting...'; done
       
       - name: Checkout Go Client
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: go-client
 
       - name: Setup Go
-        uses: actions/setup-go@v3
-        with: { go-version: '1.x' }
+        uses: actions/setup-go@v5
+        with: { go-version-file: 'go-client/go.mod' }
 
       - name: Integration test
         working-directory: go-client
@@ -71,7 +71,7 @@ jobs:
       
       - name: Save server logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: opensearch-logs-${{ matrix.opensearch_ref }}-go-${{ matrix.python-version }}
           path: |

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -10,10 +10,9 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with: { fetch-depth: 1 }
-      - uses: actions/setup-go@v3
-        with: { go-version: '1.x' }
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version-file: 'go.mod' }
       - run: go version
       - name: Increase system limits
         run: |
@@ -39,10 +38,9 @@ jobs:
     env:
       SECURE_INTEGRATION: true
     steps:
-      - uses: actions/checkout@v3
-        with: { fetch-depth: 1 }
-      - uses: actions/setup-go@v3
-        with: { go-version: '1.x' }
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version-file: 'go.mod' }
       - run: go version
       - name: Increase system limits
         run: |

--- a/.github/workflows/test-unit-tip.yml
+++ b/.github/workflows/test-unit-tip.yml
@@ -35,7 +35,6 @@ jobs:
           bash make.bash
           echo "GOROOT=$GOROOT" >> $GITHUB_ENV
           echo "$GOROOT/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@v3
-        with: { fetch-depth: 1 }
+      - uses: actions/checkout@v4
       - run: go version
       - run: make test-unit race=true

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -12,13 +12,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        go: ['1.x']
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
-        with: { fetch-depth: 1 }
-      - uses: actions/setup-go@v3
-        with: { go-version: "${{ matrix.go }}" }
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version-file: 'go.mod' }
       - run: go version
       - run: make test-unit race=true
         if: matrix.os != 'ubuntu-latest'
@@ -34,9 +32,8 @@ jobs:
     name: Benchmarks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with: { fetch-depth: 1 }
-      - uses: actions/setup-go@v3
-        with: { go-version: '1.x' }
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version-file: 'go.mod' }
       - run: go version
       - run: make test-bench

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -136,7 +136,7 @@ issues:
     - EXC0012
     - EXC0014
   exclude-rules:
-    - path: (_test\.go|opensearchapi/internal)
+    - path: (_test\.go|internal/)
       linters:
         - cyclop
         - dupl
@@ -152,7 +152,7 @@ issues:
     - linters:
         - gosec
       text: "TLS InsecureSkipVerify set true"
-      path: _test\.go
+      path: (_test\.go|internal/)
     - linters:
         - gosec
       text: "G108: Profiling endpoint is automatically exposed on /debug/pprof"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Added new struct fields introduced by opensearch 2.12 ([#482](https://github.com/opensearch-project/opensearch-go/pull/482))
 - Adds initial admin password environment variable and CI changes to support 2.12.0 release ([#449](https://github.com/opensearch-project/opensearch-go/pull/449))
+- Adds merge_id field for indices segement request ([#488](https://github.com/opensearch-project/opensearch-go/pull/488))
 ### Changed
+- Updated workflow action versions ([#488](https://github.com/opensearch-project/opensearch-go/pull/488))
+- Changed integration tests to work with secure and unsecure opensearch ([#488](https://github.com/opensearch-project/opensearch-go/pull/488))
+- Moved functions from opensearch/internal/test to internal/test for more general test uses ([#488](https://github.com/opensearch-project/opensearch-go/pull/488))
+- Changed custom_foldername field to pointer as it can be null ([#488](https://github.com/opensearch-project/opensearch-go/pull/488))
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Changed integration tests to work with secure and unsecure opensearch ([#488](https://github.com/opensearch-project/opensearch-go/pull/488))
 - Moved functions from opensearch/internal/test to internal/test for more general test uses ([#488](https://github.com/opensearch-project/opensearch-go/pull/488))
 - Changed custom_foldername field to pointer as it can be null ([#488](https://github.com/opensearch-project/opensearch-go/pull/488))
+- Changed cat indices Primary and Replica field to pointer as it can be null ([#488](https://github.com/opensearch-project/opensearch-go/pull/488))
 ### Deprecated
 ### Removed
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ endif
 ifdef race
 	$(eval testintegargs += "-race")
 endif
-	$(eval testintegargs += "-cover" "-tags='$(testintegtags)'" "-timeout=1h" "./..." "-args" "-test.gocoverdir=$(PWD)/tmp/integration")
+	$(eval testintegargs += "-cover" "-tags=$(testintegtags)" "-timeout=1h" "./..." "-args" "-test.gocoverdir=$(PWD)/tmp/integration")
 	@mkdir -p $(PWD)/tmp/integration
 	@echo "go test -v" $(testintegargs); \
 	go test -v $(testintegargs);
@@ -37,7 +37,7 @@ ifdef coverage
 endif
 
 test-integ-secure: ##Run secure integration tests
-	go test -tags=secure,integration ./opensearch_secure_integration_test.go
+	@SECURE_INTEGRATION=true make test-integ
 
 test-bench:  ## Run benchmarks
 	@printf "\033[2m→ Running benchmarks...\033[0m\n"

--- a/internal/test/helper.go
+++ b/internal/test/helper.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package ostest
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wI2L/jsondiff"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
+)
+
+// NewClient returns an opensearchapi.Client that is adjusted for the wanted test case
+func NewClient() (*opensearchapi.Client, error) {
+	config, err := ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	if config != nil {
+		return opensearchapi.NewClient(*config)
+	}
+	return opensearchapi.NewDefaultClient()
+}
+
+// IsSecure returns true when SECURE_INTEGRATION env is set to true
+func IsSecure() bool {
+	//nolint:gosimple // Getenv returns string not bool, if clause is needed
+	if os.Getenv("SECURE_INTEGRATION") == "true" {
+		return true
+	}
+	return false
+}
+
+// ClientConfig returns an opensearchapi.Config for secure opensearch
+func ClientConfig() (*opensearchapi.Config, error) {
+	if IsSecure() {
+		password, err := GetPassword()
+		if err != nil {
+			return nil, err
+		}
+
+		return &opensearchapi.Config{
+			Client: opensearch.Config{
+				Username:  "admin",
+				Password:  password,
+				Addresses: []string{"https://localhost:9200"},
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				},
+			},
+		}, nil
+	}
+	//nolint:nilnil // easier to test with nil rather then doing complex error handling for tests
+	return nil, nil
+}
+
+// GetPassword returns the password suited for the opensearch version
+func GetPassword() (string, error) {
+	var (
+		major, minor int64
+		err          error
+	)
+	password := "admin"
+	version := os.Getenv("OPENSEARCH_VERSION")
+
+	if version != "latest" && version != "" {
+		major, minor, _, err = opensearch.ParseVersion(version)
+		if err != nil {
+			return "", err
+		}
+		if version == "latest" || major > 2 || (major == 2 && minor >= 12) {
+			password = "myStrongPassword123!"
+		}
+	} else {
+		password = "myStrongPassword123!"
+	}
+	return password, nil
+}
+
+// GetVersion gets cluster info and returns version as int's
+func GetVersion(client *opensearchapi.Client) (int64, int64, int64, error) {
+	resp, err := client.Info(context.Background(), nil)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return opensearch.ParseVersion(resp.Version.Number)
+}
+
+// SkipIfBelowVersion skips a test if the cluster version is below a given version
+func SkipIfBelowVersion(t *testing.T, client *opensearchapi.Client, majorVersion, patchVersion int64, testName string) {
+	t.Helper()
+	major, patch, _, err := GetVersion(client)
+	assert.Nil(t, err)
+	if major <= majorVersion && patch <= patchVersion {
+		t.Skipf("Skiping %s as version %d.%d.x does not support this endpoint", testName, major, patch)
+	}
+}
+
+// SkipIfNotSecure skips a test runs against an unsecure cluster
+func SkipIfNotSecure(t *testing.T) {
+	t.Helper()
+	if !IsSecure() {
+		t.Skipf("Skiping %s as it needs a secured cluster", t.Name())
+	}
+}
+
+// CompareRawJSONwithParsedJSON is a helper function to determin the difference between the parsed JSON and the raw JSON
+// this is helpful to detect missing fields in the go structs
+func CompareRawJSONwithParsedJSON(t *testing.T, resp any, rawResp *opensearch.Response) {
+	t.Helper()
+	if _, ok := os.LookupEnv("OPENSEARCH_GO_SKIP_JSON_COMPARE"); ok {
+		return
+	}
+	require.NotNil(t, rawResp)
+
+	parsedBody, err := json.Marshal(resp)
+	require.Nil(t, err)
+
+	body, err := io.ReadAll(rawResp.Body)
+	require.Nil(t, err)
+
+	// If the parsedBody and body does not match, then we need to check if we are adding or removing fields
+	if string(parsedBody) != string(body) {
+		patch, err := jsondiff.CompareJSON(body, parsedBody)
+		assert.Nil(t, err)
+		operations := make([]jsondiff.Operation, 0)
+		for _, operation := range patch {
+			// different opensearch version added more field, only check if we miss some fields
+			if operation.Type != "add" {
+				operations = append(operations, operation)
+			}
+		}
+		assert.Empty(t, operations)
+		if len(operations) == 0 {
+			return
+		}
+		for _, op := range operations {
+			fmt.Printf("%s\n", op)
+		}
+		fmt.Printf("%s\n", body)
+	}
+}

--- a/opensearch_secure_integration_test.go
+++ b/opensearch_secure_integration_test.go
@@ -19,54 +19,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration && secure
+//go:build integration
 
 package opensearch_test
 
 import (
 	"context"
-	"crypto/tls"
-	"errors"
 	"log"
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/opensearch-project/opensearch-go/v3"
-	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 )
-
-func getSecuredClient() (*opensearchapi.Client, error) {
-	errs := make([]error, 0)
-	for _, password := range []string{"admin", "myStrongPassword123!"} {
-		client, _ := opensearchapi.NewClient(
-			opensearchapi.Config{
-				Client: opensearch.Config{
-					Username:  "admin",
-					Password:  password,
-					Addresses: []string{"https://localhost:9200"},
-					Transport: &http.Transport{
-						TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-					},
-				},
-			},
-		)
-		_, err := client.Info(nil, nil)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-		return client, nil
-	}
-	return nil, errors.Join(errs...)
-
-}
 
 func TestSecuredClientAPI(t *testing.T) {
 	t.Run("Check Info", func(t *testing.T) {
 		ctx := context.Background()
-		client, err := getSecuredClient()
+		client, err := ostest.NewClient()
 		if err != nil {
 			log.Fatalf("Error creating the client: %s\n", err)
 		}

--- a/opensearchapi/api_aliases_test.go
+++ b/opensearchapi/api_aliases_test.go
@@ -14,13 +14,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestAliases(t *testing.T) {
 	t.Run("Aliases", func(t *testing.T) {
-		client, err := opensearchapi.NewDefaultClient()
+		client, err := ostest.NewClient()
 		require.Nil(t, err)
 
 		index := "test-aliases"
@@ -41,7 +42,7 @@ func TestAliases(t *testing.T) {
 			require.Nil(t, err)
 			require.NotEmpty(t, resp)
 			require.NotEmpty(t, resp.Inspect().Response)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 
 		t.Run("inspect", func(t *testing.T) {

--- a/opensearchapi/api_bulk_test.go
+++ b/opensearchapi/api_bulk_test.go
@@ -16,12 +16,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestBulkClient(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 
 	index := "test-bulk"
@@ -58,7 +59,7 @@ func TestBulkClient(t *testing.T) {
 			)
 			require.Nil(t, err)
 			assert.NotEmpty(t, res)
-			osapitest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
 		})
 	}
 	t.Run("inspect", func(t *testing.T) {

--- a/opensearchapi/api_cat-indices.go
+++ b/opensearchapi/api_cat-indices.go
@@ -51,8 +51,8 @@ type CatIndexResp struct {
 	Status             string `json:"status"`
 	Index              string `json:"index"`
 	UUID               string `json:"uuid"`
-	Primary            int    `json:"pri,string"`
-	Replica            int    `json:"rep,string"`
+	Primary            *int   `json:"pri,string"`
+	Replica            *int   `json:"rep,string"`
 	DocsCount          *int   `json:"docs.count,string"`
 	DocDeleted         *int   `json:"docs.deleted,string"`
 	CreationDate       int    `json:"creation.date,string"`

--- a/opensearchapi/api_cat_test.go
+++ b/opensearchapi/api_cat_test.go
@@ -15,12 +15,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestCatClient(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 	failingClient, err := osapitest.CreateFailingClient()
 	require.Nil(t, err)
@@ -365,7 +366,7 @@ func TestCatClient(t *testing.T) {
 	for catType, value := range testCases {
 		t.Run(catType, func(t *testing.T) {
 			if catType == "ClusterManager" {
-				osapitest.SkipIfBelowVersion(t, client, 1, 3, catType)
+				ostest.SkipIfBelowVersion(t, client, 1, 3, catType)
 			}
 			for _, testCase := range value {
 				t.Run(testCase.Name, func(t *testing.T) {
@@ -389,124 +390,124 @@ func TestCatClient(t *testing.T) {
 			resp, err := client.Cat.Aliases(nil, nil)
 			assert.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Aliases, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Aliases, resp.Inspect().Response)
 		})
 		t.Run("Allocation", func(t *testing.T) {
 			resp, err := client.Cat.Allocation(nil, nil)
 			assert.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Allocations, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Allocations, resp.Inspect().Response)
 		})
 		t.Run("ClusterManager", func(t *testing.T) {
-			osapitest.SkipIfBelowVersion(t, client, 1, 3, "ClusterManager")
+			ostest.SkipIfBelowVersion(t, client, 1, 3, "ClusterManager")
 			resp, err := client.Cat.ClusterManager(nil, nil)
 			assert.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.ClusterManagers, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.ClusterManagers, resp.Inspect().Response)
 		})
 		t.Run("Count", func(t *testing.T) {
 			resp, err := client.Cat.Count(nil, nil)
 			assert.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Counts, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Counts, resp.Inspect().Response)
 		})
 		t.Run("FieldData", func(t *testing.T) {
 			resp, err := client.Cat.FieldData(nil, nil)
 			assert.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.FieldData, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.FieldData, resp.Inspect().Response)
 		})
 		t.Run("Health", func(t *testing.T) {
 			resp, err := client.Cat.Health(nil, nil)
 			assert.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Health, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Health, resp.Inspect().Response)
 		})
 		t.Run("Indices", func(t *testing.T) {
 			resp, err := client.Cat.Indices(nil, &opensearchapi.CatIndicesReq{Params: opensearchapi.CatIndicesParams{H: []string{"*"}}})
 			assert.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Indices, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Indices, resp.Inspect().Response)
 		})
 		t.Run("Master", func(t *testing.T) {
 			resp, err := client.Cat.Master(nil, nil)
 			assert.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Master, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Master, resp.Inspect().Response)
 		})
 		t.Run("NodeAttrs", func(t *testing.T) {
 			resp, err := client.Cat.NodeAttrs(nil, &opensearchapi.CatNodeAttrsReq{Params: opensearchapi.CatNodeAttrsParams{H: []string{"*"}}})
 			assert.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.NodeAttrs, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.NodeAttrs, resp.Inspect().Response)
 		})
 		t.Run("Nodes", func(t *testing.T) {
 			resp, err := client.Cat.Nodes(nil, &opensearchapi.CatNodesReq{Params: opensearchapi.CatNodesParams{H: []string{"*"}}})
 			assert.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Nodes, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Nodes, resp.Inspect().Response)
 		})
 		t.Run("PendingTasks", func(t *testing.T) {
 			resp, err := client.Cat.PendingTasks(nil, nil)
 			assert.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.PendingTasks, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.PendingTasks, resp.Inspect().Response)
 		})
 		t.Run("Plugins", func(t *testing.T) {
 			resp, err := client.Cat.Plugins(nil, nil)
 			assert.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Plugins, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Plugins, resp.Inspect().Response)
 		})
 		t.Run("Recovery", func(t *testing.T) {
 			resp, err := client.Cat.Recovery(nil, &opensearchapi.CatRecoveryReq{Params: opensearchapi.CatRecoveryParams{H: []string{"*"}}})
 			assert.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Recovery, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Recovery, resp.Inspect().Response)
 		})
 		t.Run("Repositories", func(t *testing.T) {
 			resp, err := client.Cat.Repositories(nil, nil)
 			assert.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Repositories, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Repositories, resp.Inspect().Response)
 		})
 		t.Run("Segments", func(t *testing.T) {
 			resp, err := client.Cat.Segments(nil, &opensearchapi.CatSegmentsReq{Params: opensearchapi.CatSegmentsParams{H: []string{"*"}}})
 			assert.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Segments, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Segments, resp.Inspect().Response)
 		})
 		t.Run("Shards", func(t *testing.T) {
 			resp, err := client.Cat.Shards(nil, &opensearchapi.CatShardsReq{Params: opensearchapi.CatShardsParams{H: []string{"*"}}})
 			assert.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Shards, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Shards, resp.Inspect().Response)
 		})
 		/* Need to create Snapshot + Repo
 		t.Run("Snapshots", func(t *testing.T) {
 			resp, err := client.Cat.Snapshots(nil, &opensearchapi.CatSnapshotsReq{Repository: snapshotRepo, Params: opensearchapi.CatSnapshotsParams{H: []string{"*"}}})
 			assert.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Snapshots, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Snapshots, resp.Inspect().Response)
 		})
 		*/
 		t.Run("Tasks", func(t *testing.T) {
 			resp, err := client.Cat.Tasks(nil, &opensearchapi.CatTasksReq{Params: opensearchapi.CatTasksParams{H: []string{"*"}}})
 			assert.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Tasks, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Tasks, resp.Inspect().Response)
 		})
 		t.Run("Templates", func(t *testing.T) {
 			resp, err := client.Cat.Templates(nil, nil)
 			assert.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Templates, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Templates, resp.Inspect().Response)
 		})
 		t.Run("ThreadPool", func(t *testing.T) {
 			resp, err := client.Cat.ThreadPool(nil, &opensearchapi.CatThreadPoolReq{Params: opensearchapi.CatThreadPoolParams{H: []string{"*"}}})
 			assert.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.ThreadPool, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.ThreadPool, resp.Inspect().Response)
 		})
 	})
 }

--- a/opensearchapi/api_cluster-stats.go
+++ b/opensearchapi/api_cluster-stats.go
@@ -254,7 +254,7 @@ type ClusterStatsNodes struct {
 		JavaVersion         string   `json:"java_version"`
 		Description         string   `json:"description"`
 		Classname           string   `json:"classname"`
-		CustomFoldername    string   `json:"custom_foldername"`
+		CustomFoldername    *string  `json:"custom_foldername"`
 		ExtendedPlugins     []string `json:"extended_plugins"`
 		HasNativeController bool     `json:"has_native_controller"`
 	} `json:"plugins"`

--- a/opensearchapi/api_cluster_test.go
+++ b/opensearchapi/api_cluster_test.go
@@ -15,12 +15,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestClusterClient(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 	failingClient, err := osapitest.CreateFailingClient()
 	require.Nil(t, err)
@@ -229,7 +230,7 @@ func TestClusterClient(t *testing.T) {
 	for catType, value := range testCases {
 		t.Run(catType, func(t *testing.T) {
 			if strings.Contains(catType, "Decommission") {
-				osapitest.SkipIfBelowVersion(t, client, 2, 3, catType)
+				ostest.SkipIfBelowVersion(t, client, 2, 3, catType)
 			}
 			for _, testCase := range value {
 				t.Run(testCase.Name, func(t *testing.T) {
@@ -242,7 +243,7 @@ func TestClusterClient(t *testing.T) {
 						assert.Nil(t, err)
 						assert.NotNil(t, res)
 						assert.NotNil(t, res.Inspect().Response)
-						osapitest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+						ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
 					}
 				})
 			}

--- a/opensearchapi/api_component_template_test.go
+++ b/opensearchapi/api_component_template_test.go
@@ -15,12 +15,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestComponentTemplateClient(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 	failingClient, err := osapitest.CreateFailingClient()
 	require.Nil(t, err)
@@ -83,10 +84,10 @@ func TestComponentTemplateClient(t *testing.T) {
 					Name: "with request",
 					Results: func() (osapitest.Response, error) {
 						var (
-							resp dummyInspect
+							resp osapitest.DummyInspect
 							err  error
 						)
-						resp.response, err = client.ComponentTemplate.Exists(nil, opensearchapi.ComponentTemplateExistsReq{ComponentTemplate: componentTemplate})
+						resp.Response, err = client.ComponentTemplate.Exists(nil, opensearchapi.ComponentTemplateExistsReq{ComponentTemplate: componentTemplate})
 						return resp, err
 					},
 				},
@@ -94,10 +95,10 @@ func TestComponentTemplateClient(t *testing.T) {
 					Name: "inspect",
 					Results: func() (osapitest.Response, error) {
 						var (
-							resp dummyInspect
+							resp osapitest.DummyInspect
 							err  error
 						)
-						resp.response, err = failingClient.ComponentTemplate.Exists(nil, opensearchapi.ComponentTemplateExistsReq{ComponentTemplate: componentTemplate})
+						resp.Response, err = failingClient.ComponentTemplate.Exists(nil, opensearchapi.ComponentTemplateExistsReq{ComponentTemplate: componentTemplate})
 						return resp, err
 					},
 				},
@@ -135,7 +136,7 @@ func TestComponentTemplateClient(t *testing.T) {
 						require.NotNil(t, res)
 						assert.NotNil(t, res.Inspect().Response)
 						if value.Name != "Exists" {
-							osapitest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+							ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
 						}
 					}
 				})

--- a/opensearchapi/api_dangling_test.go
+++ b/opensearchapi/api_dangling_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/opensearch-project/opensearch-go/v3"
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
@@ -172,7 +173,7 @@ func TestDanglingClient(t *testing.T) {
 			resp, err := client.Dangling.Get(nil, nil)
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Delete", func(t *testing.T) {
 			resp, err := client.Dangling.Delete(
@@ -184,7 +185,7 @@ func TestDanglingClient(t *testing.T) {
 			)
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Import", func(t *testing.T) {
 			resp, err := client.Dangling.Import(
@@ -196,7 +197,7 @@ func TestDanglingClient(t *testing.T) {
 			)
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 	})
 }

--- a/opensearchapi/api_datastream_test.go
+++ b/opensearchapi/api_datastream_test.go
@@ -15,12 +15,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestDataStreamClient(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 	failingClient, err := osapitest.CreateFailingClient()
 	require.Nil(t, err)
@@ -127,7 +128,7 @@ func TestDataStreamClient(t *testing.T) {
 						require.Nil(t, err)
 						require.NotNil(t, res)
 						assert.NotNil(t, res.Inspect().Response)
-						osapitest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+						ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
 					}
 				})
 			}

--- a/opensearchapi/api_document_test.go
+++ b/opensearchapi/api_document_test.go
@@ -17,13 +17,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchutil"
 )
 
 func TestDocumentClient(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 	failingClient, err := osapitest.CreateFailingClient()
 	require.Nil(t, err)
@@ -87,10 +88,10 @@ func TestDocumentClient(t *testing.T) {
 					Name: "with request",
 					Results: func() (osapitest.Response, error) {
 						var (
-							resp dummyInspect
+							resp osapitest.DummyInspect
 							err  error
 						)
-						resp.response, err = client.Document.Exists(nil, opensearchapi.DocumentExistsReq{Index: index, DocumentID: documentID})
+						resp.Response, err = client.Document.Exists(nil, opensearchapi.DocumentExistsReq{Index: index, DocumentID: documentID})
 						return resp, err
 					},
 				},
@@ -98,10 +99,10 @@ func TestDocumentClient(t *testing.T) {
 					Name: "inspect",
 					Results: func() (osapitest.Response, error) {
 						var (
-							resp dummyInspect
+							resp osapitest.DummyInspect
 							err  error
 						)
-						resp.response, err = failingClient.Document.Exists(nil, opensearchapi.DocumentExistsReq{Index: index, DocumentID: documentID})
+						resp.Response, err = failingClient.Document.Exists(nil, opensearchapi.DocumentExistsReq{Index: index, DocumentID: documentID})
 						return resp, err
 					},
 				},
@@ -114,10 +115,10 @@ func TestDocumentClient(t *testing.T) {
 					Name: "with request",
 					Results: func() (osapitest.Response, error) {
 						var (
-							resp dummyInspect
+							resp osapitest.DummyInspect
 							err  error
 						)
-						resp.response, err = client.Document.ExistsSource(nil, opensearchapi.DocumentExistsSourceReq{Index: index, DocumentID: documentID})
+						resp.Response, err = client.Document.ExistsSource(nil, opensearchapi.DocumentExistsSourceReq{Index: index, DocumentID: documentID})
 						return resp, err
 					},
 				},
@@ -125,10 +126,10 @@ func TestDocumentClient(t *testing.T) {
 					Name: "inspect",
 					Results: func() (osapitest.Response, error) {
 						var (
-							resp dummyInspect
+							resp osapitest.DummyInspect
 							err  error
 						)
-						resp.response, err = failingClient.Document.ExistsSource(nil, opensearchapi.DocumentExistsSourceReq{Index: index, DocumentID: documentID})
+						resp.Response, err = failingClient.Document.ExistsSource(nil, opensearchapi.DocumentExistsSourceReq{Index: index, DocumentID: documentID})
 						return resp, err
 					},
 				},
@@ -362,7 +363,7 @@ func TestDocumentClient(t *testing.T) {
 						require.NotNil(t, res)
 						assert.NotNil(t, res.Inspect().Response)
 						if !strings.Contains(value.Name, "Exists") && value.Name != "Source" {
-							osapitest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+							ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
 						}
 					}
 				})
@@ -390,7 +391,7 @@ func TestDocumentClient(t *testing.T) {
 			require.Nil(t, err)
 			require.NotNil(t, res)
 			assert.NotNil(t, res.Inspect().Response)
-			osapitest.CompareRawJSONwithParsedJSON(t, res.Source, res.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, res.Source, res.Inspect().Response)
 		})
 	})
 }

--- a/opensearchapi/api_index_template_test.go
+++ b/opensearchapi/api_index_template_test.go
@@ -15,12 +15,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestIndexTemplateClient(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 	failingClient, err := osapitest.CreateFailingClient()
 	require.Nil(t, err)
@@ -83,10 +84,10 @@ func TestIndexTemplateClient(t *testing.T) {
 					Name: "with request",
 					Results: func() (osapitest.Response, error) {
 						var (
-							resp dummyInspect
+							resp osapitest.DummyInspect
 							err  error
 						)
-						resp.response, err = client.IndexTemplate.Exists(nil, opensearchapi.IndexTemplateExistsReq{IndexTemplate: indexTemplate})
+						resp.Response, err = client.IndexTemplate.Exists(nil, opensearchapi.IndexTemplateExistsReq{IndexTemplate: indexTemplate})
 						return resp, err
 					},
 				},
@@ -94,10 +95,10 @@ func TestIndexTemplateClient(t *testing.T) {
 					Name: "inspect",
 					Results: func() (osapitest.Response, error) {
 						var (
-							resp dummyInspect
+							resp osapitest.DummyInspect
 							err  error
 						)
-						resp.response, err = failingClient.IndexTemplate.Exists(nil, opensearchapi.IndexTemplateExistsReq{IndexTemplate: indexTemplate})
+						resp.Response, err = failingClient.IndexTemplate.Exists(nil, opensearchapi.IndexTemplateExistsReq{IndexTemplate: indexTemplate})
 						return resp, err
 					},
 				},
@@ -179,7 +180,7 @@ func TestIndexTemplateClient(t *testing.T) {
 						require.NotNil(t, res)
 						assert.NotNil(t, res.Inspect().Response)
 						if value.Name != "Exists" {
-							osapitest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+							ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
 						}
 					}
 				})

--- a/opensearchapi/api_index_test.go
+++ b/opensearchapi/api_index_test.go
@@ -17,12 +17,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestIndexClient(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 
 	index := "test-index-test"
@@ -60,7 +61,7 @@ func TestIndexClient(t *testing.T) {
 			resp, err := client.Index(nil, opensearchapi.IndexReq{Index: index, Body: body, DocumentID: "test"})
 			require.Nil(t, err)
 			require.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 			assert.Equal(t, result, resp.Result)
 		}
 	})
@@ -70,7 +71,7 @@ func TestIndexClient(t *testing.T) {
 		resp, err := client.Index(nil, opensearchapi.IndexReq{Index: index, Body: body})
 		require.Nil(t, err)
 		require.NotNil(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		assert.Equal(t, index, resp.Index)
 		assert.Equal(t, "created", resp.Result)
 	})

--- a/opensearchapi/api_indices-segments.go
+++ b/opensearchapi/api_indices-segments.go
@@ -82,6 +82,7 @@ type IndicesSegmentsDetails struct {
 	Search        bool   `json:"search"`
 	Version       string `json:"version"`
 	Compound      bool   `json:"compound"`
+	MergeID       string `json:"merge_id"`
 	Sort          []struct {
 		Field   string `json:"field"`
 		Mode    string `json:"mode"`

--- a/opensearchapi/api_indices_test.go
+++ b/opensearchapi/api_indices_test.go
@@ -15,21 +15,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/opensearch-project/opensearch-go/v3"
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
-type dummyInspect struct {
-	response *opensearch.Response
-}
-
-func (r dummyInspect) Inspect() opensearchapi.Inspect {
-	return opensearchapi.Inspect{Response: r.response}
-}
-
 func TestIndicesClient(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 	failingClient, err := osapitest.CreateFailingClient()
 	require.Nil(t, err)
@@ -83,10 +75,10 @@ func TestIndicesClient(t *testing.T) {
 					Name: "with request",
 					Results: func() (osapitest.Response, error) {
 						var (
-							resp dummyInspect
+							resp osapitest.DummyInspect
 							err  error
 						)
-						resp.response, err = client.Indices.Exists(nil, opensearchapi.IndicesExistsReq{Indices: []string{index}})
+						resp.Response, err = client.Indices.Exists(nil, opensearchapi.IndicesExistsReq{Indices: []string{index}})
 						return resp, err
 					},
 				},
@@ -94,10 +86,10 @@ func TestIndicesClient(t *testing.T) {
 					Name: "inspect",
 					Results: func() (osapitest.Response, error) {
 						var (
-							resp dummyInspect
+							resp osapitest.DummyInspect
 							err  error
 						)
-						resp.response, err = failingClient.Indices.Exists(nil, opensearchapi.IndicesExistsReq{Indices: []string{index}})
+						resp.Response, err = failingClient.Indices.Exists(nil, opensearchapi.IndicesExistsReq{Indices: []string{index}})
 						return resp, err
 					},
 				},
@@ -201,10 +193,10 @@ func TestIndicesClient(t *testing.T) {
 					Name: "with request",
 					Results: func() (osapitest.Response, error) {
 						var (
-							resp dummyInspect
+							resp osapitest.DummyInspect
 							err  error
 						)
-						resp.response, err = client.Indices.Alias.Exists(nil, opensearchapi.AliasExistsReq{Indices: []string{index}, Alias: []string{alias}})
+						resp.Response, err = client.Indices.Alias.Exists(nil, opensearchapi.AliasExistsReq{Indices: []string{index}, Alias: []string{alias}})
 						return resp, err
 					},
 				},
@@ -212,10 +204,10 @@ func TestIndicesClient(t *testing.T) {
 					Name: "inspect",
 					Results: func() (osapitest.Response, error) {
 						var (
-							resp dummyInspect
+							resp osapitest.DummyInspect
 							err  error
 						)
-						resp.response, err = failingClient.Indices.Alias.Exists(nil, opensearchapi.AliasExistsReq{Indices: []string{index}, Alias: []string{alias}})
+						resp.Response, err = failingClient.Indices.Alias.Exists(nil, opensearchapi.AliasExistsReq{Indices: []string{index}, Alias: []string{alias}})
 						return resp, err
 					},
 				},
@@ -711,97 +703,97 @@ func TestIndicesClient(t *testing.T) {
 			resp, err := client.Indices.Create(nil, opensearchapi.IndicesCreateReq{Index: index})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Block", func(t *testing.T) {
 			resp, err := client.Indices.Block(nil, opensearchapi.IndicesBlockReq{Indices: []string{index}, Block: "write"})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Analyze", func(t *testing.T) {
 			resp, err := client.Indices.Analyze(nil, opensearchapi.IndicesAnalyzeReq{Body: opensearchapi.IndicesAnalyzeBody{Text: []string{"test"}, Analyzer: "standard", Explain: true}})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("ClearCache", func(t *testing.T) {
 			resp, err := client.Indices.ClearCache(nil, &opensearchapi.IndicesClearCacheReq{Indices: []string{index}})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Alias Put", func(t *testing.T) {
 			resp, err := client.Indices.Alias.Put(nil, opensearchapi.AliasPutReq{Indices: []string{index}, Alias: alias})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Alias Get", func(t *testing.T) {
 			resp, err := client.Indices.Alias.Get(nil, opensearchapi.AliasGetReq{Indices: []string{index}})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Indices, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Indices, resp.Inspect().Response)
 		})
 		t.Run("Rollover", func(t *testing.T) {
 			resp, err := client.Indices.Rollover(nil, opensearchapi.IndicesRolloverReq{Alias: alias, Index: indexRollover})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Alias Delete", func(t *testing.T) {
 			resp, err := client.Indices.Alias.Delete(nil, opensearchapi.AliasDeleteReq{Indices: []string{indexRollover}, Alias: []string{alias}})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Mapping Put", func(t *testing.T) {
 			resp, err := client.Indices.Mapping.Put(nil, opensearchapi.MappingPutReq{Indices: []string{index}, Body: strings.NewReader(`{"properties":{"test":{"type":"text"}}}`)})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Mapping Get", func(t *testing.T) {
 			resp, err := client.Indices.Mapping.Get(nil, &opensearchapi.MappingGetReq{Indices: []string{index}})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Indices, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Indices, resp.Inspect().Response)
 		})
 		t.Run("Mapping Field", func(t *testing.T) {
 			resp, err := client.Indices.Mapping.Field(nil, &opensearchapi.MappingFieldReq{Fields: []string{"*"}})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Indices, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Indices, resp.Inspect().Response)
 		})
 		t.Run("Settings Put", func(t *testing.T) {
 			resp, err := client.Indices.Settings.Put(nil, opensearchapi.SettingsPutReq{Indices: []string{index}, Body: strings.NewReader(`{"number_of_replicas":1}`)})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Settings Get", func(t *testing.T) {
 			resp, err := client.Indices.Settings.Get(nil, &opensearchapi.SettingsGetReq{Indices: []string{index}})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Indices, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Indices, resp.Inspect().Response)
 		})
 		t.Run("Flush", func(t *testing.T) {
 			resp, err := client.Indices.Flush(nil, &opensearchapi.IndicesFlushReq{Indices: []string{index}})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Forcemerge", func(t *testing.T) {
 			resp, err := client.Indices.Forcemerge(nil, &opensearchapi.IndicesForcemergeReq{Indices: []string{index}})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Clone", func(t *testing.T) {
 			resp, err := client.Indices.Clone(nil, opensearchapi.IndicesCloneReq{Index: index, Target: indexClone})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Split", func(t *testing.T) {
 			resp, err := client.Indices.Split(
@@ -814,7 +806,7 @@ func TestIndicesClient(t *testing.T) {
 			)
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Shrink", func(t *testing.T) {
 			resp, err := client.Indices.Shrink(
@@ -827,43 +819,43 @@ func TestIndicesClient(t *testing.T) {
 			)
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Get", func(t *testing.T) {
 			resp, err := client.Indices.Get(nil, opensearchapi.IndicesGetReq{Indices: []string{index, indexClone}})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Indices, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Indices, resp.Inspect().Response)
 		})
 		t.Run("Recovery", func(t *testing.T) {
 			resp, err := client.Indices.Recovery(nil, &opensearchapi.IndicesRecoveryReq{Indices: []string{index}})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Indices, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Indices, resp.Inspect().Response)
 		})
 		t.Run("Refresh", func(t *testing.T) {
 			resp, err := client.Indices.Refresh(nil, &opensearchapi.IndicesRefreshReq{Indices: []string{index}})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Segments", func(t *testing.T) {
 			resp, err := client.Indices.Segments(nil, nil)
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("ShardStores", func(t *testing.T) {
 			resp, err := client.Indices.ShardStores(nil, nil)
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Stats", func(t *testing.T) {
 			resp, err := client.Indices.Stats(nil, nil)
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("ValidateQuery", func(t *testing.T) {
 			resp, err := client.Indices.ValidateQuery(
@@ -877,13 +869,13 @@ func TestIndicesClient(t *testing.T) {
 			)
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Count", func(t *testing.T) {
 			resp, err := client.Indices.Count(nil, nil)
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("FieldCaps", func(t *testing.T) {
 			resp, err := client.Indices.FieldCaps(
@@ -894,31 +886,31 @@ func TestIndicesClient(t *testing.T) {
 			)
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Resolve", func(t *testing.T) {
 			resp, err := client.Indices.Resolve(nil, opensearchapi.IndicesResolveReq{Indices: []string{"*"}})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Close", func(t *testing.T) {
 			resp, err := client.Indices.Close(nil, opensearchapi.IndicesCloseReq{Index: index})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Open", func(t *testing.T) {
 			resp, err := client.Indices.Open(nil, opensearchapi.IndicesOpenReq{Index: index})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Delete", func(t *testing.T) {
 			resp, err := client.Indices.Delete(nil, opensearchapi.IndicesDeleteReq{Indices: testIndices})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 	})
 }

--- a/opensearchapi/api_info_test.go
+++ b/opensearchapi/api_info_test.go
@@ -14,25 +14,26 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestInfo(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 	t.Run("with nil request", func(t *testing.T) {
 		resp, err := client.Info(nil, nil)
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 	})
 
 	t.Run("with request", func(t *testing.T) {
 		resp, err := client.Info(nil, &opensearchapi.InfoReq{})
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 	})
 
 	t.Run("inspect", func(t *testing.T) {

--- a/opensearchapi/api_ingest_test.go
+++ b/opensearchapi/api_ingest_test.go
@@ -15,12 +15,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestIngestClient(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 	failingClient, err := osapitest.CreateFailingClient()
 	require.Nil(t, err)
@@ -149,7 +150,7 @@ func TestIngestClient(t *testing.T) {
 						require.NotNil(t, res)
 						assert.NotNil(t, res.Inspect().Response)
 						if value.Name != "Get" {
-							osapitest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+							ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
 						}
 					}
 				})
@@ -174,7 +175,7 @@ func TestIngestClient(t *testing.T) {
 			require.Nil(t, err)
 			require.NotNil(t, resp)
 			require.NotNil(t, resp.Inspect().Response)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Pipelines, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Pipelines, resp.Inspect().Response)
 		})
 	})
 }

--- a/opensearchapi/api_mget_test.go
+++ b/opensearchapi/api_mget_test.go
@@ -16,12 +16,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestMGet(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 
 	testIndex := "test-mget"
@@ -52,7 +53,7 @@ func TestMGet(t *testing.T) {
 		)
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 	})
 
 	t.Run("inspect", func(t *testing.T) {

--- a/opensearchapi/api_msearch-template_test.go
+++ b/opensearchapi/api_msearch-template_test.go
@@ -16,12 +16,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestMSearchTemplate(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 
 	testIndex := "test-msearch"
@@ -52,7 +53,7 @@ func TestMSearchTemplate(t *testing.T) {
 		)
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 	})
 
 	t.Run("inspect", func(t *testing.T) {

--- a/opensearchapi/api_msearch_test.go
+++ b/opensearchapi/api_msearch_test.go
@@ -16,12 +16,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestMSearch(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 
 	testIndex := "test-msearch"
@@ -52,7 +53,7 @@ func TestMSearch(t *testing.T) {
 		)
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 	})
 
 	t.Run("inspect", func(t *testing.T) {

--- a/opensearchapi/api_mtermvectors_test.go
+++ b/opensearchapi/api_mtermvectors_test.go
@@ -16,12 +16,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestMTermvectors(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 
 	testIndex := "test-mtermvectors"
@@ -94,7 +95,7 @@ func TestMTermvectors(t *testing.T) {
 		)
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 	})
 
 	t.Run("inspect", func(t *testing.T) {

--- a/opensearchapi/api_nodes-info.go
+++ b/opensearchapi/api_nodes-info.go
@@ -167,7 +167,7 @@ type NodesInfoPlugin struct {
 	JavaVersion         string   `json:"java_version"`
 	Description         string   `json:"description"`
 	Classname           string   `json:"classname"`
-	CustomFoldername    string   `json:"custom_foldername"`
+	CustomFoldername    *string  `json:"custom_foldername"`
 	ExtendedPlugins     []string `json:"extended_plugins"`
 	HasNativeController bool     `json:"has_native_controller"`
 }

--- a/opensearchapi/api_nodes_test.go
+++ b/opensearchapi/api_nodes_test.go
@@ -14,12 +14,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestNodes(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 	failingClient, err := osapitest.CreateFailingClient()
 	require.Nil(t, err)
@@ -86,10 +87,10 @@ func TestNodes(t *testing.T) {
 					Name: "without request",
 					Results: func() (osapitest.Response, error) {
 						var (
-							resp dummyInspect
+							resp osapitest.DummyInspect
 							err  error
 						)
-						resp.response, err = client.Nodes.HotThreads(nil, nil)
+						resp.Response, err = client.Nodes.HotThreads(nil, nil)
 						return resp, err
 					},
 				},
@@ -97,10 +98,10 @@ func TestNodes(t *testing.T) {
 					Name: "with request",
 					Results: func() (osapitest.Response, error) {
 						var (
-							resp dummyInspect
+							resp osapitest.DummyInspect
 							err  error
 						)
-						resp.response, err = client.Nodes.HotThreads(nil, &opensearchapi.NodesHotThreadsReq{NodeID: []string{"*"}})
+						resp.Response, err = client.Nodes.HotThreads(nil, &opensearchapi.NodesHotThreadsReq{NodeID: []string{"*"}})
 						return resp, err
 					},
 				},
@@ -108,10 +109,10 @@ func TestNodes(t *testing.T) {
 					Name: "inspect",
 					Results: func() (osapitest.Response, error) {
 						var (
-							resp dummyInspect
+							resp osapitest.DummyInspect
 							err  error
 						)
-						resp.response, err = failingClient.Nodes.HotThreads(nil, nil)
+						resp.Response, err = failingClient.Nodes.HotThreads(nil, nil)
 						return resp, err
 					},
 				},
@@ -178,7 +179,7 @@ func TestNodes(t *testing.T) {
 						require.NotNil(t, res)
 						assert.NotNil(t, res.Inspect().Response)
 						if value.Name != "HotThreads" {
-							osapitest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+							ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
 						}
 					}
 				})

--- a/opensearchapi/api_ping_test.go
+++ b/opensearchapi/api_ping_test.go
@@ -14,12 +14,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestPing(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 
 	t.Run("with nil request", func(t *testing.T) {
@@ -39,9 +40,9 @@ func TestPing(t *testing.T) {
 		require.Nil(t, err)
 
 		var (
-			resp dummyInspect
+			resp osapitest.DummyInspect
 		)
-		resp.response, err = failingClient.Ping(nil, nil)
+		resp.Response, err = failingClient.Ping(nil, nil)
 		assert.NotNil(t, err)
 		assert.NotNil(t, resp)
 		osapitest.VerifyInspect(t, resp.Inspect())

--- a/opensearchapi/api_point_in_time_test.go
+++ b/opensearchapi/api_point_in_time_test.go
@@ -15,14 +15,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestPointInTimeClient(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
-	osapitest.SkipIfBelowVersion(t, client, 2, 4, "Point_In_Time")
+	ostest.SkipIfBelowVersion(t, client, 2, 4, "Point_In_Time")
 	failingClient, err := osapitest.CreateFailingClient()
 	require.Nil(t, err)
 
@@ -111,7 +112,7 @@ func TestPointInTimeClient(t *testing.T) {
 						require.Nil(t, err)
 						require.NotNil(t, res)
 						assert.NotNil(t, res.Inspect().Response)
-						osapitest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+						ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
 					}
 				})
 			}

--- a/opensearchapi/api_rank_eval_test.go
+++ b/opensearchapi/api_rank_eval_test.go
@@ -16,12 +16,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestRankEval(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 
 	testIndex := "test-rank_eval"
@@ -52,7 +53,7 @@ func TestRankEval(t *testing.T) {
 		)
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 	})
 
 	t.Run("inspect", func(t *testing.T) {

--- a/opensearchapi/api_reindex_rethrottle_test.go
+++ b/opensearchapi/api_reindex_rethrottle_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchutil"
@@ -25,7 +26,7 @@ import (
 
 func TestReindexRethrottle(t *testing.T) {
 	t.Parallel()
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 
 	sourceIndex := "test-reindex-rethrottle-source"
@@ -90,7 +91,7 @@ func TestReindexRethrottle(t *testing.T) {
 		)
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 	})
 
 	t.Run("inspect", func(t *testing.T) {

--- a/opensearchapi/api_reindex_test.go
+++ b/opensearchapi/api_reindex_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchutil"
@@ -25,7 +26,7 @@ import (
 
 func TestReindex(t *testing.T) {
 	t.Parallel()
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 
 	sourceIndex := "test-reindex-source"
@@ -79,7 +80,7 @@ func TestReindex(t *testing.T) {
 		)
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 	})
 
 	t.Run("with request but dont wait", func(t *testing.T) {
@@ -92,7 +93,7 @@ func TestReindex(t *testing.T) {
 		)
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 	})
 
 	t.Run("inspect", func(t *testing.T) {

--- a/opensearchapi/api_render_search_template_test.go
+++ b/opensearchapi/api_render_search_template_test.go
@@ -25,6 +25,14 @@ func TestRenderSearchTemplate(t *testing.T) {
 	client, err := ostest.NewClient()
 	require.Nil(t, err)
 
+	if ostest.IsSecure() {
+		major, patch, _, err := ostest.GetVersion(client)
+		assert.Nil(t, err)
+		if major == 2 && (patch == 10 || patch == 11) {
+			t.Skipf("Skiping %s due to: https://github.com/opensearch-project/security/issues/3672", t.Name())
+		}
+	}
+
 	testScript := "test-search-template"
 	t.Cleanup(func() {
 		client.Script.Delete(nil, opensearchapi.ScriptDeleteReq{ScriptID: testScript})

--- a/opensearchapi/api_render_search_template_test.go
+++ b/opensearchapi/api_render_search_template_test.go
@@ -16,12 +16,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestRenderSearchTemplate(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 
 	testScript := "test-search-template"
@@ -48,7 +49,7 @@ func TestRenderSearchTemplate(t *testing.T) {
 		)
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 	})
 
 	t.Run("inspect", func(t *testing.T) {

--- a/opensearchapi/api_script_test.go
+++ b/opensearchapi/api_script_test.go
@@ -15,12 +15,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestScriptClient(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 	failingClient, err := osapitest.CreateFailingClient()
 	require.Nil(t, err)
@@ -154,7 +155,7 @@ func TestScriptClient(t *testing.T) {
 	for _, value := range testCases {
 		t.Run(value.Name, func(t *testing.T) {
 			if strings.Contains(value.Name, "Language") {
-				osapitest.SkipIfBelowVersion(t, client, 2, 3, value.Name)
+				ostest.SkipIfBelowVersion(t, client, 2, 3, value.Name)
 			}
 			for _, testCase := range value.Tests {
 				t.Run(testCase.Name, func(t *testing.T) {
@@ -184,32 +185,32 @@ func TestScriptClient(t *testing.T) {
 			)
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Get", func(t *testing.T) {
 			resp, err := client.Script.Get(nil, opensearchapi.ScriptGetReq{ScriptID: scriptID})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Delete", func(t *testing.T) {
 			resp, err := client.Script.Delete(nil, opensearchapi.ScriptDeleteReq{ScriptID: scriptID})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Context", func(t *testing.T) {
 			resp, err := client.Script.Context(nil, nil)
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("Language", func(t *testing.T) {
-			osapitest.SkipIfBelowVersion(t, client, 2, 3, "Language")
+			ostest.SkipIfBelowVersion(t, client, 2, 3, "Language")
 			resp, err := client.Script.Language(nil, nil)
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 		t.Run("PainlessExecute", func(t *testing.T) {
 			resp, err := client.Script.PainlessExecute(
@@ -218,7 +219,7 @@ func TestScriptClient(t *testing.T) {
 			)
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		})
 	})
 }

--- a/opensearchapi/api_scroll_test.go
+++ b/opensearchapi/api_scroll_test.go
@@ -15,12 +15,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestScrollClient(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 	failingClient, err := osapitest.CreateFailingClient()
 	require.Nil(t, err)
@@ -92,7 +93,7 @@ func TestScrollClient(t *testing.T) {
 						require.Nil(t, err)
 						require.NotNil(t, res)
 						assert.NotNil(t, res.Inspect().Response)
-						osapitest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+						ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
 					}
 				})
 			}

--- a/opensearchapi/api_search-template_test.go
+++ b/opensearchapi/api_search-template_test.go
@@ -16,12 +16,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestSearchTemplate(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 
 	testIndex := "test-search-template"
@@ -52,7 +53,7 @@ func TestSearchTemplate(t *testing.T) {
 		)
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 	})
 
 	t.Run("inspect", func(t *testing.T) {

--- a/opensearchapi/api_search_shards_test.go
+++ b/opensearchapi/api_search_shards_test.go
@@ -11,14 +11,16 @@ package opensearchapi_test
 import (
 	"testing"
 
-	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
-	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
+	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
+	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestSearchShards(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 
 	index := "test-index-search-shards"
@@ -38,14 +40,14 @@ func TestSearchShards(t *testing.T) {
 		resp, err := client.SearchShards(nil, nil)
 		require.Nil(t, err)
 		assert.NotNil(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 	})
 
 	t.Run("with request", func(t *testing.T) {
 		resp, err := client.SearchShards(nil, &opensearchapi.SearchShardsReq{Indices: []string{index}})
 		require.Nil(t, err)
 		assert.NotNil(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 	})
 
 	t.Run("inspect", func(t *testing.T) {

--- a/opensearchapi/api_search_test.go
+++ b/opensearchapi/api_search_test.go
@@ -12,14 +12,16 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
-	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
+	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
+	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestSearch(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 
 	index := "test-index-search"
@@ -41,7 +43,7 @@ func TestSearch(t *testing.T) {
 		resp, err := client.Search(nil, nil)
 		require.Nil(t, err)
 		assert.NotNil(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		assert.NotEmpty(t, resp.Hits.Hits)
 	})
 
@@ -49,7 +51,7 @@ func TestSearch(t *testing.T) {
 		resp, err := client.Search(nil, &opensearchapi.SearchReq{Indices: []string{index}, Body: strings.NewReader("")})
 		require.Nil(t, err)
 		assert.NotNil(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 		assert.NotEmpty(t, resp.Hits.Hits)
 	})
 

--- a/opensearchapi/api_snapshot_test.go
+++ b/opensearchapi/api_snapshot_test.go
@@ -17,12 +17,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestSnapshotClient(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 	failingClient, err := osapitest.CreateFailingClient()
 	require.Nil(t, err)
@@ -288,7 +289,7 @@ func TestSnapshotClient(t *testing.T) {
 						require.NotNil(t, res)
 						assert.NotNil(t, res.Inspect().Response)
 						if value.Name != "Repository Get" {
-							osapitest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+							ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
 						}
 					}
 				})
@@ -312,7 +313,7 @@ func TestSnapshotClient(t *testing.T) {
 			resp, err := client.Snapshot.Repository.Get(nil, &opensearchapi.SnapshotRepositoryGetReq{Repos: []string{testRepo}})
 			require.Nil(t, err)
 			assert.NotNil(t, resp)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Repos, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Repos, resp.Inspect().Response)
 		})
 	})
 }

--- a/opensearchapi/api_tasks_test.go
+++ b/opensearchapi/api_tasks_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchutil"
@@ -25,7 +26,7 @@ import (
 
 func TestTasksClient(t *testing.T) {
 	t.Parallel()
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 	failingClient, err := osapitest.CreateFailingClient()
 	require.Nil(t, err)
@@ -162,7 +163,7 @@ func TestTasksClient(t *testing.T) {
 						require.NotNil(t, res)
 						assert.NotNil(t, res.Inspect().Response)
 						if value.Name != "Get" && value.Name != "Exists" {
-							osapitest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+							ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
 						}
 					}
 				})

--- a/opensearchapi/api_template_test.go
+++ b/opensearchapi/api_template_test.go
@@ -15,12 +15,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestTemplateClient(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 	failingClient, err := osapitest.CreateFailingClient()
 	require.Nil(t, err)
@@ -83,10 +84,10 @@ func TestTemplateClient(t *testing.T) {
 					Name: "with request",
 					Results: func() (osapitest.Response, error) {
 						var (
-							resp dummyInspect
+							resp osapitest.DummyInspect
 							err  error
 						)
-						resp.response, err = client.Template.Exists(nil, opensearchapi.TemplateExistsReq{Template: template})
+						resp.Response, err = client.Template.Exists(nil, opensearchapi.TemplateExistsReq{Template: template})
 						return resp, err
 					},
 				},
@@ -94,10 +95,10 @@ func TestTemplateClient(t *testing.T) {
 					Name: "inspect",
 					Results: func() (osapitest.Response, error) {
 						var (
-							resp dummyInspect
+							resp osapitest.DummyInspect
 							err  error
 						)
-						resp.response, err = failingClient.Template.Exists(nil, opensearchapi.TemplateExistsReq{Template: template})
+						resp.Response, err = failingClient.Template.Exists(nil, opensearchapi.TemplateExistsReq{Template: template})
 						return resp, err
 					},
 				},
@@ -135,7 +136,7 @@ func TestTemplateClient(t *testing.T) {
 						require.NotNil(t, res)
 						assert.NotNil(t, res.Inspect().Response)
 						if value.Name != "Get" && value.Name != "Exists" {
-							osapitest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+							ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
 						}
 					}
 				})
@@ -156,7 +157,7 @@ func TestTemplateClient(t *testing.T) {
 			require.Nil(t, err)
 			require.NotNil(t, resp)
 			require.NotNil(t, resp.Inspect().Response)
-			osapitest.CompareRawJSONwithParsedJSON(t, resp.Templates, resp.Inspect().Response)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Templates, resp.Inspect().Response)
 		})
 	})
 }

--- a/opensearchapi/api_termvectors_test.go
+++ b/opensearchapi/api_termvectors_test.go
@@ -16,12 +16,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestTermvectors(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 
 	testIndex := "test-termvectors"
@@ -95,7 +96,7 @@ func TestTermvectors(t *testing.T) {
 		)
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 	})
 
 	t.Run("inspect", func(t *testing.T) {

--- a/opensearchapi/api_update_by_query_rethrottle_test.go
+++ b/opensearchapi/api_update_by_query_rethrottle_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchutil"
@@ -24,7 +25,7 @@ import (
 
 func TestUpdateByQueryRethrottle(t *testing.T) {
 	t.Parallel()
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 
 	testIndex := "test-updatebyquery-rethrottle-source"
@@ -86,7 +87,7 @@ func TestUpdateByQueryRethrottle(t *testing.T) {
 		)
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 	})
 
 	t.Run("inspect", func(t *testing.T) {

--- a/opensearchapi/api_update_by_query_test.go
+++ b/opensearchapi/api_update_by_query_test.go
@@ -16,12 +16,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestUpdateByQuery(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 
 	testIndex := "test-update_by_query"
@@ -52,7 +53,7 @@ func TestUpdateByQuery(t *testing.T) {
 		)
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 	})
 
 	t.Run("inspect", func(t *testing.T) {

--- a/opensearchapi/api_update_test.go
+++ b/opensearchapi/api_update_test.go
@@ -16,12 +16,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	osapitest "github.com/opensearch-project/opensearch-go/v3/opensearchapi/internal/test"
 )
 
 func TestUpdate(t *testing.T) {
-	client, err := opensearchapi.NewDefaultClient()
+	client, err := ostest.NewClient()
 	require.Nil(t, err)
 
 	testIndex := "test-update"
@@ -53,7 +54,7 @@ func TestUpdate(t *testing.T) {
 		)
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp)
-		osapitest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 	})
 
 	t.Run("inspect", func(t *testing.T) {

--- a/opensearchtransport/opensearchtransport_integration_test.go
+++ b/opensearchtransport/opensearchtransport_integration_test.go
@@ -39,6 +39,7 @@ import (
 	"strings"
 	"testing"
 
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchtransport"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchutil"
 )
@@ -94,15 +95,29 @@ func TestTransportRetries(t *testing.T) {
 }
 
 func TestTransportHeaders(t *testing.T) {
-	u, _ := url.Parse("http://localhost:9200")
-
 	hdr := http.Header{}
 	hdr.Set("Accept", "application/yaml")
 
+	u, _ := url.Parse("http://localhost:9200")
 	tp, _ := opensearchtransport.New(opensearchtransport.Config{
 		URLs:   []*url.URL{u},
 		Header: hdr,
 	})
+
+	config, err := ostest.ClientConfig()
+	if err != nil {
+		t.Fatalf("Failed to get client config: %s", err)
+	}
+	if config != nil {
+		u, _ := url.Parse("https://localhost:9200")
+		tp, _ = opensearchtransport.New(opensearchtransport.Config{
+			URLs:      []*url.URL{u},
+			Header:    hdr,
+			Username:  config.Client.Username,
+			Password:  config.Client.Password,
+			Transport: config.Client.Transport,
+		})
+	}
 
 	req, _ := http.NewRequest("GET", "/", nil)
 	res, err := tp.Perform(req)
@@ -127,6 +142,20 @@ func TestTransportBodyClose(t *testing.T) {
 	tp, _ := opensearchtransport.New(opensearchtransport.Config{
 		URLs: []*url.URL{u},
 	})
+
+	config, err := ostest.ClientConfig()
+	if err != nil {
+		t.Fatalf("Failed to get client config: %s", err)
+	}
+	if config != nil {
+		u, _ := url.Parse("https://localhost:9200")
+		tp, _ = opensearchtransport.New(opensearchtransport.Config{
+			URLs:      []*url.URL{u},
+			Username:  config.Client.Username,
+			Password:  config.Client.Password,
+			Transport: config.Client.Transport,
+		})
+	}
 
 	req, _ := http.NewRequest("GET", "/", nil)
 	res, err := tp.Perform(req)
@@ -159,6 +188,21 @@ func TestTransportCompression(t *testing.T) {
 		URLs:                []*url.URL{u},
 		CompressRequestBody: true,
 	})
+
+	config, err := ostest.ClientConfig()
+	if err != nil {
+		t.Fatalf("Failed to get client config: %s", err)
+	}
+	if config != nil {
+		u, _ := url.Parse("https://localhost:9200")
+		transport, _ = opensearchtransport.New(opensearchtransport.Config{
+			URLs:                []*url.URL{u},
+			CompressRequestBody: true,
+			Username:            config.Client.Username,
+			Password:            config.Client.Password,
+			Transport:           config.Client.Transport,
+		})
+	}
 
 	indexName := "/shiny_new_index"
 

--- a/opensearchutil/bulk_indexer_integration_test.go
+++ b/opensearchutil/bulk_indexer_integration_test.go
@@ -38,6 +38,7 @@ import (
 	"time"
 
 	"github.com/opensearch-project/opensearch-go/v3"
+	osapitest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchtransport"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchutil"
@@ -164,6 +165,16 @@ func TestBulkIndexerIntegration(t *testing.T) {
 				},
 			},
 		)
+
+		config, err := osapitest.ClientConfig()
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		if config != nil {
+			config.Client.CompressRequestBody = c.compressRequestBodyEnabled
+			config.Client.Logger = &opensearchtransport.ColorLogger{Output: os.Stdout}
+			client, _ = opensearchapi.NewClient(*config)
+		}
 
 		client.Indices.Delete(ctx, opensearchapi.IndicesDeleteReq{Indices: []string{indexName}, Params: opensearchapi.IndicesDeleteParams{IgnoreUnavailable: opensearchapi.ToPointer(true)}})
 		client.Indices.Create(

--- a/opensearchutil/json_reader_integration_test.go
+++ b/opensearchutil/json_reader_integration_test.go
@@ -36,6 +36,7 @@ import (
 
 	"golang.org/x/exp/slices"
 
+	osapitest "github.com/opensearch-project/opensearch-go/v3/internal/test"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchutil"
 )
@@ -44,7 +45,7 @@ func TestJSONReaderIntegration(t *testing.T) {
 	t.Run("Index and search", func(t *testing.T) {
 		ctx := context.Background()
 
-		client, err := opensearchapi.NewDefaultClient()
+		client, err := osapitest.NewClient()
 		if err != nil {
 			t.Fatalf("Error creating the client: %s\n", err)
 		}


### PR DESCRIPTION
### Description
- Update workflow action versions
- Move functions from opensearchapi/internal/test to internal/test
- Adjust integration test to work with secure opensearch
- adjust golangci-lint config for internal/ folder
- add missing merge_id field for indices segement request
- change custom_foldername field to pointer as it can be null
- skip render search template test with security due to issue

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
