### PR TITLE
plugins/ism: Fix error notification types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fix ISM Transition to omitempty Conditions field ([#609](https://github.com/opensearch-project/opensearch-go/pull/609))
 - Fix ISM Allocation field types ([#609](https://github.com/opensearch-project/opensearch-go/pull/609))
+- Fix ISM Error Notification types ([#612](https://github.com/opensearch-project/opensearch-go/pull/612))
 
 ### Security
 

--- a/plugins/ism/api_policies.go
+++ b/plugins/ism/api_policies.go
@@ -80,9 +80,14 @@ type PolicyBody struct {
 
 // PolicyErrorNotification is a sub type of PolicyBody containing information about error notification
 type PolicyErrorNotification struct {
-	Channel         string                      `json:"channel,omitempty"`
-	Destination     NotificationDestination     `json:"destination,omitempty"`
+	Channel         *NotificationChannel        `json:"channel,omitempty"`
+	Destination     *NotificationDestination    `json:"destination,omitempty"`
 	MessageTemplate NotificationMessageTemplate `json:"message_template"`
+}
+
+// NotificationChannel is a sub type of PolicyErrorNotification containing the channel id
+type NotificationChannel struct {
+	ID string `json:"id"`
 }
 
 // NotificationDestination is a sub type of PolicyErrorNotification containing information about notification destinations

--- a/plugins/ism/api_test.go
+++ b/plugins/ism/api_test.go
@@ -45,7 +45,7 @@ func TestClient(t *testing.T) {
 				Policy: ism.PolicyBody{
 					Description: "test",
 					ErrorNotification: &ism.PolicyErrorNotification{
-						Destination: ism.NotificationDestination{
+						Destination: &ism.NotificationDestination{
 							CustomWebhook: &ism.NotificationDestinationCustomWebhook{
 								Host:         "exmaple.com",
 								Scheme:       "https",
@@ -76,7 +76,7 @@ func TestClient(t *testing.T) {
 					Template: []ism.Template{
 						ism.Template{
 							IndexPatterns: []string{"test"},
-							Priority:      20,
+							Priority:      22,
 						},
 					},
 				},


### PR DESCRIPTION
### Description
- Fix error notification types by making them pointers and adding omitempty
- Add test for channel
- Add missing struct for Channel field

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
