### PR TITLE
Add action to refresh search analyzers to ISM plugin client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Adds new fields for Opensearch 3.0 ([#702](https://github.com/opensearch-project/opensearch-go/pull/702))
 - Allow users to override signing port ([#721](https://github.com/opensearch-project/opensearch-go/pull/721))
 - Add `phase_took` features supported from OpenSearch 2.12 ([#722](https://github.com/opensearch-project/opensearch-go/pull/722))
+- Adds the action to refresh the search analyzers to the ISM plugin ([#686](https://github.com/opensearch-project/opensearch-go/pull/686))
 
 ### Changed
 - Test against Opensearch 3.0 ([#702](https://github.com/opensearch-project/opensearch-go/pull/702))

--- a/plugins/ism/api_refresh_search_analyzers-params.go
+++ b/plugins/ism/api_refresh_search_analyzers-params.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package ism
+
+import "strings"
+
+// RefreshSearchAnalyzersParams represents possible parameters for the RefreshSearchAnalyzersReq
+type RefreshSearchAnalyzersParams struct {
+	Pretty     bool
+	Human      bool
+	ErrorTrace bool
+	FilterPath []string
+}
+
+func (r RefreshSearchAnalyzersParams) get() map[string]string {
+	params := make(map[string]string)
+
+	if r.Pretty {
+		params["pretty"] = "true"
+	}
+
+	if r.Human {
+		params["human"] = "true"
+	}
+
+	if r.ErrorTrace {
+		params["error_trace"] = "true"
+	}
+
+	if len(r.FilterPath) > 0 {
+		params["filter_path"] = strings.Join(r.FilterPath, ",")
+	}
+
+	return params
+}

--- a/plugins/ism/api_refresh_search_analyzers.go
+++ b/plugins/ism/api_refresh_search_analyzers.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package ism
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/opensearch-project/opensearch-go/v4"
+)
+
+// RefreshSearchAnalyzers executes a request to refresh search analyzers with the required RefreshSearchAnalyzersReq
+func (c Client) RefreshSearchAnalyzers(ctx context.Context, req RefreshSearchAnalyzersReq) (RefreshSearchAnalyzersResp, error) {
+	var (
+		data RefreshSearchAnalyzersResp
+		err  error
+	)
+	if data.response, err = c.do(ctx, req, &data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// RefreshSearchAnalyzersReq represents possible options for the /_plugins/_refresh_search_analyzers/<indices> request
+type RefreshSearchAnalyzersReq struct {
+	Indices []string
+
+	Header http.Header
+	Params RefreshSearchAnalyzersParams
+}
+
+// GetRequest returns the *http.Request that gets executed by the client
+func (r RefreshSearchAnalyzersReq) GetRequest() (*http.Request, error) {
+	indices := strings.Join(r.Indices, ",")
+
+	var path strings.Builder
+	path.Grow(len("/_plugins/_refresh_search_analyzers/") + len(indices))
+	path.WriteString("_plugins/_refresh_search_analyzers")
+	if len(r.Indices) > 0 {
+		path.WriteString("/")
+		path.WriteString(indices)
+	}
+
+	return opensearch.BuildRequest(
+		http.MethodPost,
+		path.String(),
+		nil,
+		r.Params.get(),
+		r.Header,
+	)
+}
+
+// RefreshSearchAnalyzersResp represents the returned struct of the refreshed search analyzers response
+type RefreshSearchAnalyzersResp struct {
+	Shards                   RefreshSearchAnalyzersShards                     `json:"_shards"`
+	SuccessfulRefreshDetails []RefreshSearchAnalyzersSuccessfulRefreshDetails `json:"successful_refresh_details"`
+	response                 *opensearch.Response
+}
+
+// Inspect returns the Inspect type containing the raw *opensearch.Response
+func (r RefreshSearchAnalyzersResp) Inspect() Inspect {
+	return Inspect{Response: r.response}
+}
+
+// RefreshSearchAnalyzersShards is a subtype of RefreshSearchAnalyzersResp representing information about the updated shards
+type RefreshSearchAnalyzersShards struct {
+	Total      int `json:"total"`
+	Successful int `json:"successful"`
+	Failed     int `json:"failed"`
+}
+
+// RefreshSearchAnalyzersSuccessfulRefreshDetails is a subtype of RefreshSearchAnalyzersResp representing information about the analyzers
+type RefreshSearchAnalyzersSuccessfulRefreshDetails struct {
+	Index              string   `json:"index"`
+	RefreshedAnalyzers []string `json:"refreshed_analyzers"`
+}

--- a/plugins/ism/api_test.go
+++ b/plugins/ism/api_test.go
@@ -209,6 +209,23 @@ func TestClient(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "RefreshSearchAnalyzers",
+			Tests: []clientTests{
+				{
+					Name: "with request",
+					Results: func() (osismtest.Response, error) {
+						return client.RefreshSearchAnalyzers(nil, ism.RefreshSearchAnalyzersReq{Indices: testIndex})
+					},
+				},
+				{
+					Name: "inspect",
+					Results: func() (osismtest.Response, error) {
+						return failingClient.RefreshSearchAnalyzers(nil, ism.RefreshSearchAnalyzersReq{Indices: []string{"*"}})
+					},
+				},
+			},
+		},
 	}
 	for _, value := range testCases {
 		t.Run(value.Name, func(t *testing.T) {


### PR DESCRIPTION
### Description

The changes in this merge request focus on adding support for refreshing the search analyzers to the client of the ISM plugin.

### Issues Resolved

Closes #678 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
