### PR TITLE
docs(USER_GUIDE.md): correct usage of fmt.Printf for formatted output in code examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Adds `FilterPath` param ([#673](https://github.com/opensearch-project/opensearch-go/pull/673))
 
 ### Changed
+- Changed log formatted examples code ([#694](https://github.com/opensearch-project/opensearch-go/pull/694))
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -237,7 +237,7 @@ const IndexName = "go-test-index1"
 
 func main() {
 	if err := example(); err != nil {
-		fmt.Printf("Error: %s", err)
+		fmt.Printf("Error: %s\n", err)
 		os.Exit(1)
 	}
 }

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -364,7 +364,7 @@ func example() error {
 		return err
 	}
 
-	fmt.Printf("created index: %s", createResp.Index)
+	fmt.Printf("created index: %s\n", createResp.Index)
 
 	delResp, err := client.Indices.Delete(ctx, opensearchapi.IndicesDeleteReq{Indices: []string{indexName}})
 	if err != nil {

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -371,7 +371,7 @@ func example() error {
 		return err
 	}
 
-	fmt.Printf("deleted index: %#v", delResp.Acknowledged)
+	fmt.Printf("deleted index: %#v\n", delResp.Acknowledged)
 	return nil
 }
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -237,7 +237,7 @@ const IndexName = "go-test-index1"
 
 func main() {
 	if err := example(); err != nil {
-		fmt.Println(fmt.Sprintf("Error: %s", err))
+		fmt.Printf("Error: %s", err)
 		os.Exit(1)
 	}
 }
@@ -364,14 +364,14 @@ func example() error {
 		return err
 	}
 
-	fmt.Println("created index: %s", createResp.Index)
+	fmt.Printf("created index: %s", createResp.Index)
 
 	delResp, err := client.Indices.Delete(ctx, opensearchapi.IndicesDeleteReq{Indices: []string{indexName}})
 	if err != nil {
 		return err
 	}
 
-	fmt.Println("deleted index: %#v", delResp.Acknowledged)
+	fmt.Printf("deleted index: %#v", delResp.Acknowledged)
 	return nil
 }
 


### PR DESCRIPTION
### Description
correct usage of fmt.Printf for formatted output in code examples

### Issues Resolved
None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
