### PR TITLE
Improve error response when body is an empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump golang version to 1.22 ([#691](https://github.com/opensearch-project/opensearch-go/pull/691))
 - Change ChangeCatRecoveryItemResp Byte fields from int to string ([#691](https://github.com/opensearch-project/opensearch-go/pull/691))
 - Changed log formatted examples code ([#694](https://github.com/opensearch-project/opensearch-go/pull/694))
+- Improve the error reporting of invalid body response ([#699](https://github.com/opensearch-project/opensearch-go/pull/699))
 
 ### Deprecated
 ### Removed

--- a/error.go
+++ b/error.go
@@ -128,7 +128,7 @@ func ParseError(resp *Response) error {
 	}
 
 	if !json.Valid(body) {
-		return fmt.Errorf("%s", body)
+		return fmt.Errorf("invalid body: %q", body)
 	}
 
 	var testResp struct {

--- a/error.go
+++ b/error.go
@@ -127,10 +127,6 @@ func ParseError(resp *Response) error {
 		return fmt.Errorf("%w: %w", ErrReadBody, err)
 	}
 
-	if !json.Valid(body) {
-		return fmt.Errorf("invalid body: %q", body)
-	}
-
 	var testResp struct {
 		Status  any `json:"status"`
 		Error   any `json:"error"`

--- a/error_test.go
+++ b/error_test.go
@@ -244,7 +244,7 @@ func TestError(t *testing.T) {
 			}
 			assert.True(t, resp.IsError())
 			err := opensearch.ParseError(resp)
-			assert.Contains(t, err.Error(), http.StatusText(http.StatusUnauthorized))
+			assert.True(t, errors.Is(err, opensearch.ErrJSONUnmarshalBody))
 		})
 		t.Run("too many requests", func(t *testing.T) {
 			resp := &opensearch.Response{
@@ -253,7 +253,7 @@ func TestError(t *testing.T) {
 			}
 			assert.True(t, resp.IsError())
 			err := opensearch.ParseError(resp)
-			assert.Contains(t, err.Error(), "429 Too Many Requests /testindex/_bulk")
+			assert.True(t, errors.Is(err, opensearch.ErrJSONUnmarshalBody))
 		})
 	})
 }

--- a/error_test.go
+++ b/error_test.go
@@ -244,7 +244,7 @@ func TestError(t *testing.T) {
 			}
 			assert.True(t, resp.IsError())
 			err := opensearch.ParseError(resp)
-			assert.Equal(t, err.Error(), http.StatusText(http.StatusUnauthorized))
+			assert.Contains(t, err.Error(), http.StatusText(http.StatusUnauthorized))
 		})
 		t.Run("too many requests", func(t *testing.T) {
 			resp := &opensearch.Response{
@@ -253,7 +253,7 @@ func TestError(t *testing.T) {
 			}
 			assert.True(t, resp.IsError())
 			err := opensearch.ParseError(resp)
-			assert.Equal(t, err.Error(), "429 Too Many Requests /testindex/_bulk")
+			assert.Contains(t, err.Error(), "429 Too Many Requests /testindex/_bulk")
 		})
 	})
 }


### PR DESCRIPTION
### Description
We are observing conditions where Opensearch returns with an emtpy body. In that case, the error string returned is just blank which is very confusing to the end user.

To fix this, we add some more context to the error string to make it clear.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
