### PR TITLE
Add Highlight field to SearchHit struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ### Added
+- Adds `Highlight` field to `SearchHit` ([#654](https://github.com/opensearch-project/opensearch-go/pull/654))
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ godoc: ## Display documentation for the package
 	godoc --http=localhost:6060 --play
 
 cluster.build:
-	docker compose --project-directory .ci/opensearch build;
+	docker compose --project-directory .ci/opensearch build --pull;
 
 cluster.start:
 	docker compose --project-directory .ci/opensearch up -d;

--- a/opensearchapi/api_nodes-stats.go
+++ b/opensearchapi/api_nodes-stats.go
@@ -112,6 +112,7 @@ type NodesStats struct {
 	Repositories                   []json.RawMessage                        `json:"repositories"`
 	AdmissionControl               NodesStatsAdmissionControl               `json:"admission_control"`
 	Caches                         NodesStatsCaches                         `json:"caches"`
+	RemoteStore                    NodeStatsRemoteStore                     `json:"remote_store"`
 }
 
 // NodesStatsIndices is a sub type of NodesStats representing Indices information of the node
@@ -728,4 +729,9 @@ type NodesStatsCaches struct {
 		ItemCount   int    `json:"item_count"`
 		StoreName   string `json:"store_name"`
 	} `json:"request_cache"`
+}
+
+// NodeStatsRemoteStore is a sub type of NodesStats
+type NodeStatsRemoteStore struct {
+	LastSuccessfulFetchOfPinnedTimestamps int `json:"last_successful_fetch_of_pinned_timestamps"`
 }

--- a/opensearchapi/api_search-template.go
+++ b/opensearchapi/api_search-template.go
@@ -62,6 +62,7 @@ type SearchTemplateResp struct {
 	Took    int            `json:"took"`
 	Timeout bool           `json:"timed_out"`
 	Shards  ResponseShards `json:"_shards"`
+	Status  int            `json:"status"`
 	Hits    struct {
 		Total struct {
 			Value    int    `json:"value"`

--- a/opensearchapi/api_search.go
+++ b/opensearchapi/api_search.go
@@ -99,6 +99,7 @@ type SearchHit struct {
 	Explanation *DocumentExplainDetails `json:"_explanation"`
 	SeqNo       *int                    `json:"_seq_no"`
 	PrimaryTerm *int                    `json:"_primary_term"`
+	Highlight   map[string][]string     `json:"highlight"`
 }
 
 // Suggest is a sub type of SearchResp containing information of the suggest field

--- a/opensearchapi/api_search_test.go
+++ b/opensearchapi/api_search_test.go
@@ -181,4 +181,28 @@ func TestSearch(t *testing.T) {
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp.Suggest)
 	})
+
+	t.Run("request with highlight", func(t *testing.T) {
+		resp, err := client.Search(
+			nil,
+			&opensearchapi.SearchReq{
+				Indices: []string{index},
+				Body: strings.NewReader(`{
+					"query": {
+						"match": {
+							"foo": "bar"
+						}
+					},
+					"highlight": {
+						"fields": {
+							"foo": {}
+						}
+					}
+				}`),
+			},
+		)
+		require.Nil(t, err)
+		assert.NotEmpty(t, resp.Hits.Hits)
+		assert.Equal(t, map[string][]string{"foo": []string{"<em>bar</em>"}}, resp.Hits.Hits[0].Highlight)
+	})
 }


### PR DESCRIPTION
### Description
For queries specifying [highlights](https://opensearch.org/docs/latest/search-plugins/searching-data/highlight/), the the `SearchHit`s on the `SearchResp` now include the highlight information returned in the api response.

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-go/issues/653


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
