### PR TITLE
opensearchapi: add MaxScore field to ScrollGetResp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Adds `Suggest` to `SearchResp` ([#602](https://github.com/opensearch-project/opensearch-go/pull/602))
+- Adds `MaxScore` to `ScrollGetResp` ([#607](https://github.com/opensearch-project/opensearch-go/pull/607))
 
 ### Changed
 - Split SnapshotGetResp into sub structs  ([#603](https://github.com/opensearch-project/opensearch-go/pull/603))

--- a/opensearchapi/api_scroll-get.go
+++ b/opensearchapi/api_scroll-get.go
@@ -46,8 +46,9 @@ type ScrollGetResp struct {
 		MaxScore float32     `json:"max_score"`
 		Hits     []SearchHit `json:"hits"`
 	} `json:"hits"`
-	ScrollID        *string `json:"_scroll_id,omitempty"`
-	TerminatedEarly bool    `json:"terminated_early"`
+	ScrollID        *string  `json:"_scroll_id,omitempty"`
+	TerminatedEarly bool     `json:"terminated_early"`
+	MaxScore        *float32 `json:"max_score"`
 	response        *opensearch.Response
 }
 


### PR DESCRIPTION
### Description
Add MaxScore field to ScrollGetResp

### Issues Resolved
https://github.com/opensearch-project/opensearch-go/actions/runs/10579861232/job/29313341627?pr=606#step:7:993

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
