### PR TITLE
Use docker compose v2, add nodes stats global io usage struct, tests against opesnearch 2.13

### DIFF
--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -26,6 +26,7 @@ jobs:
           - { opensearch_version: 2.10.0 }
           - { opensearch_version: 2.11.1 }
           - { opensearch_version: 2.12.0 }
+          - { opensearch_version: 2.13.0 }
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ### Added
+- Adds GlobalIOUsage struct for nodes stats ([#506]((https://github.com/opensearch-project/opensearch-go/pull/506))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Adds GlobalIOUsage struct for nodes stats ([#506]((https://github.com/opensearch-project/opensearch-go/pull/506))
 
 ### Changed
+- Use docker compose v2 instead of v1 ([#506]((https://github.com/opensearch-project/opensearch-go/pull/506))
 
 ### Deprecated
 

--- a/Makefile
+++ b/Makefile
@@ -194,13 +194,13 @@ godoc: ## Display documentation for the package
 	godoc --http=localhost:6060 --play
 
 cluster.build:
-	docker-compose --project-directory .ci/opensearch build;
+	docker compose --project-directory .ci/opensearch build;
 
 cluster.start:
-	docker-compose --project-directory .ci/opensearch up -d ;
+	docker compose --project-directory .ci/opensearch up -d ;
 
 cluster.stop:
-	docker-compose --project-directory .ci/opensearch down ;
+	docker compose --project-directory .ci/opensearch down ;
 
 
 cluster.clean: ## Remove unused Docker volumes and networks

--- a/guides/index_lifecycle.md
+++ b/guides/index_lifecycle.md
@@ -10,7 +10,7 @@ To start the cluster, run the following command:
 
 ```bash
   cd /path/to/docker-compose.yml
-  docker-compose up -d
+  docker compose up -d
 ```
 
 Let's create a client instance to access this cluster:
@@ -258,5 +258,5 @@ Notice that we are passing `ignore unavailable` to the request. This tells the s
 All resources created in this guide are automatically deleted when the cluster is stopped. You can stop the cluster by running the following command:
 
 ```bash
-  docker-compose down -v
+  docker compose down -v
 ```

--- a/opensearchapi/api_nodes-stats.go
+++ b/opensearchapi/api_nodes-stats.go
@@ -704,4 +704,9 @@ type NodesStatsAdmissionControl struct {
 			RejectionCount json.RawMessage `json:"rejection_count"`
 		} `json:"transport"`
 	} `json:"global_cpu_usage"`
+	GlobalIOUsage struct {
+		Transport struct {
+			RejectionCount json.RawMessage `json:"rejection_count"`
+		} `json:"transport"`
+	} `json:"global_io_usage"`
 }


### PR DESCRIPTION
### Description
- Adds missing struct
- tests against opensearch 2.13
- change docker compose to v2
https://github.com/actions/runner-images/issues/9557

### Issues Resolved
Closes #505 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
