### PR TITLE
Lock version of OpenSearch for integration tests.

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 env:
   GITHUB_ACTIONS: true
+  OPENSEARCH_VERSION: 2.19.0
 
 jobs:
   test:


### PR DESCRIPTION
### Description

Lock version of OpenSearch for integration tests. When 2.19 was released it broke CI, which is not desirable. With this change we have to upgrade deliberately like we do for integration tests already.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
