### PR TITLE
Improves ParseError response when server response is an unknown json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixes wrong response parsing for security get requests ([#572](https://github.com/opensearch-project/opensearch-go/pull/572))
 - Fixes opensearchtransport ignores request context cancellation when `retryBackoff` is configured ([#540](https://github.com/opensearch-project/opensearch-go/pull/540))
 - Fixes opensearchtransport sleeps unexpectedly after the last retry ([#540](https://github.com/opensearch-project/opensearch-go/pull/540))
-- Improves ParseError response when server response is an unknown json([#592](https://github.com/opensearch-project/opensearch-go/pull/592))
+- Improves ParseError response when server response is an unknown json ([#592](https://github.com/opensearch-project/opensearch-go/pull/592))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixes wrong response parsing for security get requests ([#572](https://github.com/opensearch-project/opensearch-go/pull/572))
 - Fixes opensearchtransport ignores request context cancellation when `retryBackoff` is configured ([#540](https://github.com/opensearch-project/opensearch-go/pull/540))
 - Fixes opensearchtransport sleeps unexpectedly after the last retry ([#540](https://github.com/opensearch-project/opensearch-go/pull/540))
+- Improves ParseError response when server response is unknown json(update PR# here)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixes wrong response parsing for security get requests ([#572](https://github.com/opensearch-project/opensearch-go/pull/572))
 - Fixes opensearchtransport ignores request context cancellation when `retryBackoff` is configured ([#540](https://github.com/opensearch-project/opensearch-go/pull/540))
 - Fixes opensearchtransport sleeps unexpectedly after the last retry ([#540](https://github.com/opensearch-project/opensearch-go/pull/540))
-- Improves ParseError response when server response is unknown json(update PR# here)
+- Improves ParseError response when server response is an unknown json([#592](https://github.com/opensearch-project/opensearch-go/pull/592))
 
 ### Security
 

--- a/error.go
+++ b/error.go
@@ -175,7 +175,7 @@ func ParseError(resp *Response) error {
 		return parseError(body, &apiError)
 	}
 
-	return fmt.Errorf("%w: %s", ErrUnknownOpensearchError, string(body))
+	return &StringError{Status: resp.StatusCode, Err: string(body)}
 }
 
 func parseError(body []byte, errStruct error) error {


### PR DESCRIPTION
### Description
In ParseError, when json response from server is unknown, it used to return a string response (`*fmt.wrapError`). This is now changed to return a StringError struct (`*opensearch.StringError`).  

### Issues Resolved
Closes #582

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
