### PR TITLE
Add the Explanation field containing the document explain details to SearchHit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Adds GlobalIOUsage struct for nodes stats ([#506]((https://github.com/opensearch-project/opensearch-go/pull/506))
 
-- Adds the `Explanation` field containing the document explain details to the `SearchHit` struct
+- Adds the `Explanation` field containing the document explain details to the `SearchHit` struct. ([#504](https://github.com/opensearch-project/opensearch-go/pull/504)
 ### Changed
 - Use docker compose v2 instead of v1 ([#506]((https://github.com/opensearch-project/opensearch-go/pull/506))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Adds GlobalIOUsage struct for nodes stats ([#506]((https://github.com/opensearch-project/opensearch-go/pull/506))
 
+- Adds the `Explanation` field containing the document explain details to the `SearchHit` struct
 ### Changed
 - Use docker compose v2 instead of v1 ([#506]((https://github.com/opensearch-project/opensearch-go/pull/506))
 

--- a/opensearchapi/api_search.go
+++ b/opensearchapi/api_search.go
@@ -87,10 +87,11 @@ func (r SearchResp) Inspect() Inspect {
 
 // SearchHit is a sub type of SearchResp containing information of the search hit with an unparsed Source field
 type SearchHit struct {
-	Index  string          `json:"_index"`
-	ID     string          `json:"_id"`
-	Score  float32         `json:"_score"`
-	Source json.RawMessage `json:"_source"`
-	Type   string          `json:"_type"` // Deprecated field
-	Sort   []any           `json:"sort"`
+	Index       string                  `json:"_index"`
+	ID          string                  `json:"_id"`
+	Score       float32                 `json:"_score"`
+	Source      json.RawMessage         `json:"_source"`
+	Type        string                  `json:"_type"` // Deprecated field
+	Sort        []any                   `json:"sort"`
+	Explanation *DocumentExplainDetails `json:"_explanation"`
 }

--- a/opensearchapi/api_search_test.go
+++ b/opensearchapi/api_search_test.go
@@ -66,8 +66,7 @@ func TestSearch(t *testing.T) {
 	})
 
 	t.Run("request with explain", func(t *testing.T) {
-		explain := true
-		resp, err := client.Search(nil, &opensearchapi.SearchReq{Indices: []string{index}, Body: strings.NewReader(""), Params: opensearchapi.SearchParams{Explain: &explain}})
+		resp, err := client.Search(nil, &opensearchapi.SearchReq{Indices: []string{index}, Body: strings.NewReader(""), Params: opensearchapi.SearchParams{Explain: opensearchapi.ToPointer(true)}})
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp.Hits.Hits)
 		assert.NotNil(t, resp.Hits.Hits[0].Explanation)

--- a/opensearchapi/api_search_test.go
+++ b/opensearchapi/api_search_test.go
@@ -64,4 +64,12 @@ func TestSearch(t *testing.T) {
 		assert.NotNil(t, res)
 		osapitest.VerifyInspect(t, res.Inspect())
 	})
+
+	t.Run("request with explain", func(t *testing.T) {
+		explain := true
+		resp, err := client.Search(nil, &opensearchapi.SearchReq{Indices: []string{index}, Body: strings.NewReader(""), Params: opensearchapi.SearchParams{Explain: &explain}})
+		require.Nil(t, err)
+		assert.NotEmpty(t, resp.Hits.Hits)
+		assert.NotNil(t, resp.Hits.Hits[0].Explanation)
+	})
 }


### PR DESCRIPTION
### Description
Previously, calling the `Search` function [here](https://github.com/opensearch-project/opensearch-go/blob/e0278abbe00fb090faba23170d2a1aac491d6d22/opensearchapi/api_search.go#L21) with `Explain` set to true in `Params` in the `SearchReq` did **not** add an explanation payload to each document. This pull request fixes that by adding an `Explanation` field to the `SearchHit` struct.

### Issues Resolved
This resolves issue [503](https://github.com/opensearch-project/opensearch-go/issues/503),  which I raised.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
