### PR TITLE
Preparing for release, 4.4.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
-## [Unreleased]
+## [4.4.0]
 
 ### Added
 - Adds `Highlight` field to `SearchHit` ([#654](https://github.com/opensearch-project/opensearch-go/pull/654))
@@ -302,7 +302,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `github.com/stretchr/testify` from 1.8.0 to 1.8.1
 - Bumps `github.com/aws/aws-sdk-go` from 1.44.45 to 1.44.132
 
-[Unreleased]: https://github.com/opensearch-project/opensearch-go/compare/v4.3.0...HEAD
+[4.4.0]: https://github.com/opensearch-project/opensearch-go/compare/v4.3.0...v4.4.0
 [4.3.0]: https://github.com/opensearch-project/opensearch-go/compare/v4.2.0...v4.3.0
 [4.2.0]: https://github.com/opensearch-project/opensearch-go/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/opensearch-project/opensearch-go/compare/v4.0.0...v4.1.0

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -27,4 +27,4 @@
 package version
 
 // Client returns the client version as a string.
-const Client = "4.3.1"
+const Client = "4.4.0"


### PR DESCRIPTION
### Description

Preparing for release, 4.4.0. We have new features, so bumped from 4.3.1 to 4.4.0.

### Issues Resolved

Part of https://github.com/opensearch-project/opensearch-go/issues/666.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
