### PR TITLE
Add missing _routing field in SearchHit interface

### DIFF
--- a/opensearchapi/api_search.go
+++ b/opensearchapi/api_search.go
@@ -89,6 +89,7 @@ func (r SearchResp) Inspect() Inspect {
 type SearchHit struct {
 	Index       string                  `json:"_index"`
 	ID          string                  `json:"_id"`
+	Routing     string                  `json:"_routing"`
 	Score       float32                 `json:"_score"`
 	Source      json.RawMessage         `json:"_source"`
 	Fields      json.RawMessage         `json:"fields"`


### PR DESCRIPTION
### Description
Added Routing field in  SearchHit interface
premise: 
The OpenSearch Search API currently does not return the routing key in its responses. The routing key is a crucial piece of information, especially in cases where the user or the application has specified a custom routing key for a document at the time of its creation. This omission means that any application or user querying documents from OpenSearch will not receive this key as part of the search results.

### Issues Resolved
This pull request addresses this gap by adding a Routing field to the SearchHit interface. With this change, the API will now include the routing key in the search results.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
