### PR TITLE
Add fields to document get response to support stored_fields param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Adds security plugin ([#507](https://github.com/opensearch-project/opensearch-go/pull/507))
 - Adds security settings to container for security testing ([#507](https://github.com/opensearch-project/opensearch-go/pull/507))
 - Adds cluster.get-certs to copy admin certs out of the container ([#507](https://github.com/opensearch-project/opensearch-go/pull/507))
+- Add the `Fields` field containing stored fields to the `DocumentGetResp` struct (#526)[https://github.com/opensearch-project/opensearch-go/pull/526]
 
 ### Changed
 - Uses docker compose v2 instead of v1 ([#506](https://github.com/opensearch-project/opensearch-go/pull/506))

--- a/opensearchapi/api_document-get.go
+++ b/opensearchapi/api_document-get.go
@@ -44,6 +44,7 @@ type DocumentGetResp struct {
 	Found       bool            `json:"found"`
 	Type        string          `json:"_type"` // Deprecated field
 	Source      json.RawMessage `json:"_source"`
+	Fields      json.RawMessage `json:"fields"`
 	response    *opensearch.Response
 }
 


### PR DESCRIPTION
### Description
Add `fields` to document get response to support `stored_fields` param

### Issues Resolved
To support getting document with `stored_fields` param
```
PUT /my-index
{
  "mappings": {
    "properties": {
      "demo": {
        "type" : "keyword",
        "store": true
      }
    }
  }
}
```

```
GET /my-index/_doc/1?stored_fields=foo-stored
```

```
{
    "_index": "my-index",
    "_id": "1",
    "_version": 1,
    "_seq_no": 0,
    "_primary_term": 1,
    "found": true,
    "fields": {
        "foo-stored": [
            "bar"
        ]
    }
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
