### PR TITLE
Add the Suggest field to the SearchResp struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `github.com/aws/aws-sdk-go` from 1.54.12 to 1.55.5 ([#583](https://github.com/opensearch-project/opensearch-go/pull/583), [#590](https://github.com/opensearch-project/opensearch-go/pull/590), [#595](https://github.com/opensearch-project/opensearch-go/pull/595), [#596](https://github.com/opensearch-project/opensearch-go/pull/596))
 
 ### Added
-- Adds the `Suggest` field to the `SearchResp` struct. ([#602](https://github.com/opensearch-project/opensearch-go/pull/602))
+- Adds `Suggest` to `SearchResp` ([#602](https://github.com/opensearch-project/opensearch-go/pull/602))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `github.com/aws/aws-sdk-go` from 1.54.12 to 1.55.5 ([#583](https://github.com/opensearch-project/opensearch-go/pull/583), [#590](https://github.com/opensearch-project/opensearch-go/pull/590), [#595](https://github.com/opensearch-project/opensearch-go/pull/595), [#596](https://github.com/opensearch-project/opensearch-go/pull/596))
 
 ### Added
+- Adds the `Suggest` field to the `SearchResp` struct. ([#602](https://github.com/opensearch-project/opensearch-go/pull/602))
 
 ### Changed
 

--- a/opensearchapi/api_search.go
+++ b/opensearchapi/api_search.go
@@ -74,9 +74,10 @@ type SearchResp struct {
 		MaxScore float32     `json:"max_score"`
 		Hits     []SearchHit `json:"hits"`
 	} `json:"hits"`
-	Errors       bool            `json:"errors"`
-	Aggregations json.RawMessage `json:"aggregations"`
-	ScrollID     *string         `json:"_scroll_id,omitempty"`
+	Errors       bool                 `json:"errors"`
+	Aggregations json.RawMessage      `json:"aggregations"`
+	ScrollID     *string              `json:"_scroll_id,omitempty"`
+	Suggest      map[string][]Suggest `json:"suggest,omitempty"`
 	response     *opensearch.Response
 }
 
@@ -98,4 +99,18 @@ type SearchHit struct {
 	Explanation *DocumentExplainDetails `json:"_explanation"`
 	SeqNo       *int                    `json:"_seq_no"`
 	PrimaryTerm *int                    `json:"_primary_term"`
+}
+
+// Suggest is a sub type of SearchResp containing information of the suggest field
+type Suggest struct {
+	Text    string `json:"text"`
+	Offset  int    `json:"offset"`
+	Length  int    `json:"length"`
+	Options []struct {
+		Text         string  `json:"text"`
+		Score        float32 `json:"score"`
+		Freq         int     `json:"freq"`
+		Highlighted  string  `json:"highlighted"`
+		CollateMatch bool    `json:"collate_match"`
+	} `json:"options"`
 }

--- a/opensearchapi/api_search_test.go
+++ b/opensearchapi/api_search_test.go
@@ -166,4 +166,19 @@ func TestSearch(t *testing.T) {
 			assert.Nil(t, hit.PrimaryTerm)
 		}
 	})
+
+	t.Run("request with suggest", func(t *testing.T) {
+		resp, err := client.Search(nil, &opensearchapi.SearchReq{Indices: []string{index}, Body: strings.NewReader(`{
+			"suggest": {
+			  "text": "bar",
+			  "my-suggest": {
+			    "term": {
+				  "field": "foo"
+				}
+			  }
+			}
+		  }`)})
+		require.Nil(t, err)
+		assert.NotEmpty(t, resp.Suggest)
+	})
 }


### PR DESCRIPTION
### Description
Adding the `Explanation` field to the 

### Issues Resolved
Closes issue [#601](https://github.com/opensearch-project/opensearch-go/issues/601) 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
