### PR TITLE
Bulk indexer util: Add a worker ID context value to flush events

### DIFF
--- a/opensearchutil/bulk_indexer.go
+++ b/opensearchutil/bulk_indexer.go
@@ -41,7 +41,13 @@ import (
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 )
 
-const defaultFlushInterval = 30 * time.Second
+// WorkerIdCtxKeyType is a context value type to get the worker ID from the context in flush callbacks
+type WorkerIdCtxKeyType string
+
+const (
+	WorkerCtxKey WorkerIdCtxKeyType = "workerId"
+	defaultFlushInterval = 30 * time.Second
+)
 
 // BulkIndexer represents a parallel, asynchronous, efficient indexer for OpenSearch.
 type BulkIndexer interface {
@@ -452,6 +458,7 @@ func (w *worker) writeBody(item *BulkIndexerItem) error {
 
 // flush writes out the worker buffer; it must be called under a lock.
 func (w *worker) flush(ctx context.Context) error {
+	ctx := context.WithValue(ctx, WorkerCtxKey, w.id)
 	if w.bi.config.OnFlushStart != nil {
 		ctx = w.bi.config.OnFlushStart(ctx)
 	}

--- a/opensearchutil/bulk_indexer.go
+++ b/opensearchutil/bulk_indexer.go
@@ -458,7 +458,7 @@ func (w *worker) writeBody(item *BulkIndexerItem) error {
 
 // flush writes out the worker buffer; it must be called under a lock.
 func (w *worker) flush(ctx context.Context) error {
-	ctx := context.WithValue(ctx, WorkerCtxKey, w.id)
+	ctx = context.WithValue(ctx, WorkerCtxKey, w.id)
 	if w.bi.config.OnFlushStart != nil {
 		ctx = w.bi.config.OnFlushStart(ctx)
 	}


### PR DESCRIPTION
### Description
_Describe what this change achieves._

This PR adds a context value to the flush event callbacks, to allow clients to determine which worker the callback comes from.
This allows detailed logging and rate per worker metrics, aswell as custom rate control.

```
	indexerConfig := opensearchutil.BulkIndexerConfig{
                .......
		OnFlushStart: b.onFlushStart,
		OnFlushEnd:   b.onFlushEnd,
	}

func (b *BulkWriter) onFlushStart(ctx context.Context) context.Context {
	log.Println("flush start by worker ID:", ctx.Value(opensearchutil.WorkerCtxKey))
	b.metrics.ObserveBulkIndexerFlush(ctx.Value(opensearchutil.WorkerCtxKey))
	return ctx
}
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
