### PR TITLE
Add the Total fields to the SearchResp struct

### DIFF
--- a/opensearchapi/api_search.go
+++ b/opensearchapi/api_search.go
@@ -79,6 +79,10 @@ type SearchResp struct {
 	ScrollID     *string              `json:"_scroll_id,omitempty"`
 	Suggest      map[string][]Suggest `json:"suggest,omitempty"`
 	response     *opensearch.Response
+	Total        struct {
+		Value    int    `json:"value"`
+		Relation string `json:"relation"`
+	} `json:"total"`
 }
 
 // Inspect returns the Inspect type containing the raw *opensearch.Response

--- a/opensearchapi/api_search_test.go
+++ b/opensearchapi/api_search_test.go
@@ -181,4 +181,17 @@ func TestSearch(t *testing.T) {
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp.Suggest)
 	})
+
+	t.Run("request with track_total_hits", func(t *testing.T) {
+		resp, err := client.Search(nil, &opensearchapi.SearchReq{Indices: []string{index}, Body: strings.NewReader(`{
+		  "track_total_hits": true, 
+		  "query": {
+			"match": {
+			  "foo": "bar"
+			}
+		  }
+		}`)})
+		require.Nil(t, err)
+		assert.NotZero(t, resp.Total.Value)
+	})
 }


### PR DESCRIPTION
### Description
The opensearch Search [reference documentation](https://opensearch.org/docs/latest/api-reference/search/) give some information on the `track_total_hits` parameter but doesn't include the full response body when it's used. `track_total_hits` is useful when you're trying to get a count of all hits in a given index for a given query without using the scroll api or some other traching mechinism. 

This PR adds the return values structure for the `track_total_hits` parameter into the SearchResp structure. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
