### PR TITLE
opensearchapi: split SnapshotGetResp into sub structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Adds `Suggest` to `SearchResp` ([#602](https://github.com/opensearch-project/opensearch-go/pull/602))
 
 ### Changed
+- Split SnapshotGetResp into sub structs  ([#603](https://github.com/opensearch-project/opensearch-go/pull/603))
 
 ### Deprecated
 

--- a/opensearchapi/api_snapshot-get.go
+++ b/opensearchapi/api_snapshot-get.go
@@ -40,33 +40,39 @@ func (r SnapshotGetReq) GetRequest() (*http.Request, error) {
 
 // SnapshotGetResp represents the returned struct of the index create response
 type SnapshotGetResp struct {
-	Snapshots []struct {
-		Snapshot                    string            `json:"snapshot"`
-		UUID                        string            `json:"uuid"`
-		VersionID                   int               `json:"version_id"`
-		Version                     string            `json:"version"`
-		RemoteStoreIndexShallowCopy bool              `json:"remote_store_index_shallow_copy"`
-		Indices                     []string          `json:"indices"`
-		DataStreams                 []json.RawMessage `json:"data_streams"`
-		IncludeGlobalState          bool              `json:"include_global_state"`
-		Metadata                    map[string]string `json:"metadata"`
-		State                       string            `json:"state"`
-		StartTime                   string            `json:"start_time"`
-		StartTimeInMillis           int64             `json:"start_time_in_millis"`
-		EndTime                     string            `json:"end_time"`
-		EndTimeInMillis             int64             `json:"end_time_in_millis"`
-		DurationInMillis            int               `json:"duration_in_millis"`
-		Failures                    []json.RawMessage `json:"failures"`
-		Shards                      struct {
-			Total      int `json:"total"`
-			Failed     int `json:"failed"`
-			Successful int `json:"successful"`
-		} `json:"shards"`
-	} `json:"snapshots"`
-	response *opensearch.Response
+	Snapshots []SnapshotGet `json:"snapshots"`
+	response  *opensearch.Response
 }
 
 // Inspect returns the Inspect type containing the raw *opensearch.Reponse
 func (r SnapshotGetResp) Inspect() Inspect {
 	return Inspect{Response: r.response}
+}
+
+// SnapshotGet is a sub type of SnapshotGetResp represeting a single snapshot
+type SnapshotGet struct {
+	Snapshot                    string            `json:"snapshot"`
+	UUID                        string            `json:"uuid"`
+	VersionID                   int               `json:"version_id"`
+	Version                     string            `json:"version"`
+	RemoteStoreIndexShallowCopy bool              `json:"remote_store_index_shallow_copy"`
+	Indices                     []string          `json:"indices"`
+	DataStreams                 []json.RawMessage `json:"data_streams"`
+	IncludeGlobalState          bool              `json:"include_global_state"`
+	Metadata                    map[string]string `json:"metadata"`
+	State                       string            `json:"state"`
+	StartTime                   string            `json:"start_time"`
+	StartTimeInMillis           int64             `json:"start_time_in_millis"`
+	EndTime                     string            `json:"end_time"`
+	EndTimeInMillis             int64             `json:"end_time_in_millis"`
+	DurationInMillis            int               `json:"duration_in_millis"`
+	Failures                    []json.RawMessage `json:"failures"`
+	Shards                      SnapshotGetShards `json:"shards"`
+}
+
+// SnapshotGetShards is a sub type of SnapshotGet containing shard numbers
+type SnapshotGetShards struct {
+	Total      int `json:"total"`
+	Failed     int `json:"failed"`
+	Successful int `json:"successful"`
 }


### PR DESCRIPTION
### Description
Split the SnapshotGetResp into more sub structs so they can be reused by the user.
This is for example needed when looping over `SnapshotGetResp.Snapshots` and want to give the struct to a function.

This is actually a more general issue affecting more structs that could be solved by code generation in the future.

### Issues Resolved
None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
