### PR TITLE
Add security plugin

### DIFF
--- a/.ci/opensearch/Dockerfile.opensearch
+++ b/.ci/opensearch/Dockerfile.opensearch
@@ -4,9 +4,21 @@ FROM opensearchproject/opensearch:${OPENSEARCH_VERSION}
 ARG opensearch_path=/usr/share/opensearch
 ARG SECURE_INTEGRATION
 ENV SECURE_INTEGRATION=$SECURE_INTEGRATION
+ARG OPENSEARCH_INITIAL_ADMIN_PASSWORD
 
+# Some opensearch secuirty settings are only present since 2.8.0 and causes older versions to brake if the setting is present
+# https://apple.stackexchange.com/a/123408/11374
 RUN if [ "$SECURE_INTEGRATION" != "true" ] ; then \
       $opensearch_path/bin/opensearch-plugin remove opensearch-security; \
+      else \
+        $opensearch_path/opensearch-onetime-setup.sh; \
+        echo "plugins.security.nodes_dn_dynamic_config_enabled: true"  | tee -a $opensearch_path/config/opensearch.yml > /dev/null; \
+        echo "plugins.security.unsupported.restapi.allow_securityconfig_modification: true"  | tee -a $opensearch_path/config/opensearch.yml > /dev/null; \
+        echo "plugins.security.ssl_cert_reload_enabled: true" | tee -a $opensearch_path/config/opensearch.yml > /dev/null; \
+        function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }; \
+        if [ $(version $OPENSEARCH_VERSION) -ge $(version "2.8.0") ] || [ $OPENSEARCH_VERSION == "latest" ]; then \
+          echo "plugins.security.restapi.admin.enabled: true" | tee -a $opensearch_path/config/opensearch.yml > /dev/null; \
+        fi \
       fi
 
 HEALTHCHECK --start-period=20s --interval=30s \

--- a/.ci/opensearch/Dockerfile.opensearch
+++ b/.ci/opensearch/Dockerfile.opensearch
@@ -1,25 +1,15 @@
 ARG OPENSEARCH_VERSION
 FROM opensearchproject/opensearch:${OPENSEARCH_VERSION}
 
-ARG OPENSEARCH_VERSION
 ARG opensearch_path=/usr/share/opensearch
 ARG SECURE_INTEGRATION
 ENV SECURE_INTEGRATION=$SECURE_INTEGRATION
 
-# Starting in 2.12.0 security demo requires an initial admin password, which is set as myStrongPassword123!
-# https://apple.stackexchange.com/a/123408/11374
 RUN if [ "$SECURE_INTEGRATION" != "true" ] ; then \
       $opensearch_path/bin/opensearch-plugin remove opensearch-security; \
-      else \
-        function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }; \
-        if [ $(version $OPENSEARCH_VERSION) -ge $(version "2.12.0") ] || [ $OPENSEARCH_VERSION == "latest" ]; then \
-          echo user admin:myStrongPassword123! > curl.conf ; \
-        else \
-          echo user admin:admin > curl.conf ; \
-        fi\
       fi
 
 HEALTHCHECK --start-period=20s --interval=30s \
   CMD curl -sf -retry 5 --max-time 5 --retry-delay 5 --retry-max-time 30 \
-  $(if $SECURE_INTEGRATION; then echo "-K curl.conf -k https://"; fi)"localhost:9200" \
+  $(if $SECURE_INTEGRATION; then echo "--cert config/kirk.pem --key config/kirk-key.pem -k https://"; fi)"localhost:9200" \
   || bash -c 'kill -s 15 -1 && (sleep 10; kill -s 9 -1)'

--- a/.ci/opensearch/docker-compose.yml
+++ b/.ci/opensearch/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       args:
         - SECURE_INTEGRATION=${SECURE_INTEGRATION:-false}
         - OPENSEARCH_VERSION=${OPENSEARCH_VERSION:-latest}
+        - OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!
     environment:
       - discovery.type=single-node
       - bootstrap.memory_lock=true

--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           export OPENSEARCH_VERSION=${{ matrix.entry.opensearch_version }}
           export SECURE_INTEGRATION=${{ matrix.secured }}
-          make test-integ race=true
+          make cluster.get-cert test-integ race=true
 
       - name: Stop the OpenSearch cluster
         run: |

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -26,11 +26,7 @@ jobs:
           for attempt in `seq 25`; do sleep 5; \
           if curl -s localhost:9200; \
           then echo '=====> ready'; break; fi; if [ $attempt == 25 ]; then exit 1; fi; echo '=====> waiting...'; done
-      - run: make test-integ race=true coverage=true
-      - uses: codecov/codecov-action@v4
-        with:
-          file: tmp/integ.cov
-          flags: integration
+      - run: make test-integ race=true
 
   secured:
     name: Tests against secure cluster
@@ -54,4 +50,8 @@ jobs:
           for attempt in `seq 25`; do sleep 5; \
           if curl -s -ku admin:myStrongPassword123! https://localhost:9200; \
           then echo '=====> ready'; break; fi; if [ $attempt == 25 ]; then exit 1; fi; echo '=====> waiting...'; done
-      - run: make cluster.get-cert test-integ-secure
+      - run: make cluster.get-cert test-integ-secure race=true coverage=true
+      - uses: codecov/codecov-action@v4
+        with:
+          file: tmp/integ.cov
+          flags: integration

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -54,4 +54,4 @@ jobs:
           for attempt in `seq 25`; do sleep 5; \
           if curl -s -ku admin:myStrongPassword123! https://localhost:9200; \
           then echo '=====> ready'; break; fi; if [ $attempt == 25 ]; then exit 1; fi; echo '=====> waiting...'; done
-      - run: make test-integ-secure
+      - run: make cluster.get-cert test-integ-secure

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -172,4 +172,4 @@ issues:
       path: opensearchtransport/opensearchtransport.go
     - linters:
         - dupl
-      path: (-params\.go|api_indices|api_dangling\.go|api_point_in_time\.go|rethrottle\.go|api_cat-.*\.go)
+      path: (-params\.go|api_indices|api_dangling\.go|api_point_in_time\.go|rethrottle\.go|api_cat-.*\.go|plugins/security/api_\w+.go|plugins/security/api_.*-patch.go)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Adds new error types ([#512](https://github.com/opensearch-project/opensearch-go/pull/506))
 - Adds handling of non json errors to ParseError ([#512](https://github.com/opensearch-project/opensearch-go/pull/506))
 - Adds the `Failures` field to opensearchapi structs ([#510](https://github.com/opensearch-project/opensearch-go/pull/510))
+- Adds the `Fields` field containing the document fields to the `SearchHit` struct. ([#508](https://github.com/opensearch-project/opensearch-go/pull/508))
+- Adds security plugin ([#507](https://github.com/opensearch-project/opensearch-go/pull/507))
+- Adds security settings to container for security testing ([#507](https://github.com/opensearch-project/opensearch-go/pull/507))
+- Adds cluster.get-certs to copy admin certs out of the container ([#507](https://github.com/opensearch-project/opensearch-go/pull/507))
 
 ### Changed
 - Uses docker compose v2 instead of v1 ([#506](https://github.com/opensearch-project/opensearch-go/pull/506))
@@ -21,6 +25,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Adjusts and extent opensearch tests for better coverage ([#517](https://github.com/opensearch-project/opensearch-go/pull/517))
 - Bumps codecov action version to v4 ([#517](https://github.com/opensearch-project/opensearch-go/pull/517))
 - Changes bulk error/reason field and some cat response fields to pointer as they can be nil ([#510](https://github.com/opensearch-project/opensearch-go/pull/510))
+- Adjust workflows to work with security plugin ([#507](https://github.com/opensearch-project/opensearch-go/pull/507))
 
 ### Deprecated
 

--- a/Makefile
+++ b/Makefile
@@ -197,10 +197,16 @@ cluster.build:
 	docker compose --project-directory .ci/opensearch build;
 
 cluster.start:
-	docker compose --project-directory .ci/opensearch up -d ;
+	docker compose --project-directory .ci/opensearch up -d;
 
 cluster.stop:
-	docker compose --project-directory .ci/opensearch down ;
+	docker compose --project-directory .ci/opensearch down;
+
+cluster.get-cert:
+	@if [[ -v SECURE_INTEGRATION ]] && [[ $$SECURE_INTEGRATION == "true" ]]; then \
+		docker cp $$(docker compose --project-directory .ci/opensearch ps --format '{{.Name}}'):/usr/share/opensearch/config/kirk.pem admin.pem && \
+		docker cp $$(docker compose --project-directory .ci/opensearch ps --format '{{.Name}}'):/usr/share/opensearch/config/kirk-key.pem admin.key; \
+	fi
 
 
 cluster.clean: ## Remove unused Docker volumes and networks

--- a/opensearch.go
+++ b/opensearch.go
@@ -325,3 +325,8 @@ func addrsToURLs(addrs []string) ([]*url.URL, error) {
 
 	return urls, nil
 }
+
+// ToPointer converts any value to a pointer, mainly used for request parameters
+func ToPointer[V any](value V) *V {
+	return &value
+}

--- a/opensearch_internal_test.go
+++ b/opensearch_internal_test.go
@@ -414,3 +414,9 @@ func TestParseElasticsearchVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestToPointer(t *testing.T) {
+	testPointer := ToPointer(true)
+	assert.NotNil(t, testPointer)
+	assert.True(t, *testPointer)
+}

--- a/plugins/security/api.go
+++ b/plugins/security/api.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// Config represents the client configuration
+type Config struct {
+	Client opensearch.Config
+}
+
+// Client represents the security Client summarizing all API calls
+type Client struct {
+	Client         *opensearch.Client
+	Account        accountClient
+	ActionGroups   actiongroupsClient
+	Audit          auditClient
+	InternalUsers  internalusersClient
+	NodesDN        nodesdnClient
+	Roles          rolesClient
+	RolesMapping   rolesmappingClient
+	SecurityConfig securityconfigClient
+	SSL            sslClient
+	Tenants        tenantsClient
+}
+
+// clientInit inits the Client with all sub clients
+func clientInit(rootClient *opensearch.Client) *Client {
+	client := &Client{
+		Client: rootClient,
+	}
+	client.Account = accountClient{apiClient: client}
+	client.ActionGroups = actiongroupsClient{apiClient: client}
+	client.Audit = auditClient{apiClient: client}
+	client.InternalUsers = internalusersClient{apiClient: client}
+	client.NodesDN = nodesdnClient{apiClient: client}
+	client.Roles = rolesClient{apiClient: client}
+	client.RolesMapping = rolesmappingClient{apiClient: client}
+	client.SecurityConfig = securityconfigClient{apiClient: client}
+	client.SSL = sslClient{apiClient: client}
+	client.Tenants = tenantsClient{apiClient: client}
+	return client
+}
+
+// NewClient returns a security client
+func NewClient(config Config) (*Client, error) {
+	rootClient, err := opensearch.NewClient(config.Client)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientInit(rootClient), nil
+}
+
+// do calls the opensearch.Client.Do() and checks the response for errors
+func (c *Client) do(ctx context.Context, req opensearch.Request, dataPointer any) (*opensearch.Response, error) {
+	resp, err := c.Client.Do(ctx, req, dataPointer)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.IsError() {
+		if dataPointer != nil {
+			return resp, opensearch.ParseError(resp)
+		} else {
+			return resp, fmt.Errorf("status: %s", resp.Status())
+		}
+	}
+
+	return resp, nil
+}

--- a/plugins/security/api_account-get.go
+++ b/plugins/security/api_account-get.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// AccountGetReq represents possible options for the account get request
+type AccountGetReq struct {
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r AccountGetReq) GetRequest() (*http.Request, error) {
+	return opensearch.BuildRequest(
+		"GET",
+		"/_plugins/_security/api/account",
+		nil,
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// AccountGetResp represents the returned struct of the account get response
+type AccountGetResp struct {
+	UserName            string          `json:"user_name"`
+	IsReserved          bool            `json:"is_reserved"`
+	IsHidden            bool            `json:"is_hidden"`
+	IsInternaluser      bool            `json:"is_internal_user"`
+	BackendRoles        []string        `json:"backend_roles"`
+	CustomAttributes    []string        `json:"custom_attribute_names"`
+	UserRequestedTenant *string         `json:"user_requested_tenant"`
+	Tennants            map[string]bool `json:"tenants"`
+	Roles               []string        `json:"roles"`
+	response            *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r AccountGetResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_account-put.go
+++ b/plugins/security/api_account-put.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// AccountPutReq represents possible options for the account put request
+type AccountPutReq struct {
+	Body AccountPutBody
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r AccountPutReq) GetRequest() (*http.Request, error) {
+	body, err := json.Marshal(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return opensearch.BuildRequest(
+		"PUT",
+		"/_plugins/_security/api/account",
+		bytes.NewReader(body),
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// AccountPutBody reperensts the request body for AccountPutReq
+type AccountPutBody struct {
+	CurrentPassword string `json:"current_password"`
+	Password        string `json:"password"`
+}
+
+// AccountPutResp represents the returned struct of the account put response
+type AccountPutResp struct {
+	Message  string `json:"message"`
+	Status   string `json:"status"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r AccountPutResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_account.go
+++ b/plugins/security/api_account.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"context"
+)
+
+type accountClient struct {
+	apiClient *Client
+}
+
+// Get executes a get account request with the optional AccountGetReq
+func (c accountClient) Get(ctx context.Context, req *AccountGetReq) (AccountGetResp, error) {
+	if req == nil {
+		req = &AccountGetReq{}
+	}
+
+	var (
+		data AccountGetResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Put executes a put account request with the required AccountPutReq
+func (c accountClient) Put(ctx context.Context, req AccountPutReq) (AccountPutResp, error) {
+	var (
+		data AccountPutResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}

--- a/plugins/security/api_account_test.go
+++ b/plugins/security/api_account_test.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+//
+//go:build integration
+
+package security_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
+	"github.com/opensearch-project/opensearch-go/v3/plugins/security"
+	ossectest "github.com/opensearch-project/opensearch-go/v3/plugins/security/internal/test"
+)
+
+func TestAccountClient(t *testing.T) {
+	ostest.SkipIfNotSecure(t)
+	client, err := ossectest.NewClient()
+	require.Nil(t, err)
+
+	failingClient, err := ossectest.CreateFailingClient()
+	require.Nil(t, err)
+
+	testUser := "testUser"
+	t.Cleanup(func() { client.InternalUsers.Delete(nil, security.InternalUsersDeleteReq{User: testUser}) })
+
+	type accountTests struct {
+		Name    string
+		Results func() (ossectest.Response, error)
+	}
+
+	testCases := []struct {
+		Name  string
+		Tests []accountTests
+	}{
+		{
+			Name: "Get",
+			Tests: []accountTests{
+				{
+					Name: "without request",
+					Results: func() (ossectest.Response, error) {
+						return client.Account.Get(nil, nil)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.Account.Get(nil, nil)
+					},
+				},
+			},
+		},
+		{
+			Name: "Put",
+			Tests: []accountTests{
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						var nilResp ossectest.Response
+						// Get new client config
+						config, err := ossectest.ClientConfig()
+						if err != nil {
+							return nilResp, err
+						}
+
+						// Set password to a "strong" password
+						config.Client.Password = "Str0ngP4ss123!"
+						config.Client.Username = testUser
+
+						// Create the test user
+						_, err = client.InternalUsers.Put(
+							nil,
+							security.InternalUsersPutReq{
+								User: config.Client.Username,
+								Body: security.InternalUsersPutBody{
+									Password: config.Client.Password,
+								},
+							},
+						)
+						if err != nil {
+							return nilResp, err
+						}
+
+						// Create a new client with the test user
+						usrClient, err := security.NewClient(*config)
+						if err != nil {
+							return nilResp, err
+						}
+
+						// Run the change password request we want to test
+						return usrClient.Account.Put(
+							nil,
+							security.AccountPutReq{
+								Body: security.AccountPutBody{
+									CurrentPassword: config.Client.Password,
+									Password:        "myStrongPassword123!",
+								},
+							},
+						)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.Account.Put(nil, security.AccountPutReq{})
+					},
+				},
+			},
+		},
+	}
+	for _, value := range testCases {
+		t.Run(value.Name, func(t *testing.T) {
+			for _, testCase := range value.Tests {
+				t.Run(testCase.Name, func(t *testing.T) {
+					res, err := testCase.Results()
+					if testCase.Name == "inspect" {
+						assert.NotNil(t, err)
+						assert.NotNil(t, res)
+						ossectest.VerifyInspect(t, res.Inspect())
+					} else {
+						require.Nil(t, err)
+						require.NotNil(t, res)
+						assert.NotNil(t, res.Inspect().Response)
+						ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+					}
+				})
+			}
+		})
+	}
+}

--- a/plugins/security/api_actiongroups-delete.go
+++ b/plugins/security/api_actiongroups-delete.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// ActionGroupsDeleteReq represents possible options for the actiongroups delete request
+type ActionGroupsDeleteReq struct {
+	ActionGroup string
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r ActionGroupsDeleteReq) GetRequest() (*http.Request, error) {
+	return opensearch.BuildRequest(
+		"DELETE",
+		fmt.Sprintf("/_plugins/_security/api/actiongroups/%s", r.ActionGroup),
+		nil,
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// ActionGroupsDeleteResp represents the returned struct of the actiongroups delete response
+type ActionGroupsDeleteResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r ActionGroupsDeleteResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_actiongroups-get.go
+++ b/plugins/security/api_actiongroups-get.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// ActionGroupsGetReq represents possible options for the actiongroups get request
+type ActionGroupsGetReq struct {
+	Header      http.Header
+	ActionGroup string
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r ActionGroupsGetReq) GetRequest() (*http.Request, error) {
+	var path strings.Builder
+	path.Grow(len("/_plugins/_security/api/actiongroups/") + len(r.ActionGroup))
+	path.WriteString("/_plugins/_security/api/actiongroups")
+	if len(r.ActionGroup) > 0 {
+		path.WriteString("/")
+		path.WriteString(r.ActionGroup)
+	}
+
+	return opensearch.BuildRequest(
+		"GET",
+		path.String(),
+		nil,
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// ActionGroupsGetResp represents the returned struct of the actiongroups get response
+type ActionGroupsGetResp struct {
+	Groups   map[string]ActionGroupsGet
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r ActionGroupsGetResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}
+
+// ActionGroupsGet is a sub type of ActionGroupsGetResp represeting information about an action group
+type ActionGroupsGet struct {
+	Reserved       bool     `json:"reserved"`
+	Hidden         bool     `json:"hidden"`
+	AllowedActions []string `json:"allowed_actions"`
+	Static         bool     `json:"static"`
+	Description    string   `json:"description,omitempty"`
+	Type           string   `json:"type,omitempty"`
+}

--- a/plugins/security/api_actiongroups-patch.go
+++ b/plugins/security/api_actiongroups-patch.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// ActionGroupsPatchReq represents possible options for the actiongroups patch request
+type ActionGroupsPatchReq struct {
+	ActionGroup string
+	Body        ActionGroupsPatchBody
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r ActionGroupsPatchReq) GetRequest() (*http.Request, error) {
+	body, err := json.Marshal(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var path strings.Builder
+	path.Grow(len("/_plugins/_security/api/actiongroups/") + len(r.ActionGroup))
+	path.WriteString("/_plugins/_security/api/actiongroups")
+	if len(r.ActionGroup) > 0 {
+		path.WriteString("/")
+		path.WriteString(r.ActionGroup)
+	}
+
+	return opensearch.BuildRequest(
+		"PATCH",
+		path.String(),
+		bytes.NewReader(body),
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// ActionGroupsPatchResp represents the returned struct of the actiongroups patch response
+type ActionGroupsPatchResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r ActionGroupsPatchResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}
+
+// ActionGroupsPatchBody represents the request body for the action groups patch request
+type ActionGroupsPatchBody []ActionGroupsPatchBodyItem
+
+// ActionGroupsPatchBodyItem is a sub type of ActionGroupsPatchBody represeting an action group
+type ActionGroupsPatchBodyItem struct {
+	OP    string `json:"op"`
+	Path  string `json:"path"`
+	Value any    `json:"value,omitempty"`
+}

--- a/plugins/security/api_actiongroups-put.go
+++ b/plugins/security/api_actiongroups-put.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// ActionGroupsPutReq represents possible options for the actiongroups put request
+type ActionGroupsPutReq struct {
+	ActionGroup string
+	Body        ActionGroupsPutBody
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r ActionGroupsPutReq) GetRequest() (*http.Request, error) {
+	body, err := json.Marshal(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return opensearch.BuildRequest(
+		"PUT",
+		fmt.Sprintf("/_plugins/_security/api/actiongroups/%s", r.ActionGroup),
+		bytes.NewReader(body),
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// ActionGroupsPutResp represents the returned struct of the actiongroups put response
+type ActionGroupsPutResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r ActionGroupsPutResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}
+
+// ActionGroupsPutBody represents the request body for the action groups put request
+type ActionGroupsPutBody struct {
+	AllowedActions []string `json:"allowed_actions"`
+	Type           *string  `json:"type,omitempty"`
+	Description    *string  `json:"description,omitempty"`
+}

--- a/plugins/security/api_actiongroups.go
+++ b/plugins/security/api_actiongroups.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"context"
+)
+
+type actiongroupsClient struct {
+	apiClient *Client
+}
+
+// Get executes a get actiongroups request with the optional ActionGroupsGetReq
+func (c actiongroupsClient) Get(ctx context.Context, req *ActionGroupsGetReq) (ActionGroupsGetResp, error) {
+	if req == nil {
+		req = &ActionGroupsGetReq{}
+	}
+
+	var (
+		data ActionGroupsGetResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Put executes a put actiongroups request with the required ActionGroupsPutReq
+func (c actiongroupsClient) Put(ctx context.Context, req ActionGroupsPutReq) (ActionGroupsPutResp, error) {
+	var (
+		data ActionGroupsPutResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Delete executes a delete actiongroups request with the required ActionGroupsDeleteReq
+func (c actiongroupsClient) Delete(ctx context.Context, req ActionGroupsDeleteReq) (ActionGroupsDeleteResp, error) {
+	var (
+		data ActionGroupsDeleteResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Patch executes a patch actiongroups request with the required ActionGroupsPatchReq
+func (c actiongroupsClient) Patch(ctx context.Context, req ActionGroupsPatchReq) (ActionGroupsPatchResp, error) {
+	var (
+		data ActionGroupsPatchResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}

--- a/plugins/security/api_actiongroups_test.go
+++ b/plugins/security/api_actiongroups_test.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+//
+//go:build integration
+
+package security_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
+	"github.com/opensearch-project/opensearch-go/v3/plugins/security"
+	ossectest "github.com/opensearch-project/opensearch-go/v3/plugins/security/internal/test"
+)
+
+func TestActiongroupsClient(t *testing.T) {
+	ostest.SkipIfNotSecure(t)
+	client, err := ossectest.NewClient()
+	require.Nil(t, err)
+
+	failingClient, err := ossectest.CreateFailingClient()
+	require.Nil(t, err)
+
+	type actiongroupsTests struct {
+		Name    string
+		Results func() (ossectest.Response, error)
+	}
+
+	testCases := []struct {
+		Name  string
+		Tests []actiongroupsTests
+	}{
+		{
+			Name: "Get",
+			Tests: []actiongroupsTests{
+				{
+					Name: "without request",
+					Results: func() (ossectest.Response, error) {
+						return client.ActionGroups.Get(nil, nil)
+					},
+				},
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.ActionGroups.Get(nil, &security.ActionGroupsGetReq{ActionGroup: "write"})
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.ActionGroups.Get(nil, nil)
+					},
+				},
+			},
+		},
+		{
+			Name: "Put",
+			Tests: []actiongroupsTests{
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.ActionGroups.Put(
+							nil,
+							security.ActionGroupsPutReq{
+								ActionGroup: "test",
+								Body: security.ActionGroupsPutBody{
+									AllowedActions: []string{"indices:data/read/msearch*", "indices:admin/mapping/put"},
+									Type:           opensearch.ToPointer("index"),
+									Description:    opensearch.ToPointer("Test"),
+								},
+							},
+						)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.ActionGroups.Put(nil, security.ActionGroupsPutReq{})
+					},
+				},
+			},
+		},
+		{
+			Name: "Delete",
+			Tests: []actiongroupsTests{
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.ActionGroups.Delete(nil, security.ActionGroupsDeleteReq{ActionGroup: "test"})
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.ActionGroups.Delete(nil, security.ActionGroupsDeleteReq{})
+					},
+				},
+			},
+		},
+		{
+			Name: "Patch",
+			Tests: []actiongroupsTests{
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.ActionGroups.Patch(
+							nil,
+							security.ActionGroupsPatchReq{
+								Body: security.ActionGroupsPatchBody{security.ActionGroupsPatchBodyItem{
+									OP:   "add",
+									Path: "/test",
+									Value: security.ActionGroupsPutBody{
+										AllowedActions: []string{"indices:data/read/msearch*", "indices:admin/mapping/put"},
+									},
+								},
+								},
+							},
+						)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.ActionGroups.Patch(nil, security.ActionGroupsPatchReq{})
+					},
+				},
+			},
+		},
+	}
+	for _, value := range testCases {
+		t.Run(value.Name, func(t *testing.T) {
+			for _, testCase := range value.Tests {
+				t.Run(testCase.Name, func(t *testing.T) {
+					res, err := testCase.Results()
+					if testCase.Name == "inspect" {
+						assert.NotNil(t, err)
+						assert.NotNil(t, res)
+						ossectest.VerifyInspect(t, res.Inspect())
+					} else {
+						require.Nil(t, err)
+						require.NotNil(t, res)
+						assert.NotNil(t, res.Inspect().Response)
+						if value.Name != "Get" {
+							ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+						}
+					}
+				})
+			}
+		})
+	}
+	t.Run("ValidateResponse", func(t *testing.T) {
+		t.Run("Get", func(t *testing.T) {
+			resp, err := client.ActionGroups.Get(nil, nil)
+			assert.Nil(t, err)
+			assert.NotNil(t, resp)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Groups, resp.Inspect().Response)
+		})
+	})
+}

--- a/plugins/security/api_audit-get.go
+++ b/plugins/security/api_audit-get.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// AuditGetReq represents possible options for the audit get request
+type AuditGetReq struct {
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r AuditGetReq) GetRequest() (*http.Request, error) {
+	return opensearch.BuildRequest(
+		"GET",
+		"/_plugins/_security/api/audit",
+		nil,
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// AuditGetResp represents the returned struct of the audit get response
+type AuditGetResp struct {
+	ReadOnly []string    `json:"_readonly"`
+	Config   AuditConfig `json:"config"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r AuditGetResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_audit-patch.go
+++ b/plugins/security/api_audit-patch.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// AuditPatchReq represents possible options for the audit patch request
+type AuditPatchReq struct {
+	Body AuditPatchBody
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r AuditPatchReq) GetRequest() (*http.Request, error) {
+	body, err := json.Marshal(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return opensearch.BuildRequest(
+		"PATCH",
+		"/_plugins/_security/api/audit",
+		bytes.NewReader(body),
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// AuditPatchResp represents the returned struct of the audit patch response
+type AuditPatchResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r AuditPatchResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}
+
+// AuditPatchBody represents the request body for the audit patch request
+type AuditPatchBody []AuditPatchBodyItem
+
+// AuditPatchBodyItem is a sub type of AuditPatchBody represeting patch item
+type AuditPatchBodyItem struct {
+	OP    string `json:"op"`
+	Path  string `json:"path"`
+	Value any    `json:"value,omitempty"`
+}

--- a/plugins/security/api_audit-put.go
+++ b/plugins/security/api_audit-put.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// AuditPutReq represents possible options for the audit put request
+type AuditPutReq struct {
+	Body AuditPutBody
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r AuditPutReq) GetRequest() (*http.Request, error) {
+	body, err := json.Marshal(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return opensearch.BuildRequest(
+		"PUT",
+		"/_plugins/_security/api/audit/config",
+		bytes.NewReader(body),
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// AuditPutBody is an alias of AuditConfig uses as request body
+type AuditPutBody AuditConfig
+
+// AuditPutResp represents the returned struct of the audit put response
+type AuditPutResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r AuditPutResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_audit.go
+++ b/plugins/security/api_audit.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type auditClient struct {
+	apiClient *Client
+}
+
+// Get executes a get audit request with the optional AuditGetReq
+func (c auditClient) Get(ctx context.Context, req *AuditGetReq) (AuditGetResp, error) {
+	if req == nil {
+		req = &AuditGetReq{}
+	}
+
+	var (
+		data AuditGetResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Put executes a put audit request with the required AuditPutReq
+func (c auditClient) Put(ctx context.Context, req AuditPutReq) (AuditPutResp, error) {
+	var (
+		data AuditPutResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Patch executes a patch audit request with the required AuditPatchReq
+func (c auditClient) Patch(ctx context.Context, req AuditPatchReq) (AuditPatchResp, error) {
+	var (
+		data AuditPatchResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// AuditConfig represents the security audit config uses for Put and Get request
+type AuditConfig struct {
+	Compliance struct {
+		Enabled             bool            `json:"enabled"`
+		WriteLogDiffs       bool            `json:"write_log_diffs"`
+		ReadWatchedFields   json.RawMessage `json:"read_watched_fields"`
+		ReadIgnoreUsers     []string        `json:"read_ignore_users"`
+		WriteWatchedIndices []string        `json:"write_watched_indices"`
+		WriteIgnoreUsers    []string        `json:"write_ignore_users"`
+		ReadMetadataOnly    bool            `json:"read_metadata_only"`
+		WriteMetadataOnly   bool            `json:"write_metadata_only"`
+		ExternalConfig      bool            `json:"external_config"`
+		InternalConfig      bool            `json:"internal_config"`
+	} `json:"compliance"`
+	Enabled bool `json:"enabled"`
+	Audit   struct {
+		IgnoreUsers    []string `json:"ignore_users"`
+		IgnoreRequests []string `json:"ignore_requests"`
+		// Needs to be a pointer so the omitempty machtes on nil and not on empty slice
+		IgnoreHeaders               *[]string `json:"ignore_headers,omitempty"`
+		IgnoreURLParams             *[]string `json:"ignore_url_params,omitempty"`
+		DisabledRestCategories      []string  `json:"disabled_rest_categories"`
+		DisabledTransportCategories []string  `json:"disabled_transport_categories"`
+		LogRequestBody              bool      `json:"log_request_body"`
+		ResolveIndices              bool      `json:"resolve_indices"`
+		ResolveBulkRequests         bool      `json:"resolve_bulk_requests"`
+		ExcludeSensitiveHeaders     bool      `json:"exclude_sensitive_headers"`
+		EnableTransport             bool      `json:"enable_transport"`
+		EnableRest                  bool      `json:"enable_rest"`
+	} `json:"audit"`
+}

--- a/plugins/security/api_audit_test.go
+++ b/plugins/security/api_audit_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+//
+//go:build integration
+
+package security_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
+	"github.com/opensearch-project/opensearch-go/v3/plugins/security"
+	ossectest "github.com/opensearch-project/opensearch-go/v3/plugins/security/internal/test"
+)
+
+func TestAuditClient(t *testing.T) {
+	ostest.SkipIfNotSecure(t)
+	client, err := ossectest.NewClient()
+	require.Nil(t, err)
+
+	failingClient, err := ossectest.CreateFailingClient()
+	require.Nil(t, err)
+
+	var getResp security.AuditGetResp
+
+	type auditTests struct {
+		Name    string
+		Results func() (ossectest.Response, error)
+	}
+
+	testCases := []struct {
+		Name  string
+		Tests []auditTests
+	}{
+		{
+			Name: "Get",
+			Tests: []auditTests{
+				{
+					Name: "without request",
+					Results: func() (ossectest.Response, error) {
+						getResp, err := client.Audit.Get(nil, nil)
+						return getResp, err
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.Audit.Get(nil, nil)
+					},
+				},
+			},
+		},
+		{
+			Name: "Put",
+			Tests: []auditTests{
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.Audit.Put(
+							nil,
+							security.AuditPutReq{
+								Body: security.AuditPutBody{
+									Compliance: getResp.Config.Compliance,
+									Enabled:    getResp.Config.Enabled,
+									Audit:      getResp.Config.Audit,
+								},
+							},
+						)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.Audit.Put(nil, security.AuditPutReq{})
+					},
+				},
+			},
+		},
+		{
+			Name: "Patch",
+			Tests: []auditTests{
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.Audit.Patch(
+							nil,
+							security.AuditPatchReq{
+								Body: security.AuditPatchBody{
+									security.AuditPatchBodyItem{
+										OP:    "add",
+										Path:  "/config/enabled",
+										Value: true,
+									},
+								},
+							},
+						)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.Audit.Patch(nil, security.AuditPatchReq{})
+					},
+				},
+			},
+		},
+	}
+	for _, value := range testCases {
+		t.Run(value.Name, func(t *testing.T) {
+			for _, testCase := range value.Tests {
+				t.Run(testCase.Name, func(t *testing.T) {
+					res, err := testCase.Results()
+					if testCase.Name == "inspect" {
+						assert.NotNil(t, err)
+						assert.NotNil(t, res)
+						ossectest.VerifyInspect(t, res.Inspect())
+					} else {
+						require.Nil(t, err)
+						require.NotNil(t, res)
+						assert.NotNil(t, res.Inspect().Response)
+						ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+					}
+				})
+			}
+		})
+	}
+}

--- a/plugins/security/api_flushcache.go
+++ b/plugins/security/api_flushcache.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// FlushCache executes a flush cache request with the optional FlushCacheReq
+func (c Client) FlushCache(ctx context.Context, req *FlushCacheReq) (FlushCacheResp, error) {
+	if req == nil {
+		req = &FlushCacheReq{}
+	}
+
+	var (
+		data FlushCacheResp
+		err  error
+	)
+	if data.response, err = c.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// FlushCacheReq represents possible options for the clush cache request
+type FlushCacheReq struct {
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r FlushCacheReq) GetRequest() (*http.Request, error) {
+	return opensearch.BuildRequest(
+		"DELETE",
+		"/_plugins/_security/api/cache",
+		nil,
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// FlushCacheResp represents the returned struct of the flush cache response
+type FlushCacheResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r FlushCacheResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_flushcache_test.go
+++ b/plugins/security/api_flushcache_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+//
+//go:build integration
+
+package security_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
+	ossectest "github.com/opensearch-project/opensearch-go/v3/plugins/security/internal/test"
+)
+
+func TestFlushCache(t *testing.T) {
+	ostest.SkipIfNotSecure(t)
+	client, err := ossectest.NewClient()
+	require.Nil(t, err)
+
+	failingClient, err := ossectest.CreateFailingClient()
+	require.Nil(t, err)
+
+	t.Run("without request", func(t *testing.T) {
+		resp, err := client.FlushCache(nil, nil)
+		require.Nil(t, err)
+		assert.NotNil(t, resp)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
+	})
+
+	t.Run("inspect", func(t *testing.T) {
+		res, err := failingClient.FlushCache(nil, nil)
+		assert.NotNil(t, err)
+		assert.NotNil(t, res)
+		ossectest.VerifyInspect(t, res.Inspect())
+	})
+}

--- a/plugins/security/api_health.go
+++ b/plugins/security/api_health.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// Health executes a get health request with the optional HealthReq
+func (c Client) Health(ctx context.Context, req *HealthReq) (HealthResp, error) {
+	if req == nil {
+		req = &HealthReq{}
+	}
+
+	var (
+		data HealthResp
+		err  error
+	)
+	if data.response, err = c.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// HealthReq represents possible options for the health get request
+type HealthReq struct {
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r HealthReq) GetRequest() (*http.Request, error) {
+	return opensearch.BuildRequest(
+		"GET",
+		"/_plugins/_security/health",
+		nil,
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// HealthResp represents the returned struct of the health get response
+type HealthResp struct {
+	Message  *string `json:"message"`
+	Mode     string  `json:"mode"`
+	Status   string  `json:"status"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r HealthResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_health_test.go
+++ b/plugins/security/api_health_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+//
+//go:build integration
+
+package security_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
+	ossectest "github.com/opensearch-project/opensearch-go/v3/plugins/security/internal/test"
+)
+
+func TestHealthClient(t *testing.T) {
+	ostest.SkipIfNotSecure(t)
+	client, err := ossectest.NewClient()
+	require.Nil(t, err)
+
+	failingClient, err := ossectest.CreateFailingClient()
+	require.Nil(t, err)
+
+	type healthTests struct {
+		Name    string
+		Results func() (ossectest.Response, error)
+	}
+
+	testCases := []struct {
+		Name  string
+		Tests []healthTests
+	}{
+		{
+			Name: "Health",
+			Tests: []healthTests{
+				{
+					Name: "without request",
+					Results: func() (ossectest.Response, error) {
+						return client.Health(nil, nil)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.Health(nil, nil)
+					},
+				},
+			},
+		},
+	}
+	for _, value := range testCases {
+		t.Run(value.Name, func(t *testing.T) {
+			for _, testCase := range value.Tests {
+				t.Run(testCase.Name, func(t *testing.T) {
+					res, err := testCase.Results()
+					if testCase.Name == "inspect" {
+						assert.NotNil(t, err)
+						assert.NotNil(t, res)
+						ossectest.VerifyInspect(t, res.Inspect())
+					} else {
+						require.Nil(t, err)
+						require.NotNil(t, res)
+						assert.NotNil(t, res.Inspect().Response)
+						ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+					}
+				})
+			}
+		})
+	}
+}

--- a/plugins/security/api_internalusers-delete.go
+++ b/plugins/security/api_internalusers-delete.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// InternalUsersDeleteReq represents possible options for the internalusers delete request
+type InternalUsersDeleteReq struct {
+	User string
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r InternalUsersDeleteReq) GetRequest() (*http.Request, error) {
+	return opensearch.BuildRequest(
+		"DELETE",
+		fmt.Sprintf("/_plugins/_security/api/internalusers/%s", r.User),
+		nil,
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// InternalUsersDeleteResp represents the returned struct of the internalusers delete response
+type InternalUsersDeleteResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r InternalUsersDeleteResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_internalusers-get.go
+++ b/plugins/security/api_internalusers-get.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// InternalUsersGetReq represents possible options for the internal users get request
+type InternalUsersGetReq struct {
+	User string
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r InternalUsersGetReq) GetRequest() (*http.Request, error) {
+	var path strings.Builder
+	path.Grow(len("/_plugins/_security/api/internalusers/") + len(r.User))
+	path.WriteString("/_plugins/_security/api/internalusers")
+	if len(r.User) > 0 {
+		path.WriteString("/")
+		path.WriteString(r.User)
+	}
+
+	return opensearch.BuildRequest(
+		"GET",
+		path.String(),
+		nil,
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// InternalUsersGetResp represents the returned struct of the internal users get response
+type InternalUsersGetResp struct {
+	Users    map[string]InternalUsersGetItem
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r InternalUsersGetResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}
+
+// InternalUsersGetItem is a sub type of InternalUsersGetResp containing information about a user
+type InternalUsersGetItem struct {
+	Hash          string            `json:"hash"`
+	Reserved      bool              `json:"reserved"`
+	Hidden        bool              `json:"hidden"`
+	BackendRoles  []string          `json:"backend_roles"`
+	Attributes    map[string]string `json:"attributes"`
+	Description   string            `json:"description"`
+	SecurityRoles []string          `json:"opendistro_security_roles"`
+	Statis        bool              `json:"static"`
+}

--- a/plugins/security/api_internalusers-patch.go
+++ b/plugins/security/api_internalusers-patch.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// InternalUsersPatchReq represents possible options for the internalusers patch request
+type InternalUsersPatchReq struct {
+	User string
+	Body InternalUsersPatchBody
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r InternalUsersPatchReq) GetRequest() (*http.Request, error) {
+	body, err := json.Marshal(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var path strings.Builder
+	path.Grow(len("/_plugins/_security/api/internalusers/") + len(r.User))
+	path.WriteString("/_plugins/_security/api/internalusers")
+	if len(r.User) > 0 {
+		path.WriteString("/")
+		path.WriteString(r.User)
+	}
+
+	return opensearch.BuildRequest(
+		"PATCH",
+		path.String(),
+		bytes.NewReader(body),
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// InternalUsersPatchResp represents the returned struct of the internalusers patch response
+type InternalUsersPatchResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r InternalUsersPatchResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}
+
+// InternalUsersPatchBody represents the request body for the internalusers patch request
+type InternalUsersPatchBody []InternalUsersPatchBodyItem
+
+// InternalUsersPatchBodyItem is a sub type of InternalUsersPatchBody represeting patch item
+type InternalUsersPatchBodyItem struct {
+	OP    string `json:"op"`
+	Path  string `json:"path"`
+	Value any    `json:"value,omitempty"`
+}

--- a/plugins/security/api_internalusers-put.go
+++ b/plugins/security/api_internalusers-put.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// InternalUsersPutReq represents possible options for the internalusers put request
+type InternalUsersPutReq struct {
+	User string
+	Body InternalUsersPutBody
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r InternalUsersPutReq) GetRequest() (*http.Request, error) {
+	body, err := json.Marshal(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return opensearch.BuildRequest(
+		"PUT",
+		fmt.Sprintf("/_plugins/_security/api/internalusers/%s", r.User),
+		bytes.NewReader(body),
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// InternalUsersPutBody represents the request body for InternalUsersPutReq
+type InternalUsersPutBody struct {
+	Password      string            `json:"password,omitempty"`
+	Hash          string            `json:"hash,omitempty"`
+	BackendRoles  []string          `json:"backend_roles,omitempty"`
+	Attributes    map[string]string `json:"attributes,omitempty"`
+	Description   string            `json:"description,omitempty"`
+	SecurityRoles []string          `json:"opendistro_security_roles,omitempty"`
+}
+
+// InternalUsersPutResp represents the returned struct of the internalusers put response
+type InternalUsersPutResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r InternalUsersPutResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_internalusers.go
+++ b/plugins/security/api_internalusers.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"context"
+)
+
+type internalusersClient struct {
+	apiClient *Client
+}
+
+// Get executes a get internalusers request with the optional InternalUsersGetReq
+func (c internalusersClient) Get(ctx context.Context, req *InternalUsersGetReq) (InternalUsersGetResp, error) {
+	if req == nil {
+		req = &InternalUsersGetReq{}
+	}
+
+	var (
+		data InternalUsersGetResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Put executes a put internalusers request with the required InternalUsersPutReq
+func (c internalusersClient) Put(ctx context.Context, req InternalUsersPutReq) (InternalUsersPutResp, error) {
+	var (
+		data InternalUsersPutResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Delete executes a delete internalusers request with the required InternalUsersDeleteReq
+func (c internalusersClient) Delete(ctx context.Context, req InternalUsersDeleteReq) (InternalUsersDeleteResp, error) {
+	var (
+		data InternalUsersDeleteResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Patch executes a patch internalusers request with the required InternalUsersPatchReq
+func (c internalusersClient) Patch(ctx context.Context, req InternalUsersPatchReq) (InternalUsersPatchResp, error) {
+	var (
+		data InternalUsersPatchResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}

--- a/plugins/security/api_internalusers_test.go
+++ b/plugins/security/api_internalusers_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+//
+//go:build integration
+
+package security_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
+	"github.com/opensearch-project/opensearch-go/v3/plugins/security"
+	ossectest "github.com/opensearch-project/opensearch-go/v3/plugins/security/internal/test"
+)
+
+func TestInternalUsersClient(t *testing.T) {
+	ostest.SkipIfNotSecure(t)
+	client, err := ossectest.NewClient()
+	require.Nil(t, err)
+
+	failingClient, err := ossectest.CreateFailingClient()
+	require.Nil(t, err)
+
+	testUser := "test_user"
+
+	type internalusersTests struct {
+		Name    string
+		Results func() (ossectest.Response, error)
+	}
+
+	testCases := []struct {
+		Name  string
+		Tests []internalusersTests
+	}{
+		{
+			Name: "Put",
+			Tests: []internalusersTests{
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.InternalUsers.Put(
+							nil,
+							security.InternalUsersPutReq{
+								User: testUser,
+								Body: security.InternalUsersPutBody{
+									Password: "myStrongPassword123!",
+								},
+							},
+						)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.InternalUsers.Put(nil, security.InternalUsersPutReq{})
+					},
+				},
+			},
+		},
+		{
+			Name: "Get",
+			Tests: []internalusersTests{
+				{
+					Name: "without request",
+					Results: func() (ossectest.Response, error) {
+						return client.InternalUsers.Get(nil, nil)
+					},
+				},
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.InternalUsers.Get(nil, &security.InternalUsersGetReq{User: testUser})
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.InternalUsers.Get(nil, nil)
+					},
+				},
+			},
+		},
+		{
+			Name: "Delete",
+			Tests: []internalusersTests{
+				{
+					Name: "without request",
+					Results: func() (ossectest.Response, error) {
+						return client.InternalUsers.Delete(nil, security.InternalUsersDeleteReq{User: testUser})
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.InternalUsers.Delete(nil, security.InternalUsersDeleteReq{User: testUser})
+					},
+				},
+			},
+		},
+		{
+			Name: "Patch",
+			Tests: []internalusersTests{
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.InternalUsers.Patch(
+							nil,
+							security.InternalUsersPatchReq{
+								Body: security.InternalUsersPatchBody{
+									security.InternalUsersPatchBodyItem{
+										OP:   "add",
+										Path: "/test",
+										Value: security.InternalUsersPutBody{
+											Password: "myStrongPassword123!",
+										},
+									},
+									security.InternalUsersPatchBodyItem{
+										OP:   "remove",
+										Path: "/test",
+									},
+								},
+							},
+						)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.InternalUsers.Patch(nil, security.InternalUsersPatchReq{})
+					},
+				},
+			},
+		},
+	}
+	for _, value := range testCases {
+		t.Run(value.Name, func(t *testing.T) {
+			for _, testCase := range value.Tests {
+				t.Run(testCase.Name, func(t *testing.T) {
+					res, err := testCase.Results()
+					if testCase.Name == "inspect" {
+						assert.NotNil(t, err)
+						assert.NotNil(t, res)
+						ossectest.VerifyInspect(t, res.Inspect())
+					} else {
+						require.Nil(t, err)
+						require.NotNil(t, res)
+						assert.NotNil(t, res.Inspect().Response)
+						if value.Name != "Get" {
+							ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+						}
+					}
+				})
+			}
+		})
+	}
+	t.Run("ValidateResponse", func(t *testing.T) {
+		t.Run("Get", func(t *testing.T) {
+			resp, err := client.InternalUsers.Get(nil, nil)
+			assert.Nil(t, err)
+			assert.NotNil(t, resp)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Users, resp.Inspect().Response)
+		})
+	})
+}

--- a/plugins/security/api_nodesdn-delete.go
+++ b/plugins/security/api_nodesdn-delete.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// NodesDNDeleteReq represents possible options for the nodesdn delete request
+type NodesDNDeleteReq struct {
+	Cluster string
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r NodesDNDeleteReq) GetRequest() (*http.Request, error) {
+	return opensearch.BuildRequest(
+		"DELETE",
+		fmt.Sprintf("/_plugins/_security/api/nodesdn/%s", r.Cluster),
+		nil,
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// NodesDNDeleteResp represents the returned struct of the nodesdn delete response
+type NodesDNDeleteResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r NodesDNDeleteResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_nodesdn-get.go
+++ b/plugins/security/api_nodesdn-get.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// NodesDNGetReq represents possible options for the nodes dn get request
+type NodesDNGetReq struct {
+	Cluster string
+	Header  http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r NodesDNGetReq) GetRequest() (*http.Request, error) {
+	var path strings.Builder
+	path.Grow(len("/_plugins/_security/api/nodesdn/") + len(r.Cluster))
+	path.WriteString("/_plugins/_security/api/nodesdn")
+	if len(r.Cluster) > 0 {
+		path.WriteString("/")
+		path.WriteString(r.Cluster)
+	}
+
+	return opensearch.BuildRequest(
+		"GET",
+		path.String(),
+		nil,
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// NodesDNGetResp represents the returned struct of the nodes dn get response
+type NodesDNGetResp struct {
+	DistinguishedNames map[string]struct {
+		NodesDN []string `json:"nodes_dn"`
+	}
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r NodesDNGetResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_nodesdn-patch.go
+++ b/plugins/security/api_nodesdn-patch.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// NodesDNPatchReq represents possible options for the nodesdn patch request
+type NodesDNPatchReq struct {
+	Cluster string
+	Body    NodesDNPatchBody
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r NodesDNPatchReq) GetRequest() (*http.Request, error) {
+	body, err := json.Marshal(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var path strings.Builder
+	path.Grow(len("/_plugins/_security/api/nodesdn/") + len(r.Cluster))
+	path.WriteString("/_plugins/_security/api/nodesdn")
+	if len(r.Cluster) > 0 {
+		path.WriteString("/")
+		path.WriteString(r.Cluster)
+	}
+
+	return opensearch.BuildRequest(
+		"PATCH",
+		path.String(),
+		bytes.NewReader(body),
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// NodesDNPatchResp represents the returned struct of the nodesdn patch response
+type NodesDNPatchResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r NodesDNPatchResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}
+
+// NodesDNPatchBody represents the request body for the nodesdn patch request
+type NodesDNPatchBody []NodesDNPatchBodyItem
+
+// NodesDNPatchBodyItem is a sub type of NodesDNPatchBody represeting patch item
+type NodesDNPatchBodyItem struct {
+	OP    string `json:"op"`
+	Path  string `json:"path"`
+	Value any    `json:"value,omitempty"`
+}

--- a/plugins/security/api_nodesdn-put.go
+++ b/plugins/security/api_nodesdn-put.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// NodesDNPutReq represents possible options for the nodesdn put request
+type NodesDNPutReq struct {
+	Cluster string
+	Body    NodesDNPutBody
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r NodesDNPutReq) GetRequest() (*http.Request, error) {
+	body, err := json.Marshal(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return opensearch.BuildRequest(
+		"PUT",
+		fmt.Sprintf("/_plugins/_security/api/nodesdn/%s", r.Cluster),
+		bytes.NewReader(body),
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// NodesDNPutBody reperensts the request body for NodesDNPutReq
+type NodesDNPutBody struct {
+	NodesDN []string `json:"nodes_dn"`
+}
+
+// NodesDNPutResp represents the returned struct of the nodesdn put response
+type NodesDNPutResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r NodesDNPutResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_nodesdn.go
+++ b/plugins/security/api_nodesdn.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"context"
+)
+
+type nodesdnClient struct {
+	apiClient *Client
+}
+
+// Get executes a get nodesdn request with the optional NodesDNGetReq
+func (c nodesdnClient) Get(ctx context.Context, req *NodesDNGetReq) (NodesDNGetResp, error) {
+	if req == nil {
+		req = &NodesDNGetReq{}
+	}
+
+	var (
+		data NodesDNGetResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data.DistinguishedNames); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Put executes a put nodesdn request with the required NodesDNPutReq
+func (c nodesdnClient) Put(ctx context.Context, req NodesDNPutReq) (NodesDNPutResp, error) {
+	var (
+		data NodesDNPutResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Delete executes a delete nodesdn request with the required NodesDNDeleteReq
+func (c nodesdnClient) Delete(ctx context.Context, req NodesDNDeleteReq) (NodesDNDeleteResp, error) {
+	var (
+		data NodesDNDeleteResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Patch executes a put nodesdn request with the required NodesDNPatchReq
+func (c nodesdnClient) Patch(ctx context.Context, req NodesDNPatchReq) (NodesDNPatchResp, error) {
+	var (
+		data NodesDNPatchResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}

--- a/plugins/security/api_nodesdn_test.go
+++ b/plugins/security/api_nodesdn_test.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+//
+//go:build integration
+
+package security_test
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
+	"github.com/opensearch-project/opensearch-go/v3/plugins/security"
+	ossectest "github.com/opensearch-project/opensearch-go/v3/plugins/security/internal/test"
+)
+
+func TestNodesDNClient(t *testing.T) {
+	ostest.SkipIfNotSecure(t)
+	config, err := ossectest.ClientConfig()
+	require.Nil(t, err)
+
+	clientTLSCert, err := tls.LoadX509KeyPair("../../admin.pem", "../../admin.key")
+	require.Nil(t, err)
+
+	config.Client.Transport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			Certificates:       []tls.Certificate{clientTLSCert},
+		},
+	}
+
+	client, err := security.NewClient(*config)
+	require.Nil(t, err)
+
+	failingClient, err := ossectest.CreateFailingClient()
+	require.Nil(t, err)
+
+	type nodesdnTests struct {
+		Name    string
+		Results func() (ossectest.Response, error)
+	}
+
+	testCases := []struct {
+		Name  string
+		Tests []nodesdnTests
+	}{
+		{
+			Name: "Put",
+			Tests: []nodesdnTests{
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.NodesDN.Put(
+							nil,
+							security.NodesDNPutReq{
+								Cluster: "test",
+								Body: security.NodesDNPutBody{
+									NodesDN: []string{"CN=test.example.com"},
+								},
+							},
+						)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.NodesDN.Put(nil, security.NodesDNPutReq{})
+					},
+				},
+			},
+		},
+		{
+			Name: "Get",
+			Tests: []nodesdnTests{
+				{
+					Name: "without request",
+					Results: func() (ossectest.Response, error) {
+						return client.NodesDN.Get(nil, nil)
+					},
+				},
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.NodesDN.Get(nil, &security.NodesDNGetReq{Cluster: "test"})
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.NodesDN.Get(nil, nil)
+					},
+				},
+			},
+		},
+		{
+			Name: "Delete",
+			Tests: []nodesdnTests{
+				{
+					Name: "without request",
+					Results: func() (ossectest.Response, error) {
+						return client.NodesDN.Delete(nil, security.NodesDNDeleteReq{Cluster: "test"})
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.NodesDN.Delete(nil, security.NodesDNDeleteReq{Cluster: "test"})
+					},
+				},
+			},
+		},
+		{
+			Name: "Patch",
+			Tests: []nodesdnTests{
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.NodesDN.Patch(
+							nil,
+							security.NodesDNPatchReq{
+								Body: security.NodesDNPatchBody{
+									security.NodesDNPatchBodyItem{
+										OP:   "add",
+										Path: "/test",
+										Value: security.NodesDNPutBody{
+											NodesDN: []string{"CN=test.example.com"},
+										},
+									},
+									security.NodesDNPatchBodyItem{
+										OP:   "remove",
+										Path: "/test",
+									},
+								},
+							},
+						)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.NodesDN.Patch(nil, security.NodesDNPatchReq{})
+					},
+				},
+			},
+		},
+	}
+	for _, value := range testCases {
+		t.Run(value.Name, func(t *testing.T) {
+			for _, testCase := range value.Tests {
+				t.Run(testCase.Name, func(t *testing.T) {
+					res, err := testCase.Results()
+					if testCase.Name == "inspect" {
+						assert.NotNil(t, err)
+						assert.NotNil(t, res)
+						ossectest.VerifyInspect(t, res.Inspect())
+					} else {
+						require.Nil(t, err)
+						require.NotNil(t, res)
+						assert.NotNil(t, res.Inspect().Response)
+						if value.Name != "Get" {
+							ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+						}
+					}
+				})
+			}
+		})
+	}
+	t.Run("ValidateResponse", func(t *testing.T) {
+		t.Run("Get", func(t *testing.T) {
+			resp, err := client.NodesDN.Get(nil, nil)
+			assert.Nil(t, err)
+			assert.NotNil(t, resp)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.DistinguishedNames, resp.Inspect().Response)
+		})
+	})
+}

--- a/plugins/security/api_roles-delete.go
+++ b/plugins/security/api_roles-delete.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// RolesDeleteReq represents possible options for the roles delete request
+type RolesDeleteReq struct {
+	Role string
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r RolesDeleteReq) GetRequest() (*http.Request, error) {
+	return opensearch.BuildRequest(
+		"DELETE",
+		fmt.Sprintf("/_plugins/_security/api/roles/%s", r.Role),
+		nil,
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// RolesDeleteResp represents the returned struct of the roles delete response
+type RolesDeleteResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r RolesDeleteResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_roles-get.go
+++ b/plugins/security/api_roles-get.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// RolesGetReq represents possible options for the roles get request
+type RolesGetReq struct {
+	Role string
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r RolesGetReq) GetRequest() (*http.Request, error) {
+	var path strings.Builder
+	path.Grow(len("/_plugins/_security/api/roles/") + len(r.Role))
+	path.WriteString("/_plugins/_security/api/roles")
+	if len(r.Role) > 0 {
+		path.WriteString("/")
+		path.WriteString(r.Role)
+	}
+
+	return opensearch.BuildRequest(
+		"GET",
+		path.String(),
+		nil,
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// RolesGetResp represents the returned struct of the roles get response
+type RolesGetResp struct {
+	Roles    map[string]RolesGetItem
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r RolesGetResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}
+
+// RolesGetItem is a sub type of RolesGetResp containing information about a role
+type RolesGetItem struct {
+	Reserved           bool                    `json:"reserved"`
+	Hidden             bool                    `json:"hidden"`
+	Description        string                  `json:"description"`
+	ClusterPermissions []string                `json:"cluster_permissions"`
+	IndexPermissions   []RolesIndexPermission  `json:"index_permissions"`
+	TenantPermissions  []RolesTenantPermission `json:"tenant_permissions"`
+	Statis             bool                    `json:"static"`
+}

--- a/plugins/security/api_roles-patch.go
+++ b/plugins/security/api_roles-patch.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// RolesPatchReq represents possible options for the roles patch request
+type RolesPatchReq struct {
+	Role string
+	Body RolesPatchBody
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r RolesPatchReq) GetRequest() (*http.Request, error) {
+	body, err := json.Marshal(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var path strings.Builder
+	path.Grow(len("/_plugins/_security/api/roles/") + len(r.Role))
+	path.WriteString("/_plugins/_security/api/roles")
+	if len(r.Role) > 0 {
+		path.WriteString("/")
+		path.WriteString(r.Role)
+	}
+
+	return opensearch.BuildRequest(
+		"PATCH",
+		path.String(),
+		bytes.NewReader(body),
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// RolesPatchResp represents the returned struct of the roles patch response
+type RolesPatchResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r RolesPatchResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}
+
+// RolesPatchBody represents the request body for the roles patch request
+type RolesPatchBody []RolesPatchBodyItem
+
+// RolesPatchBodyItem is a sub type of RolesPatchBody represeting patch item
+type RolesPatchBodyItem struct {
+	OP    string `json:"op"`
+	Path  string `json:"path"`
+	Value any    `json:"value,omitempty"`
+}

--- a/plugins/security/api_roles-put.go
+++ b/plugins/security/api_roles-put.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// RolesPutReq represents possible options for the roles put request
+type RolesPutReq struct {
+	Role string
+	Body RolesPutBody
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r RolesPutReq) GetRequest() (*http.Request, error) {
+	body, err := json.Marshal(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return opensearch.BuildRequest(
+		"PUT",
+		fmt.Sprintf("/_plugins/_security/api/roles/%s", r.Role),
+		bytes.NewReader(body),
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// RolesPutBody represents the request body for RolesPutReq
+type RolesPutBody struct {
+	Description        string                  `json:"description,omitempty"`
+	ClusterPermissions []string                `json:"cluster_permissions,omitempty"`
+	IndexPermissions   []RolesIndexPermission  `json:"index_permissions,omitempty"`
+	TenantPermissions  []RolesTenantPermission `json:"tenant_permissions,omitempty"`
+}
+
+// RolesPutResp represents the returned struct of the roles put response
+type RolesPutResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r RolesPutResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_roles.go
+++ b/plugins/security/api_roles.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"context"
+)
+
+type rolesClient struct {
+	apiClient *Client
+}
+
+// Get executes a get roles request with the optional RolesGetReq
+func (c rolesClient) Get(ctx context.Context, req *RolesGetReq) (RolesGetResp, error) {
+	if req == nil {
+		req = &RolesGetReq{}
+	}
+
+	var (
+		data RolesGetResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Put executes a put roles request with the required RolesPutReq
+func (c rolesClient) Put(ctx context.Context, req RolesPutReq) (RolesPutResp, error) {
+	var (
+		data RolesPutResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Delete executes a delete roles request with the required RolesDeleteReq
+func (c rolesClient) Delete(ctx context.Context, req RolesDeleteReq) (RolesDeleteResp, error) {
+	var (
+		data RolesDeleteResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Patch executes a patch roles request with the required RolesPatchReq
+func (c rolesClient) Patch(ctx context.Context, req RolesPatchReq) (RolesPatchResp, error) {
+	var (
+		data RolesPatchResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// RolesIndexPermission contains index permissions and is used for Get and Put requests
+type RolesIndexPermission struct {
+	IndexPatterns  []string `json:"index_patterns,omitempty"`
+	DLS            string   `json:"dls,omitempty"`
+	FLS            string   `json:"fls,omitempty"`
+	MaskedFields   []string `json:"masked_fields,omitempty"`
+	AllowedActions []string `json:"allowed_actions,omitempty"`
+}
+
+// RolesTenantPermission contains tenant permissions and is used for Get and Put requests
+type RolesTenantPermission struct {
+	TenantPatterns []string `json:"tenant_patterns,omitempty"`
+	AllowedActions []string `json:"allowed_actions,omitempty"`
+}

--- a/plugins/security/api_roles_test.go
+++ b/plugins/security/api_roles_test.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+//
+//go:build integration
+
+package security_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
+	"github.com/opensearch-project/opensearch-go/v3/plugins/security"
+	ossectest "github.com/opensearch-project/opensearch-go/v3/plugins/security/internal/test"
+)
+
+func TestRolesClient(t *testing.T) {
+	ostest.SkipIfNotSecure(t)
+	client, err := ossectest.NewClient()
+	require.Nil(t, err)
+
+	failingClient, err := ossectest.CreateFailingClient()
+	require.Nil(t, err)
+
+	testRole := "test_role"
+
+	type rolesTests struct {
+		Name    string
+		Results func() (ossectest.Response, error)
+	}
+
+	testCases := []struct {
+		Name  string
+		Tests []rolesTests
+	}{
+		{
+			Name: "Put",
+			Tests: []rolesTests{
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.Roles.Put(
+							nil,
+							security.RolesPutReq{
+								Role: testRole,
+								Body: security.RolesPutBody{
+									Description:        "Test",
+									ClusterPermissions: []string{"cluster_monitor"},
+									IndexPermissions:   []security.RolesIndexPermission{security.RolesIndexPermission{IndexPatterns: []string{"*"}, AllowedActions: []string{"indices_monitor"}}},
+								},
+							},
+						)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.Roles.Put(nil, security.RolesPutReq{})
+					},
+				},
+			},
+		},
+		{
+			Name: "Get",
+			Tests: []rolesTests{
+				{
+					Name: "without request",
+					Results: func() (ossectest.Response, error) {
+						return client.Roles.Get(nil, nil)
+					},
+				},
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.Roles.Get(nil, &security.RolesGetReq{Role: testRole})
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.Roles.Get(nil, nil)
+					},
+				},
+			},
+		},
+		{
+			Name: "Delete",
+			Tests: []rolesTests{
+				{
+					Name: "without request",
+					Results: func() (ossectest.Response, error) {
+						return client.Roles.Delete(nil, security.RolesDeleteReq{Role: testRole})
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.Roles.Delete(nil, security.RolesDeleteReq{Role: testRole})
+					},
+				},
+			},
+		},
+		{
+			Name: "Patch",
+			Tests: []rolesTests{
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.Roles.Patch(
+							nil,
+							security.RolesPatchReq{
+								Body: security.RolesPatchBody{
+									security.RolesPatchBodyItem{
+										OP:   "add",
+										Path: "/test",
+										Value: security.RolesPutBody{
+											Description:        "Test",
+											ClusterPermissions: []string{"cluster_monitor"},
+											IndexPermissions:   []security.RolesIndexPermission{security.RolesIndexPermission{IndexPatterns: []string{"*"}, AllowedActions: []string{"indices_monitor"}}},
+										},
+									},
+									security.RolesPatchBodyItem{
+										OP:   "remove",
+										Path: "/test",
+									},
+								},
+							},
+						)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.Roles.Patch(nil, security.RolesPatchReq{})
+					},
+				},
+			},
+		},
+	}
+	for _, value := range testCases {
+		t.Run(value.Name, func(t *testing.T) {
+			for _, testCase := range value.Tests {
+				t.Run(testCase.Name, func(t *testing.T) {
+					res, err := testCase.Results()
+					if testCase.Name == "inspect" {
+						assert.NotNil(t, err)
+						assert.NotNil(t, res)
+						ossectest.VerifyInspect(t, res.Inspect())
+					} else {
+						if err != nil {
+							fmt.Println(err)
+						}
+						require.Nil(t, err)
+						require.NotNil(t, res)
+						assert.NotNil(t, res.Inspect().Response)
+						if value.Name != "Get" {
+							ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+						}
+					}
+				})
+			}
+		})
+	}
+	t.Run("ValidateResponse", func(t *testing.T) {
+		t.Run("Get", func(t *testing.T) {
+			resp, err := client.Roles.Get(nil, nil)
+			assert.Nil(t, err)
+			assert.NotNil(t, resp)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Roles, resp.Inspect().Response)
+		})
+	})
+}

--- a/plugins/security/api_rolesmapping-delete.go
+++ b/plugins/security/api_rolesmapping-delete.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// RolesMappingDeleteReq represents possible options for the roles delete request
+type RolesMappingDeleteReq struct {
+	Role string
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r RolesMappingDeleteReq) GetRequest() (*http.Request, error) {
+	return opensearch.BuildRequest(
+		"DELETE",
+		fmt.Sprintf("/_plugins/_security/api/rolesmapping/%s", r.Role),
+		nil,
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// RolesMappingDeleteResp represents the returned struct of the roles delete response
+type RolesMappingDeleteResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r RolesMappingDeleteResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_rolesmapping-get.go
+++ b/plugins/security/api_rolesmapping-get.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// RolesMappingGetReq represents possible options for the rolesmapping get request
+type RolesMappingGetReq struct {
+	Role string
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r RolesMappingGetReq) GetRequest() (*http.Request, error) {
+	var path strings.Builder
+	path.Grow(len("/_plugins/_security/api/rolesmapping/") + len(r.Role))
+	path.WriteString("/_plugins/_security/api/rolesmapping")
+	if len(r.Role) > 0 {
+		path.WriteString("/")
+		path.WriteString(r.Role)
+	}
+
+	return opensearch.BuildRequest(
+		"GET",
+		path.String(),
+		nil,
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// RolesMappingGetResp represents the returned struct of the rolesmapping get response
+type RolesMappingGetResp struct {
+	RolesMapping map[string]RolesMappingGetItem
+	response     *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r RolesMappingGetResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}
+
+// RolesMappingGetItem is a sub type of RolesMappingGetResp containing information about a role
+type RolesMappingGetItem struct {
+	Reserved        bool     `json:"reserved"`
+	Hidden          bool     `json:"hidden"`
+	Hosts           []string `json:"hosts"`
+	Users           []string `json:"users"`
+	BackendRoles    []string `json:"backend_roles"`
+	AndBackendRoles []string `json:"and_backend_roles"`
+	Description     string   `json:"description"`
+}

--- a/plugins/security/api_rolesmapping-patch.go
+++ b/plugins/security/api_rolesmapping-patch.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// RolesMappingPatchReq represents possible options for the rolesmapping patch request
+type RolesMappingPatchReq struct {
+	Role string
+	Body RolesMappingPatchBody
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r RolesMappingPatchReq) GetRequest() (*http.Request, error) {
+	body, err := json.Marshal(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var path strings.Builder
+	path.Grow(len("/_plugins/_security/api/rolesmapping/") + len(r.Role))
+	path.WriteString("/_plugins/_security/api/rolesmapping")
+	if len(r.Role) > 0 {
+		path.WriteString("/")
+		path.WriteString(r.Role)
+	}
+
+	return opensearch.BuildRequest(
+		"PATCH",
+		path.String(),
+		bytes.NewReader(body),
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// RolesMappingPatchResp represents the returned struct of the rolesmapping patch response
+type RolesMappingPatchResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r RolesMappingPatchResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}
+
+// RolesMappingPatchBody represents the request body for the rolesmapping patch request
+type RolesMappingPatchBody []RolesMappingPatchBodyItem
+
+// RolesMappingPatchBodyItem is a sub type of RolesMappingPatchBody represeting patch item
+type RolesMappingPatchBodyItem struct {
+	OP    string `json:"op"`
+	Path  string `json:"path"`
+	Value any    `json:"value,omitempty"`
+}

--- a/plugins/security/api_rolesmapping-put.go
+++ b/plugins/security/api_rolesmapping-put.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// RolesMappingPutReq represents possible options for the rolesmapping put request
+type RolesMappingPutReq struct {
+	Role string
+	Body RolesMappingPutBody
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r RolesMappingPutReq) GetRequest() (*http.Request, error) {
+	body, err := json.Marshal(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return opensearch.BuildRequest(
+		"PUT",
+		fmt.Sprintf("/_plugins/_security/api/rolesmapping/%s", r.Role),
+		bytes.NewReader(body),
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// RolesMappingPutBody represents the request body for RolesMappingPutReq
+type RolesMappingPutBody struct {
+	Hosts           []string `json:"hosts,omitempty"`
+	Users           []string `json:"users,omitempty"`
+	BackendRoles    []string `json:"backend_roles,omitempty"`
+	AndBackendRoles []string `json:"and_backend_roles,omitempty"`
+	Description     string   `json:"description,omitempty"`
+}
+
+// RolesMappingPutResp represents the returned struct of the rolesmapping put response
+type RolesMappingPutResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r RolesMappingPutResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_rolesmapping.go
+++ b/plugins/security/api_rolesmapping.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"context"
+)
+
+type rolesmappingClient struct {
+	apiClient *Client
+}
+
+// Get executes a get roles request with the optional RolesMappingGetReq
+func (c rolesmappingClient) Get(ctx context.Context, req *RolesMappingGetReq) (RolesMappingGetResp, error) {
+	if req == nil {
+		req = &RolesMappingGetReq{}
+	}
+
+	var (
+		data RolesMappingGetResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Put executes a put roles request with the required RolesMappingPutReq
+func (c rolesmappingClient) Put(ctx context.Context, req RolesMappingPutReq) (RolesMappingPutResp, error) {
+	var (
+		data RolesMappingPutResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Delete executes a delete roles request with the required RolesMappingDeleteReq
+func (c rolesmappingClient) Delete(ctx context.Context, req RolesMappingDeleteReq) (RolesMappingDeleteResp, error) {
+	var (
+		data RolesMappingDeleteResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Patch executes a patch roles request with the required RolesMappingPatchReq
+func (c rolesmappingClient) Patch(ctx context.Context, req RolesMappingPatchReq) (RolesMappingPatchResp, error) {
+	var (
+		data RolesMappingPatchResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}

--- a/plugins/security/api_rolesmapping_test.go
+++ b/plugins/security/api_rolesmapping_test.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+//
+//go:build integration
+
+package security_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
+	"github.com/opensearch-project/opensearch-go/v3/plugins/security"
+	ossectest "github.com/opensearch-project/opensearch-go/v3/plugins/security/internal/test"
+)
+
+func TestRolesMappingClient(t *testing.T) {
+	ostest.SkipIfNotSecure(t)
+	client, err := ossectest.NewClient()
+	require.Nil(t, err)
+
+	failingClient, err := ossectest.CreateFailingClient()
+	require.Nil(t, err)
+
+	testRole := "test_role"
+	client.Roles.Put(
+		nil,
+		security.RolesPutReq{
+			Role: testRole,
+			Body: security.RolesPutBody{
+				Description:        "Test",
+				ClusterPermissions: []string{"cluster_monitor"},
+				IndexPermissions:   []security.RolesIndexPermission{security.RolesIndexPermission{IndexPatterns: []string{"*"}, AllowedActions: []string{"indices_monitor"}}},
+			},
+		},
+	)
+	t.Cleanup(func() {
+		client.Roles.Delete(nil, security.RolesDeleteReq{Role: testRole})
+	})
+
+	type rolesmappingTests struct {
+		Name    string
+		Results func() (ossectest.Response, error)
+	}
+
+	testCases := []struct {
+		Name  string
+		Tests []rolesmappingTests
+	}{
+		{
+			Name: "Put",
+			Tests: []rolesmappingTests{
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.RolesMapping.Put(
+							nil,
+							security.RolesMappingPutReq{
+								Role: testRole,
+								Body: security.RolesMappingPutBody{
+									Description:  "Test",
+									Users:        []string{"test"},
+									BackendRoles: []string{"test"},
+								},
+							},
+						)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.RolesMapping.Put(nil, security.RolesMappingPutReq{})
+					},
+				},
+			},
+		},
+		{
+			Name: "Get",
+			Tests: []rolesmappingTests{
+				{
+					Name: "without request",
+					Results: func() (ossectest.Response, error) {
+						return client.RolesMapping.Get(nil, nil)
+					},
+				},
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.RolesMapping.Get(nil, &security.RolesMappingGetReq{Role: testRole})
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.RolesMapping.Get(nil, nil)
+					},
+				},
+			},
+		},
+		{
+			Name: "Delete",
+			Tests: []rolesmappingTests{
+				{
+					Name: "without request",
+					Results: func() (ossectest.Response, error) {
+						return client.RolesMapping.Delete(nil, security.RolesMappingDeleteReq{Role: testRole})
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.RolesMapping.Delete(nil, security.RolesMappingDeleteReq{Role: testRole})
+					},
+				},
+			},
+		},
+		{
+			Name: "Patch",
+			Tests: []rolesmappingTests{
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.RolesMapping.Patch(
+							nil,
+							security.RolesMappingPatchReq{
+								Body: security.RolesMappingPatchBody{
+									security.RolesMappingPatchBodyItem{
+										OP:   "add",
+										Path: "/test",
+										Value: security.RolesMappingPutBody{
+											Description:  "Test",
+											Users:        []string{"test"},
+											BackendRoles: []string{"test"},
+										},
+									},
+									security.RolesMappingPatchBodyItem{
+										OP:   "remove",
+										Path: "/test",
+									},
+								},
+							},
+						)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.RolesMapping.Patch(nil, security.RolesMappingPatchReq{})
+					},
+				},
+			},
+		},
+	}
+	for _, value := range testCases {
+		t.Run(value.Name, func(t *testing.T) {
+			for _, testCase := range value.Tests {
+				t.Run(testCase.Name, func(t *testing.T) {
+					res, err := testCase.Results()
+					if testCase.Name == "inspect" {
+						assert.NotNil(t, err)
+						assert.NotNil(t, res)
+						ossectest.VerifyInspect(t, res.Inspect())
+					} else {
+						if err != nil {
+							fmt.Println(err)
+						}
+						require.Nil(t, err)
+						require.NotNil(t, res)
+						assert.NotNil(t, res.Inspect().Response)
+						if value.Name != "Get" {
+							ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+						}
+					}
+				})
+			}
+		})
+	}
+	t.Run("ValidateResponse", func(t *testing.T) {
+		t.Run("Get", func(t *testing.T) {
+			resp, err := client.RolesMapping.Get(nil, nil)
+			assert.Nil(t, err)
+			assert.NotNil(t, resp)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.RolesMapping, resp.Inspect().Response)
+		})
+	})
+}

--- a/plugins/security/api_securityconfig-get.go
+++ b/plugins/security/api_securityconfig-get.go
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// ConfigGetReq represents possible options for the securityconfig get request
+type ConfigGetReq struct {
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r ConfigGetReq) GetRequest() (*http.Request, error) {
+	return opensearch.BuildRequest(
+		"GET",
+		"/_plugins/_security/api/securityconfig",
+		nil,
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// ConfigGetResp represents the returned struct of the securityconfig get response
+type ConfigGetResp struct {
+	Config struct {
+		Dynamic ConfigDynamic `json:"dynamic"`
+	} `json:"config"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r ConfigGetResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}
+
+// ConfigDynamic represents the opensearch security config and is sub type of ConfigGetResp and ConfigPutBody
+type ConfigDynamic struct {
+	FilteredAliasMode            string              `json:"filtered_alias_mode"`
+	DisableRestAuth              bool                `json:"disable_rest_auth"`
+	DisableIntertransportAuth    bool                `json:"disable_intertransport_auth"`
+	RespectRequestIndicesOptions bool                `json:"respect_request_indices_options"`
+	Kibana                       ConfigDynamicKibana `json:"kibana"`
+	HTTP                         ConfigDynamicHTTP   `json:"http"`
+	Authc                        ConfigDynamicAuthc  `json:"authc"`
+	Authz                        ConfigDynamicAuthz  `json:"authz"`
+	AuthFailureListeners         json.RawMessage     `json:"auth_failure_listeners"`
+	DoNotFailOnForbidden         bool                `json:"do_not_fail_on_forbidden"`
+	MultiRolespanEnabled         bool                `json:"multi_rolespan_enabled"`
+	HostsResolverMode            string              `json:"hosts_resolver_mode"`
+	DoNotFailOnForbiddenEmpty    bool                `json:"do_not_fail_on_forbidden_empty"`
+	OnBehalfOf                   *struct {
+		Enabled bool `json:"enabled"`
+	} `json:"on_behalf_of,omitempty"`
+}
+
+// ConfigDynamicKibana is a sub type of ConfigDynamic containing security settings for kibana
+type ConfigDynamicKibana struct {
+	MultitenancyEnabled  bool    `json:"multitenancy_enabled"`
+	PrivateTenantEnabled *bool   `json:"private_tenant_enabled,omitempty"`
+	DefaultTenant        *string `json:"default_tenant,omitempty"`
+	ServerUsername       string  `json:"server_username"`
+	Index                string  `json:"index"`
+}
+
+// ConfigDynamicHTTP is a sub type of ConfigDynamic containing security settings for HTTP
+type ConfigDynamicHTTP struct {
+	AnonymousAuthEnabled bool `json:"anonymous_auth_enabled"`
+	Xff                  struct {
+		Enabled         bool   `json:"enabled"`
+		InternalProxies string `json:"internalProxies"`
+		RemoteIPHeader  string `json:"remoteIpHeader"`
+	} `json:"xff"`
+}
+
+// ConfigDynamicAuthc is a sub type of ConfigDynamic containing security settings for Authc
+type ConfigDynamicAuthc struct {
+	JwtAuthDomain struct {
+		HTTPEnabled       bool  `json:"http_enabled"`
+		TransportEnabled  *bool `json:"transport_enabled,omitempty"`
+		Order             int   `json:"order"`
+		HTTPAuthenticator struct {
+			Challenge bool   `json:"challenge"`
+			Type      string `json:"type"`
+			Config    struct {
+				SigningKey                   string `json:"signing_key"`
+				JwtHeader                    string `json:"jwt_header"`
+				JwtClockSkewToleranceSeconds int    `json:"jwt_clock_skew_tolerance_seconds"`
+			} `json:"config"`
+		} `json:"http_authenticator"`
+		AuthenticationBackend struct {
+			Type   string          `json:"type"`
+			Config json.RawMessage `json:"config"`
+		} `json:"authentication_backend"`
+		Description string `json:"description"`
+	} `json:"jwt_auth_domain"`
+	LDAP struct {
+		HTTPEnabled       bool  `json:"http_enabled"`
+		TransportEnabled  *bool `json:"transport_enabled,omitempty"`
+		Order             int   `json:"order"`
+		HTTPAuthenticator struct {
+			Challenge bool            `json:"challenge"`
+			Type      string          `json:"type"`
+			Config    json.RawMessage `json:"config"`
+		} `json:"http_authenticator"`
+		AuthenticationBackend struct {
+			Type   string `json:"type"`
+			Config struct {
+				EnableSSL           bool     `json:"enable_ssl"`
+				EnableStartTLS      bool     `json:"enable_start_tls"`
+				EnableSSLClientAuth bool     `json:"enable_ssl_client_auth"`
+				VerifyHostnames     bool     `json:"verify_hostnames"`
+				Hosts               []string `json:"hosts"`
+				Userbase            string   `json:"userbase"`
+				Usersearch          string   `json:"usersearch"`
+			} `json:"config"`
+		} `json:"authentication_backend"`
+		Description string `json:"description"`
+	} `json:"ldap"`
+	BasicInternalAuthDomain struct {
+		HTTPEnabled       bool  `json:"http_enabled"`
+		TransportEnabled  *bool `json:"transport_enabled,omitempty"`
+		Order             int   `json:"order"`
+		HTTPAuthenticator struct {
+			Challenge bool            `json:"challenge"`
+			Type      string          `json:"type"`
+			Config    json.RawMessage `json:"config"`
+		} `json:"http_authenticator"`
+		AuthenticationBackend struct {
+			Type   string          `json:"type"`
+			Config json.RawMessage `json:"config"`
+		} `json:"authentication_backend"`
+		Description string `json:"description"`
+	} `json:"basic_internal_auth_domain"`
+	ProxyAuthDomain struct {
+		HTTPEnabled       bool  `json:"http_enabled"`
+		TransportEnabled  *bool `json:"transport_enabled,omitempty"`
+		Order             int   `json:"order"`
+		HTTPAuthenticator struct {
+			Challenge bool   `json:"challenge"`
+			Type      string `json:"type"`
+			Config    struct {
+				UserHeader  string `json:"user_header"`
+				RolesHeader string `json:"roles_header"`
+			} `json:"config"`
+		} `json:"http_authenticator"`
+		AuthenticationBackend struct {
+			Type   string          `json:"type"`
+			Config json.RawMessage `json:"config"`
+		} `json:"authentication_backend"`
+		Description string `json:"description"`
+	} `json:"proxy_auth_domain"`
+	ClientcertAuthDomain struct {
+		HTTPEnabled       bool  `json:"http_enabled"`
+		TransportEnabled  *bool `json:"transport_enabled,omitempty"`
+		Order             int   `json:"order"`
+		HTTPAuthenticator struct {
+			Challenge bool   `json:"challenge"`
+			Type      string `json:"type"`
+			Config    struct {
+				UsernameAttribute string `json:"username_attribute"`
+			} `json:"config"`
+		} `json:"http_authenticator"`
+		AuthenticationBackend struct {
+			Type   string          `json:"type"`
+			Config json.RawMessage `json:"config"`
+		} `json:"authentication_backend"`
+		Description string `json:"description"`
+	} `json:"clientcert_auth_domain"`
+	KerberosAuthDomain struct {
+		HTTPEnabled       bool  `json:"http_enabled"`
+		TransportEnabled  *bool `json:"transport_enabled,omitempty"`
+		Order             int   `json:"order"`
+		HTTPAuthenticator struct {
+			Challenge bool   `json:"challenge"`
+			Type      string `json:"type"`
+			Config    struct {
+				KrbDebug                bool `json:"krb_debug"`
+				StripRealmFromPrincipal bool `json:"strip_realm_from_principal"`
+			} `json:"config"`
+		} `json:"http_authenticator"`
+		AuthenticationBackend struct {
+			Type   string          `json:"type"`
+			Config json.RawMessage `json:"config"`
+		} `json:"authentication_backend"`
+	} `json:"kerberos_auth_domain"`
+}
+
+// ConfigDynamicAuthz is a sub type of ConfigDynamic containing security settings for Authz
+type ConfigDynamicAuthz struct {
+	RolesFromAnotherLdap struct {
+		HTTPEnabled          bool  `json:"http_enabled"`
+		TransportEnabled     *bool `json:"transport_enabled,omitempty"`
+		AuthorizationBackend struct {
+			Type   string          `json:"type"`
+			Config json.RawMessage `json:"config"`
+		} `json:"authorization_backend"`
+		Description string `json:"description"`
+	} `json:"roles_from_another_ldap"`
+	RolesFromMyldap struct {
+		HTTPEnabled          bool  `json:"http_enabled"`
+		TransportEnabled     *bool `json:"transport_enabled,omitempty"`
+		AuthorizationBackend struct {
+			Type   string `json:"type"`
+			Config struct {
+				EnableSsl           bool     `json:"enable_ssl"`
+				EnableStartTLS      bool     `json:"enable_start_tls"`
+				EnableSslClientAuth bool     `json:"enable_ssl_client_auth"`
+				VerifyHostnames     bool     `json:"verify_hostnames"`
+				Hosts               []string `json:"hosts"`
+				Rolebase            string   `json:"rolebase"`
+				Rolesearch          string   `json:"rolesearch"`
+				Userrolename        string   `json:"userrolename"`
+				Rolename            string   `json:"rolename"`
+				ResolveNestedRoles  bool     `json:"resolve_nested_roles"`
+				Userbase            string   `json:"userbase"`
+				Usersearch          string   `json:"usersearch"`
+			} `json:"config"`
+		} `json:"authorization_backend"`
+		Description string `json:"description"`
+	} `json:"roles_from_myldap"`
+}

--- a/plugins/security/api_securityconfig-patch.go
+++ b/plugins/security/api_securityconfig-patch.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// ConfigPatchReq represents possible options for the securityconfig patch request
+type ConfigPatchReq struct {
+	Body ConfigPatchBody
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r ConfigPatchReq) GetRequest() (*http.Request, error) {
+	body, err := json.Marshal(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return opensearch.BuildRequest(
+		"PATCH",
+		"/_plugins/_security/api/securityconfig",
+		bytes.NewReader(body),
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// ConfigPatchResp represents the returned struct of the securityconfig patch response
+type ConfigPatchResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r ConfigPatchResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}
+
+// ConfigPatchBody represents the request body for the securityconfig patch request
+type ConfigPatchBody []ConfigPatchBodyItem
+
+// ConfigPatchBodyItem is a sub type of ConfigPatchBody represeting patch item
+type ConfigPatchBodyItem struct {
+	OP    string `json:"op"`
+	Path  string `json:"path"`
+	Value any    `json:"value,omitempty"`
+}

--- a/plugins/security/api_securityconfig-put.go
+++ b/plugins/security/api_securityconfig-put.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// ConfigPutReq represents possible options for the securityconfig get request
+type ConfigPutReq struct {
+	Body ConfigPutBody
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r ConfigPutReq) GetRequest() (*http.Request, error) {
+	body, err := json.Marshal(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return opensearch.BuildRequest(
+		"PUT",
+		"/_plugins/_security/api/securityconfig/config",
+		bytes.NewReader(body),
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// ConfigPutBody represents the request body for ConfigPutReq
+type ConfigPutBody struct {
+	Dynamic ConfigDynamic `json:"dynamic"`
+}
+
+// ConfigPutResp represents the returned struct of the securityconfig get response
+type ConfigPutResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r ConfigPutResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_securityconfig.go
+++ b/plugins/security/api_securityconfig.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"context"
+)
+
+type securityconfigClient struct {
+	apiClient *Client
+}
+
+// Get executes a get securityconfig request with the optional ConfigGetReq
+func (c securityconfigClient) Get(ctx context.Context, req *ConfigGetReq) (ConfigGetResp, error) {
+	if req == nil {
+		req = &ConfigGetReq{}
+	}
+
+	var (
+		data ConfigGetResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Put executes a put securityconfig request with the required ConfigPutReq
+func (c securityconfigClient) Put(ctx context.Context, req ConfigPutReq) (ConfigPutResp, error) {
+	var (
+		data ConfigPutResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Patch executes a patch securityconfig request with the required ConfigPatchReq
+func (c securityconfigClient) Patch(ctx context.Context, req ConfigPatchReq) (ConfigPatchResp, error) {
+	var (
+		data ConfigPatchResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}

--- a/plugins/security/api_securityconfig_test.go
+++ b/plugins/security/api_securityconfig_test.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+//
+//go:build integration
+
+package security_test
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
+	"github.com/opensearch-project/opensearch-go/v3/plugins/security"
+	ossectest "github.com/opensearch-project/opensearch-go/v3/plugins/security/internal/test"
+)
+
+func TestSecurityConfigClient(t *testing.T) {
+	ostest.SkipIfNotSecure(t)
+	config, err := ossectest.ClientConfig()
+	require.Nil(t, err)
+
+	clientTLSCert, err := tls.LoadX509KeyPair("../../admin.pem", "../../admin.key")
+	require.Nil(t, err)
+
+	config.Client.Transport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			Certificates:       []tls.Certificate{clientTLSCert},
+		},
+	}
+
+	client, err := security.NewClient(*config)
+	require.Nil(t, err)
+
+	failingClient, err := ossectest.CreateFailingClient()
+	require.Nil(t, err)
+
+	var putBody security.ConfigDynamic
+
+	type securityconfigTests struct {
+		Name    string
+		Results func() (ossectest.Response, error)
+	}
+
+	testCases := []struct {
+		Name  string
+		Tests []securityconfigTests
+	}{
+		{
+			Name: "Get",
+			Tests: []securityconfigTests{
+				{
+					Name: "without request",
+					Results: func() (ossectest.Response, error) {
+						resp, err := client.SecurityConfig.Get(nil, nil)
+						putBody = resp.Config.Dynamic
+						return resp, err
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.SecurityConfig.Get(nil, nil)
+					},
+				},
+			},
+		},
+		{
+			Name: "Put",
+			Tests: []securityconfigTests{
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.SecurityConfig.Put(
+							nil,
+							security.ConfigPutReq{
+								Body: security.ConfigPutBody{Dynamic: putBody},
+							},
+						)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.SecurityConfig.Put(nil, security.ConfigPutReq{})
+					},
+				},
+			},
+		},
+		{
+			Name: "Patch",
+			Tests: []securityconfigTests{
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.SecurityConfig.Patch(
+							nil,
+							security.ConfigPatchReq{
+								Body: security.ConfigPatchBody{
+									security.ConfigPatchBodyItem{
+										OP:    "replace",
+										Path:  "/config/dynamic/authc/basic_internal_auth_domain/http_enabled",
+										Value: false,
+									},
+									security.ConfigPatchBodyItem{
+										OP:    "replace",
+										Path:  "/config/dynamic/authc/basic_internal_auth_domain/http_enabled",
+										Value: true,
+									},
+								},
+							},
+						)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.SecurityConfig.Patch(nil, security.ConfigPatchReq{})
+					},
+				},
+			},
+		},
+	}
+	for _, value := range testCases {
+		t.Run(value.Name, func(t *testing.T) {
+			for _, testCase := range value.Tests {
+				t.Run(testCase.Name, func(t *testing.T) {
+					res, err := testCase.Results()
+					if testCase.Name == "inspect" {
+						assert.NotNil(t, err)
+						assert.NotNil(t, res)
+						ossectest.VerifyInspect(t, res.Inspect())
+					} else {
+						require.Nil(t, err)
+						require.NotNil(t, res)
+						assert.NotNil(t, res.Inspect().Response)
+						ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+					}
+				})
+			}
+		})
+	}
+}

--- a/plugins/security/api_ssl-get.go
+++ b/plugins/security/api_ssl-get.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// SSLGetReq represents possible options for the ssl/certs get request
+type SSLGetReq struct {
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r SSLGetReq) GetRequest() (*http.Request, error) {
+	return opensearch.BuildRequest(
+		"GET",
+		"/_plugins/_security/api/ssl/certs",
+		nil,
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// SSLGetResp represents the returned struct of the ssl/certs get response
+type SSLGetResp struct {
+	HTTPCerts     []SSLCertItem `json:"http_certificates_list"`
+	TransportCert []SSLCertItem `json:"transport_certificates_list"`
+	response      *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r SSLGetResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}
+
+// SSLCertItem is a sub type of SSLGetResp containing information about a cert
+type SSLCertItem struct {
+	IssuerDN  string    `json:"issuer_dn"`
+	SubjectDN string    `json:"subject_dn"`
+	SAN       string    `json:"san"`
+	NotBefore time.Time `json:"not_before"`
+	NotAfter  time.Time `json:"not_after"`
+}

--- a/plugins/security/api_ssl-http-reload.go
+++ b/plugins/security/api_ssl-http-reload.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// SSLHTTPReloadReq represents possible options for the http ssl reload request
+type SSLHTTPReloadReq struct {
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r SSLHTTPReloadReq) GetRequest() (*http.Request, error) {
+	return opensearch.BuildRequest(
+		"PUT",
+		"/_plugins/_security/api/ssl/http/reloadcerts",
+		nil,
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// SSLHTTPReloadResp represents the returned struct of the http ssl reload response
+type SSLHTTPReloadResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r SSLHTTPReloadResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_ssl-transport-reload.go
+++ b/plugins/security/api_ssl-transport-reload.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// SSLTransportReloadReq represents possible options for the transport ssl reload request
+type SSLTransportReloadReq struct {
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r SSLTransportReloadReq) GetRequest() (*http.Request, error) {
+	return opensearch.BuildRequest(
+		"PUT",
+		"/_plugins/_security/api/ssl/transport/reloadcerts",
+		nil,
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// SSLTransportReloadResp represents the returned struct of the transport ssl reload response
+type SSLTransportReloadResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r SSLTransportReloadResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_ssl.go
+++ b/plugins/security/api_ssl.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"context"
+)
+
+type sslClient struct {
+	apiClient *Client
+}
+
+// Get executes a get ssl request with the optional SSLGetReq
+func (c sslClient) Get(ctx context.Context, req *SSLGetReq) (SSLGetResp, error) {
+	if req == nil {
+		req = &SSLGetReq{}
+	}
+
+	var (
+		data SSLGetResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// HTTPReload executes a reload ssl request with the optional SSLHTTPReloadReq
+func (c sslClient) HTTPReload(ctx context.Context, req *SSLHTTPReloadReq) (SSLHTTPReloadResp, error) {
+	if req == nil {
+		req = &SSLHTTPReloadReq{}
+	}
+
+	var (
+		data SSLHTTPReloadResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// TransportReload executes a reload ssl request with the optional SSLTransportReloadReq
+func (c sslClient) TransportReload(ctx context.Context, req *SSLTransportReloadReq) (SSLTransportReloadResp, error) {
+	if req == nil {
+		req = &SSLTransportReloadReq{}
+	}
+
+	var (
+		data SSLTransportReloadResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}

--- a/plugins/security/api_ssl_test.go
+++ b/plugins/security/api_ssl_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+//
+//go:build integration
+
+package security_test
+
+import (
+	"crypto/tls"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
+	"github.com/opensearch-project/opensearch-go/v3/plugins/security"
+	ossectest "github.com/opensearch-project/opensearch-go/v3/plugins/security/internal/test"
+)
+
+func TestSSLClient(t *testing.T) {
+	ostest.SkipIfNotSecure(t)
+	config, err := ossectest.ClientConfig()
+	require.Nil(t, err)
+
+	osAPIclient, err := ostest.NewClient()
+	require.Nil(t, err)
+
+	ostest.SkipIfBelowVersion(t, osAPIclient, 1, 3, "SSLClient")
+
+	clientTLSCert, err := tls.LoadX509KeyPair("../../admin.pem", "../../admin.key")
+	require.Nil(t, err)
+
+	config.Client.Transport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			Certificates:       []tls.Certificate{clientTLSCert},
+		},
+	}
+
+	client, err := security.NewClient(*config)
+	require.Nil(t, err)
+
+	failingClient, err := ossectest.CreateFailingClient()
+	require.Nil(t, err)
+
+	type sslTests struct {
+		Name    string
+		Results func() (ossectest.Response, error)
+	}
+
+	testCases := []struct {
+		Name  string
+		Tests []sslTests
+	}{
+		{
+			Name: "HTTPReload",
+			Tests: []sslTests{
+				{
+					Name: "without request",
+					Results: func() (ossectest.Response, error) {
+						return client.SSL.HTTPReload(nil, nil)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.SSL.HTTPReload(nil, &security.SSLHTTPReloadReq{})
+					},
+				},
+			},
+		},
+		{
+			Name: "TransportReload",
+			Tests: []sslTests{
+				{
+					Name: "without request",
+					Results: func() (ossectest.Response, error) {
+						return client.SSL.TransportReload(nil, nil)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.SSL.TransportReload(nil, &security.SSLTransportReloadReq{})
+					},
+				},
+			},
+		},
+		{
+			Name: "Get",
+			Tests: []sslTests{
+				{
+					Name: "without request",
+					Results: func() (ossectest.Response, error) {
+						return client.SSL.Get(nil, nil)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.SSL.Get(nil, nil)
+					},
+				},
+			},
+		},
+	}
+	for _, value := range testCases {
+		t.Run(value.Name, func(t *testing.T) {
+			for _, testCase := range value.Tests {
+				t.Run(testCase.Name, func(t *testing.T) {
+					if strings.HasSuffix(value.Name, "Reload") && strings.Contains(testCase.Name, "request") {
+						ostest.SkipIfBelowVersion(t, osAPIclient, 2, 7, value.Name)
+					}
+					res, err := testCase.Results()
+					if testCase.Name == "inspect" {
+						assert.NotNil(t, err)
+						assert.NotNil(t, res)
+						ossectest.VerifyInspect(t, res.Inspect())
+					} else {
+						require.Nil(t, err)
+						require.NotNil(t, res)
+						assert.NotNil(t, res.Inspect().Response)
+						ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+					}
+				})
+			}
+		})
+	}
+}

--- a/plugins/security/api_tenants-delete.go
+++ b/plugins/security/api_tenants-delete.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// TenantsDeleteReq represents possible options for the tenants delete request
+type TenantsDeleteReq struct {
+	Tenant string
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r TenantsDeleteReq) GetRequest() (*http.Request, error) {
+	return opensearch.BuildRequest(
+		"DELETE",
+		fmt.Sprintf("/_plugins/_security/api/tenants/%s", r.Tenant),
+		nil,
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// TenantsDeleteResp represents the returned struct of the tenants delete response
+type TenantsDeleteResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r TenantsDeleteResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_tenants-get.go
+++ b/plugins/security/api_tenants-get.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// TenantsGetReq represents possible options for the tenants get request
+type TenantsGetReq struct {
+	Tenant string
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r TenantsGetReq) GetRequest() (*http.Request, error) {
+	var path strings.Builder
+	path.Grow(len("/_plugins/_security/api/tenants/") + len(r.Tenant))
+	path.WriteString("/_plugins/_security/api/tenants")
+	if len(r.Tenant) > 0 {
+		path.WriteString("/")
+		path.WriteString(r.Tenant)
+	}
+
+	return opensearch.BuildRequest(
+		"GET",
+		path.String(),
+		nil,
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// TenantsGetResp represents the returned struct of the tenants get response
+type TenantsGetResp struct {
+	Tenants  map[string]TenantsGetItem
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r TenantsGetResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}
+
+// TenantsGetItem is a sub type of TenantsGetResp containing information about a tenant
+type TenantsGetItem struct {
+	Reserved    bool   `json:"reserved"`
+	Hidden      bool   `json:"hidden"`
+	Description string `json:"description"`
+	Statis      bool   `json:"static"`
+}

--- a/plugins/security/api_tenants-patch.go
+++ b/plugins/security/api_tenants-patch.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// TenantsPatchReq represents possible options for the tenants patch request
+type TenantsPatchReq struct {
+	Tenant string
+	Body   TenantsPatchBody
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r TenantsPatchReq) GetRequest() (*http.Request, error) {
+	body, err := json.Marshal(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var path strings.Builder
+	path.Grow(len("/_plugins/_security/api/tenants/") + len(r.Tenant))
+	path.WriteString("/_plugins/_security/api/tenants")
+	if len(r.Tenant) > 0 {
+		path.WriteString("/")
+		path.WriteString(r.Tenant)
+	}
+
+	return opensearch.BuildRequest(
+		"PATCH",
+		path.String(),
+		bytes.NewReader(body),
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// TenantsPatchResp represents the returned struct of the tenants patch response
+type TenantsPatchResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r TenantsPatchResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}
+
+// TenantsPatchBody represents the request body for the tenants patch request
+type TenantsPatchBody []TenantsPatchBodyItem
+
+// TenantsPatchBodyItem is a sub type of TenantsPatchBody represeting patch item
+type TenantsPatchBodyItem struct {
+	OP    string `json:"op"`
+	Path  string `json:"path"`
+	Value any    `json:"value,omitempty"`
+}

--- a/plugins/security/api_tenants-put.go
+++ b/plugins/security/api_tenants-put.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+)
+
+// TenantsPutReq represents possible options for the tenants put request
+type TenantsPutReq struct {
+	Tenant string
+	Body   TenantsPutBody
+
+	Header http.Header
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r TenantsPutReq) GetRequest() (*http.Request, error) {
+	body, err := json.Marshal(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return opensearch.BuildRequest(
+		"PUT",
+		fmt.Sprintf("/_plugins/_security/api/tenants/%s", r.Tenant),
+		bytes.NewReader(body),
+		make(map[string]string),
+		r.Header,
+	)
+}
+
+// TenantsPutBody is the request body for the TenantsPutReq
+type TenantsPutBody struct {
+	Description string `json:"description,omitempty"`
+}
+
+// TenantsPutResp represents the returned struct of the tenants put response
+type TenantsPutResp struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	response *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Reponse
+func (r TenantsPutResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}

--- a/plugins/security/api_tenants.go
+++ b/plugins/security/api_tenants.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import (
+	"context"
+)
+
+type tenantsClient struct {
+	apiClient *Client
+}
+
+// Get executes a get tenants request with the optional TenantsGetReq
+func (c tenantsClient) Get(ctx context.Context, req *TenantsGetReq) (TenantsGetResp, error) {
+	if req == nil {
+		req = &TenantsGetReq{}
+	}
+
+	var (
+		data TenantsGetResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Put executes a put tenants request with the required TenantsPutReq
+func (c tenantsClient) Put(ctx context.Context, req TenantsPutReq) (TenantsPutResp, error) {
+	var (
+		data TenantsPutResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Delete executes a delete tenants request with the required TenantsDeleteReq
+func (c tenantsClient) Delete(ctx context.Context, req TenantsDeleteReq) (TenantsDeleteResp, error) {
+	var (
+		data TenantsDeleteResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Patch executes a patch tenants request with the required TenantsPatchReq
+func (c tenantsClient) Patch(ctx context.Context, req TenantsPatchReq) (TenantsPatchResp, error) {
+	var (
+		data TenantsPatchResp
+		err  error
+	)
+	if data.response, err = c.apiClient.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}

--- a/plugins/security/api_tenants_test.go
+++ b/plugins/security/api_tenants_test.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+//
+//go:build integration
+
+package security_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
+	"github.com/opensearch-project/opensearch-go/v3/plugins/security"
+	ossectest "github.com/opensearch-project/opensearch-go/v3/plugins/security/internal/test"
+)
+
+func TestTenantsClient(t *testing.T) {
+	ostest.SkipIfNotSecure(t)
+	client, err := ossectest.NewClient()
+	require.Nil(t, err)
+
+	failingClient, err := ossectest.CreateFailingClient()
+	require.Nil(t, err)
+
+	testTenant := "test_tenant"
+
+	type tenantsTests struct {
+		Name    string
+		Results func() (ossectest.Response, error)
+	}
+
+	testCases := []struct {
+		Name  string
+		Tests []tenantsTests
+	}{
+		{
+			Name: "Put",
+			Tests: []tenantsTests{
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.Tenants.Put(
+							nil,
+							security.TenantsPutReq{
+								Tenant: testTenant,
+								Body: security.TenantsPutBody{
+									Description: "Test",
+								},
+							},
+						)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.Tenants.Put(nil, security.TenantsPutReq{})
+					},
+				},
+			},
+		},
+		{
+			Name: "Get",
+			Tests: []tenantsTests{
+				{
+					Name: "without request",
+					Results: func() (ossectest.Response, error) {
+						return client.Tenants.Get(nil, nil)
+					},
+				},
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.Tenants.Get(nil, &security.TenantsGetReq{Tenant: testTenant})
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.Tenants.Get(nil, nil)
+					},
+				},
+			},
+		},
+		{
+			Name: "Delete",
+			Tests: []tenantsTests{
+				{
+					Name: "without request",
+					Results: func() (ossectest.Response, error) {
+						return client.Tenants.Delete(nil, security.TenantsDeleteReq{Tenant: testTenant})
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.Tenants.Delete(nil, security.TenantsDeleteReq{Tenant: testTenant})
+					},
+				},
+			},
+		},
+		{
+			Name: "Patch",
+			Tests: []tenantsTests{
+				{
+					Name: "with request",
+					Results: func() (ossectest.Response, error) {
+						return client.Tenants.Patch(
+							nil,
+							security.TenantsPatchReq{
+								Body: security.TenantsPatchBody{
+									security.TenantsPatchBodyItem{
+										OP:   "add",
+										Path: "/test",
+										Value: security.TenantsPutBody{
+											Description: "Test",
+										},
+									},
+									security.TenantsPatchBodyItem{
+										OP:   "remove",
+										Path: "/test",
+									},
+								},
+							},
+						)
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (ossectest.Response, error) {
+						return failingClient.Tenants.Patch(nil, security.TenantsPatchReq{})
+					},
+				},
+			},
+		},
+	}
+	for _, value := range testCases {
+		t.Run(value.Name, func(t *testing.T) {
+			for _, testCase := range value.Tests {
+				t.Run(testCase.Name, func(t *testing.T) {
+					res, err := testCase.Results()
+					if testCase.Name == "inspect" {
+						assert.NotNil(t, err)
+						assert.NotNil(t, res)
+						ossectest.VerifyInspect(t, res.Inspect())
+					} else {
+						if err != nil {
+							fmt.Println(err)
+						}
+						require.Nil(t, err)
+						require.NotNil(t, res)
+						assert.NotNil(t, res.Inspect().Response)
+						if value.Name != "Get" {
+							ostest.CompareRawJSONwithParsedJSON(t, res, res.Inspect().Response)
+						}
+					}
+				})
+			}
+		})
+	}
+	t.Run("ValidateResponse", func(t *testing.T) {
+		t.Run("Get", func(t *testing.T) {
+			resp, err := client.Tenants.Get(nil, nil)
+			assert.Nil(t, err)
+			assert.NotNil(t, resp)
+			ostest.CompareRawJSONwithParsedJSON(t, resp.Tenants, resp.Inspect().Response)
+		})
+	})
+}

--- a/plugins/security/inspect.go
+++ b/plugins/security/inspect.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package security
+
+import "github.com/opensearch-project/opensearch-go/v3"
+
+// Inspect represents the struct returned by Inspect() func, its main use is to return the opensearch.Response to the user
+type Inspect struct {
+	Response *opensearch.Response
+}

--- a/plugins/security/internal/test/helper.go
+++ b/plugins/security/internal/test/helper.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package ossectest
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+	ostest "github.com/opensearch-project/opensearch-go/v3/internal/test"
+	"github.com/opensearch-project/opensearch-go/v3/plugins/security"
+)
+
+// Response is a dummy interface to run tests with Inspect()
+type Response interface {
+	Inspect() security.Inspect
+}
+
+// NewClient returns an opensearchapi.Client that is adjusted for the wanted test case
+func NewClient() (*security.Client, error) {
+	config, err := ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	if config == nil {
+		return nil, fmt.Errorf("failed to get config: requires secure opensearch")
+	}
+	return security.NewClient(*config)
+}
+
+// ClientConfig returns an opensearchapi.Config for secure opensearch
+func ClientConfig() (*security.Config, error) {
+	if ostest.IsSecure() {
+		password, err := ostest.GetPassword()
+		if err != nil {
+			return nil, err
+		}
+
+		return &security.Config{
+			Client: opensearch.Config{
+				Username:  "admin",
+				Password:  password,
+				Addresses: []string{"https://localhost:9200"},
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				},
+			},
+		}, nil
+	}
+	//nolint:nilnil // easier to test with nil rather then doing complex error handling for tests
+	return nil, nil
+}
+
+// CreateFailingClient returns an security.Client that always return 400 with an empty object as body
+func CreateFailingClient() (*security.Client, error) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil {
+			defer r.Body.Close()
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		io.Copy(w, strings.NewReader(`{"status": "error", "reason": "Test Failing Client Response"}`))
+	}))
+
+	return security.NewClient(security.Config{Client: opensearch.Config{Addresses: []string{ts.URL}}})
+}
+
+// VerifyInspect validates the returned security.Inspect type
+func VerifyInspect(t *testing.T, inspect security.Inspect) {
+	t.Helper()
+	assert.NotEmpty(t, inspect)
+	assert.Equal(t, http.StatusBadRequest, inspect.Response.StatusCode)
+	assert.NotEmpty(t, inspect.Response.Body)
+}


### PR DESCRIPTION
### Description
- adds security plugin
- moves errors to opensearch package
- add more error types and parse them by type assertion

The changes made to error are more or less braking changes as they get moved to another package.
Normal use should still work but for uses who try to parse the error with `errors.As` it is braking.

### Issues Resolved
Closes #94 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
