### PR TITLE
Fix empty request body on retries with compression enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
+- Fixes empty request body on retry with compression enabled. ([#542](https://github.com/opensearch-project/opensearch-go/pull/542))
+
 ### Security
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
-- Fixes empty request body on retry with compression enabled. ([#542](https://github.com/opensearch-project/opensearch-go/pull/542))
+- Fixes empty request body on retry with compression enabled ([#543](https://github.com/opensearch-project/opensearch-go/pull/543))
 
 ### Security
 

--- a/opensearchtransport/opensearchtransport_internal_test.go
+++ b/opensearchtransport/opensearchtransport_internal_test.go
@@ -689,6 +689,47 @@ func TestTransportPerformRetries(t *testing.T) {
 		}
 	})
 
+	t.Run("Reset request body during retry with request body compression", func(t *testing.T) {
+		var bodies []string
+		u, _ := url.Parse("https://foo.com/bar")
+		tp, _ := New(
+			Config{
+				URLs:                []*url.URL{u},
+				CompressRequestBody: true,
+				Transport: &mockTransp{
+					RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+						body, err := io.ReadAll(req.Body)
+						if err != nil {
+							panic(err)
+						}
+						bodies = append(bodies, string(body))
+						return &http.Response{Status: "MOCK", StatusCode: http.StatusBadGateway}, nil
+					},
+				},
+			},
+		)
+
+		foobar := "FOOBAR"
+		foobar_gzipped := "\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xffr\xf3\xf7wr\f\x02\x04\x00\x00\xff\xff\x13\xd8\x0en\x06\x00\x00\x00"
+
+		req, _ := http.NewRequest(http.MethodPost, "/abc", strings.NewReader(foobar))
+		//nolint:bodyclose // Mock response does not have a body to close
+		res, err := tp.Perform(req)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		_ = res
+
+		if n := len(bodies); n != 4 {
+			t.Fatalf("expected 4 requests, got %d", n)
+		}
+		for i, body := range bodies {
+			if body != foobar_gzipped {
+				t.Fatalf("request %d body: expected %q, got %q", i, foobar_gzipped, body)
+			}
+		}
+	})
+
 	t.Run("Don't retry request on regular error", func(t *testing.T) {
 		var i int
 

--- a/opensearchtransport/opensearchtransport_internal_test.go
+++ b/opensearchtransport/opensearchtransport_internal_test.go
@@ -710,7 +710,7 @@ func TestTransportPerformRetries(t *testing.T) {
 		)
 
 		foobar := "FOOBAR"
-		foobar_gzipped := "\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xffr\xf3\xf7wr\f\x02\x04\x00\x00\xff\xff\x13\xd8\x0en\x06\x00\x00\x00"
+		foobarGzipped := "\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xffr\xf3\xf7wr\f\x02\x04\x00\x00\xff\xff\x13\xd8\x0en\x06\x00\x00\x00"
 
 		req, _ := http.NewRequest(http.MethodPost, "/abc", strings.NewReader(foobar))
 		//nolint:bodyclose // Mock response does not have a body to close
@@ -724,8 +724,8 @@ func TestTransportPerformRetries(t *testing.T) {
 			t.Fatalf("expected 4 requests, got %d", n)
 		}
 		for i, body := range bodies {
-			if body != foobar_gzipped {
-				t.Fatalf("request %d body: expected %q, got %q", i, foobar_gzipped, body)
+			if body != foobarGzipped {
+				t.Fatalf("request %d body: expected %q, got %q", i, foobarGzipped, body)
 			}
 		}
 	})


### PR DESCRIPTION
### Description
Make the transport use a new reader for each retry when gzip compression is enabled.
Also be more explicit about doing so for non-compressed requests.
Test included.

### Issues Resolved
Closes #541.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
