### PR TITLE
Add search pipeline support to search api

### DIFF
--- a/opensearchapi/api.search.go
+++ b/opensearchapi/api.search.go
@@ -84,6 +84,7 @@ type SearchRequest struct {
 	RestTotalHitsAsInt         *bool
 	Routing                    []string
 	Scroll                     time.Duration
+	SearchPipeline             string
 	SearchType                 string
 	SeqNoPrimaryTerm           *bool
 	Size                       *int
@@ -229,6 +230,10 @@ func (r SearchRequest) Do(ctx context.Context, transport Transport) (*Response, 
 
 	if r.Scroll != 0 {
 		params["scroll"] = formatDuration(r.Scroll)
+	}
+
+	if r.SearchPipeline != "" {
+		params["search_pipeline"] = r.SearchPipeline
 	}
 
 	if r.SearchType != "" {


### PR DESCRIPTION
### Description
Adds support for specifying a [search
pipeline](https://opensearch.org/docs/latest/search-plugins/search-pipelines/using-search-pipeline/) as part of a `SearchRequest`. The field, if set, is added as a query parameter during the construction of the request URL, and otherwise has no impact.

### Issues Resolved
https://github.com/opensearch-project/opensearch-go/issues/586

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
