### PR TITLE
Fix: empty body SHA is incorrect using AWS SDK v1 signer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Fix SigV4 with AWS SDK v1 ([#496](https://github.com/opensearch-project/opensearch-go/pull/496))
 ### Security
 
 ## [3.0.0]

--- a/signer/aws/aws.go
+++ b/signer/aws/aws.go
@@ -31,7 +31,7 @@ const OpenSearchService = "es"
 const OpenSearchServerless = "aoss"
 
 //nolint:gosec // static empty Body
-const emptyBodySHA256 = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+const emptyBodySHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
 // Signer is an interface that will implement opensearchtransport.Signer
 type Signer struct {

--- a/signer/aws/aws_test.go
+++ b/signer/aws/aws_test.go
@@ -65,7 +65,7 @@ func TestV4Signer(t *testing.T) {
 		q := req.Header
 		assert.NotEmpty(t, q.Get("Authorization"))
 		assert.NotEmpty(t, q.Get("X-Amz-Date"))
-		assert.Equal(t, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", q.Get("X-Amz-Content-Sha256"))
+		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", q.Get("X-Amz-Content-Sha256"))
 	})
 
 	t.Run("sign request success with body", func(t *testing.T) {


### PR DESCRIPTION
### Description

The empty body SHA is different (incorrect, it's the SHA for "hello") in the SDK v1 code, it should be one of an empty string.

It's correct in V2, https://github.com/opensearch-project/opensearch-go/blob/d38bdc15de7a759e3c1c538d173a63eef45a2dd2/signer/awsv2/sdkv2signer.go#L33C23-L33C87. 

### Issues Resolved

Closes #492.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
