### PR TITLE
Bump golang version to 1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Adds `FilterPath` param ([#673](https://github.com/opensearch-project/opensearch-go/pull/673))
 
 ### Changed
+- Bump golang version to 1.22 ([#691](https://github.com/opensearch-project/opensearch-go/pull/691))
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 - Bump golang version to 1.22 ([#691](https://github.com/opensearch-project/opensearch-go/pull/691))
+- Change ChangeCatRecoveryItemResp Byte fields from int to string ([#691](https://github.com/opensearch-project/opensearch-go/pull/691))
 ### Deprecated
 ### Removed
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/opensearch-project/opensearch-go/v4
 
-go 1.21
+go 1.22
+
+toolchain go1.22.12
 
 require (
 	github.com/aws/aws-sdk-go v1.55.6

--- a/opensearchapi/api_cat-recovery.go
+++ b/opensearchapi/api_cat-recovery.go
@@ -66,10 +66,10 @@ type CatRecoveryItemResp struct {
 	FilesRecovered       int    `json:"files_recovered,string"`
 	FilesPercent         string `json:"files_percent"`
 	FilesTotal           int    `json:"files_total,string"`
-	Bytes                int    `json:"bytes,string"`
-	BytesRecovered       int    `json:"bytes_recovered,string"`
+	Bytes                string `json:"bytes"`
+	BytesRecovered       string `json:"bytes_recovered"`
 	BytesPercent         string `json:"bytes_percent"`
-	BytesTotal           int    `json:"bytes_total,string"`
+	BytesTotal           string `json:"bytes_total"`
 	TranslogOps          int    `json:"translog_ops,string"`
 	TranslogOpsRecovered int    `json:"translog_ops_recovered,string"`
 	TranslogOpsPercent   string `json:"translog_ops_percent"`


### PR DESCRIPTION
### Description
Bump Golang to version 1.22 because it is the oldest maintaned Golang version.
This also fixed the CI for dependency PR's.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
