### PR TITLE
Adds MatchedQueries field to SearchHit

### DIFF
--- a/.github/workflows/test-integration-unreleased.yml
+++ b/.github/workflows/test-integration-unreleased.yml
@@ -11,7 +11,7 @@ jobs:
         entry:
           - { branch: '1.x', java-version: '11' }
           - { branch: '2.x', java-version: '17' }
-          - { branch: 'main', java-version: '17' }
+          - { branch: 'main', java-version: '21' }
     steps:
       - name: Checkout OpenSearch
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Adds `Highlight` field to `SearchHit` ([#654](https://github.com/opensearch-project/opensearch-go/pull/654))
+- Adds `MatchedQueries` field to `SearchHit` ([#663](https://github.com/opensearch-project/opensearch-go/pull/663))
 
 ### Changed
 

--- a/opensearchapi/api_search.go
+++ b/opensearchapi/api_search.go
@@ -88,18 +88,19 @@ func (r SearchResp) Inspect() Inspect {
 
 // SearchHit is a sub type of SearchResp containing information of the search hit with an unparsed Source field
 type SearchHit struct {
-	Index       string                  `json:"_index"`
-	ID          string                  `json:"_id"`
-	Routing     string                  `json:"_routing"`
-	Score       float32                 `json:"_score"`
-	Source      json.RawMessage         `json:"_source"`
-	Fields      json.RawMessage         `json:"fields"`
-	Type        string                  `json:"_type"` // Deprecated field
-	Sort        []any                   `json:"sort"`
-	Explanation *DocumentExplainDetails `json:"_explanation"`
-	SeqNo       *int                    `json:"_seq_no"`
-	PrimaryTerm *int                    `json:"_primary_term"`
-	Highlight   map[string][]string     `json:"highlight"`
+	Index          string                  `json:"_index"`
+	ID             string                  `json:"_id"`
+	Routing        string                  `json:"_routing"`
+	Score          float32                 `json:"_score"`
+	Source         json.RawMessage         `json:"_source"`
+	Fields         json.RawMessage         `json:"fields"`
+	Type           string                  `json:"_type"` // Deprecated field
+	Sort           []any                   `json:"sort"`
+	Explanation    *DocumentExplainDetails `json:"_explanation"`
+	SeqNo          *int                    `json:"_seq_no"`
+	PrimaryTerm    *int                    `json:"_primary_term"`
+	Highlight      map[string][]string     `json:"highlight"`
+	MatchedQueries []string                `json:"matched_queries"`
 }
 
 // Suggest is a sub type of SearchResp containing information of the suggest field

--- a/opensearchapi/api_search_test.go
+++ b/opensearchapi/api_search_test.go
@@ -215,7 +215,7 @@ func TestSearch(t *testing.T) {
 					"query": {
 						"match": {
 							"foo": {
-								"query": "bar",
+								"query": "bar"
 							},
 							"_name": "test"
 						}

--- a/opensearchapi/api_search_test.go
+++ b/opensearchapi/api_search_test.go
@@ -205,4 +205,26 @@ func TestSearch(t *testing.T) {
 		assert.NotEmpty(t, resp.Hits.Hits)
 		assert.Equal(t, map[string][]string{"foo": []string{"<em>bar</em>"}}, resp.Hits.Hits[0].Highlight)
 	})
+
+	t.Run("request with matched queries", func(t *testing.T) {
+		resp, err := client.Search(
+			nil,
+			&opensearchapi.SearchReq{
+				Indices: []string{index},
+				Body: strings.NewReader(`{
+					"query": {
+						"match": {
+							"foo": {
+								"query": "bar",
+							},
+							"_name": "test"
+						}
+					}
+				}`),
+			},
+		)
+		require.Nil(t, err)
+		assert.NotEmpty(t, resp.Hits.Hits)
+		assert.Equal(t, []string{"test"}, resp.Hits.Hits[0].MatchedQueries)
+	})
 }

--- a/opensearchapi/api_search_test.go
+++ b/opensearchapi/api_search_test.go
@@ -215,9 +215,9 @@ func TestSearch(t *testing.T) {
 					"query": {
 						"match": {
 							"foo": {
-								"query": "bar"
-							},
-							"_name": "test"
+								"query": "bar",
+								"_name": "test"
+							}
 						}
 					}
 				}`),


### PR DESCRIPTION
### Description
_Describe what this change achieves._
Added MatchedQueries field in response struct of SearchHit.
This is done to add support for receiving matched queries in response when using `_name` with query clauses

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [opensearch-project/opensearch-go/issues/573]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
