### PR TITLE
Adds Aggregations field to MSearchResp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Adds `InnerHits` field to `SearchResp` ([#672](https://github.com/opensearch-project/opensearch-go/pull/672))
 - Adds `FilterPath` param ([#673](https://github.com/opensearch-project/opensearch-go/pull/673))
+- Adds `Aggregations` field to `MSearchResp` ([#690](https://github.com/opensearch-project/opensearch-go/pull/690))
 
 ### Changed
 - Bump golang version to 1.22 ([#691](https://github.com/opensearch-project/opensearch-go/pull/691))

--- a/opensearchapi/api_msearch.go
+++ b/opensearchapi/api_msearch.go
@@ -8,6 +8,7 @@ package opensearchapi
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
@@ -72,7 +73,8 @@ type MSearchResp struct {
 			MaxScore float32     `json:"max_score"`
 			Hits     []SearchHit `json:"hits"`
 		} `json:"hits"`
-		Status int `json:"status"`
+		Status       int             `json:"status"`
+		Aggregations json.RawMessage `json:"aggregations"`
 	} `json:"responses"`
 	response *opensearch.Response
 }

--- a/opensearchapi/api_msearch_test.go
+++ b/opensearchapi/api_msearch_test.go
@@ -35,7 +35,7 @@ func TestMSearch(t *testing.T) {
 			nil,
 			opensearchapi.DocumentCreateReq{
 				Index:      testIndex,
-				Body:       strings.NewReader(`{"foo": "bar"}`),
+				Body:       strings.NewReader(`{"foo": "bar", "number": 1}`),
 				DocumentID: strconv.Itoa(i),
 				Params:     opensearchapi.DocumentCreateParams{Refresh: "true"},
 			},
@@ -64,5 +64,18 @@ func TestMSearch(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.NotNil(t, res)
 		osapitest.VerifyInspect(t, res.Inspect())
+	})
+
+	t.Run("with aggs request", func(t *testing.T) {
+		resp, err := client.MSearch(
+			nil,
+			opensearchapi.MSearchReq{
+				Indices: []string{testIndex},
+				Body:    strings.NewReader("{}\n{\"aggs\":{\"number_terms\":{\"terms\":{\"field\":\"number\"}}}}\n"),
+			},
+		)
+		require.Nil(t, err)
+		assert.NotNil(t, resp)
+		ostest.CompareRawJSONwithParsedJSON(t, resp, resp.Inspect().Response)
 	})
 }


### PR DESCRIPTION
### Description
_Describe what this change achieves._
Added Aggregations field in response struct of MSearchResp.
This is done to add support for receiving aggregations in msearch responses

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
