### PR TITLE
Add support for Opensearch 3.0/ Drop Opensearch 1.x support

### DIFF
--- a/.ci/opensearch/Dockerfile.opensearch
+++ b/.ci/opensearch/Dockerfile.opensearch
@@ -16,7 +16,7 @@ RUN if [ "$SECURE_INTEGRATION" != "true" ] ; then \
         echo "plugins.security.unsupported.restapi.allow_securityconfig_modification: true"  | tee -a $opensearch_path/config/opensearch.yml > /dev/null; \
         echo "plugins.security.ssl_cert_reload_enabled: true" | tee -a $opensearch_path/config/opensearch.yml > /dev/null; \
         function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }; \
-        if [ $(version $OPENSEARCH_VERSION) -ge $(version "2.8.0") ] || [ $OPENSEARCH_VERSION == "latest" ]; then \
+        if [ $(version $OPENSEARCH_VERSION) -ge $(version "2.8.0") ] || [ "$OPENSEARCH_VERSION" == "latest" ]; then \
           echo "plugins.security.restapi.admin.enabled: true" | tee -a $opensearch_path/config/opensearch.yml > /dev/null; \
         fi \
       fi

--- a/.ci/opensearch/Dockerfile.opensearch
+++ b/.ci/opensearch/Dockerfile.opensearch
@@ -22,6 +22,6 @@ RUN if [ "$SECURE_INTEGRATION" != "true" ] ; then \
       fi
 
 HEALTHCHECK --start-period=20s --interval=30s \
-  CMD curl -sf -retry 5 --max-time 5 --retry-delay 5 --retry-max-time 30 \
+  CMD curl -sf --retry 5 --max-time 5 --retry-delay 5 --retry-max-time 30 --retry-all-errors \
   $(if $SECURE_INTEGRATION; then echo "--cert config/kirk.pem --key config/kirk-key.pem -k https://"; fi)"localhost:9200" \
   || bash -c 'kill -s 15 -1 && (sleep 10; kill -s 9 -1)'

--- a/.ci/opensearch/docker-compose.yml
+++ b/.ci/opensearch/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   opensearch:
     deploy:

--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -10,7 +10,6 @@ jobs:
       matrix:
         secured: ["true", "false"]
         entry:
-          - { opensearch_version: 1.3.18 }
           - { opensearch_version: 2.0.1 }
           - { opensearch_version: 2.1.0 }
           - { opensearch_version: 2.2.1 }
@@ -28,9 +27,10 @@ jobs:
           - { opensearch_version: 2.14.0 }
           - { opensearch_version: 2.15.0 }
           - { opensearch_version: 2.16.0 }
-          - { opensearch_version: 2.17.0 }
+          - { opensearch_version: 2.17.1 }
           - { opensearch_version: 2.18.0 }
-          - { opensearch_version: 2.19.0 }
+          - { opensearch_version: 2.19.2 }
+          - { opensearch_version: 3.0.0 }
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test-integration-unreleased.yml
+++ b/.github/workflows/test-integration-unreleased.yml
@@ -9,8 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         entry:
-          - { branch: '1.x', java-version: '11' }
           - { branch: '2.x', java-version: '17' }
+          - { branch: '3.x', java-version: '21' }
           - { branch: 'main', java-version: '21' }
     steps:
       - name: Checkout OpenSearch

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   GITHUB_ACTIONS: true
-  OPENSEARCH_VERSION: 2.19.0
+  OPENSEARCH_VERSION: 2.19.2
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Bump golang version to 1.22 ([#691](https://github.com/opensearch-project/opensearch-go/pull/691))
 - Change ChangeCatRecoveryItemResp Byte fields from int to string ([#691](https://github.com/opensearch-project/opensearch-go/pull/691))
+- Test against Opensearch 3.0, drop Opensearch 1.x ([#702](https://github.com/opensearch-project/opensearch-go/pull/702))
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump golang version to 1.22 ([#691](https://github.com/opensearch-project/opensearch-go/pull/691))
 - Change ChangeCatRecoveryItemResp Byte fields from int to string ([#691](https://github.com/opensearch-project/opensearch-go/pull/691))
 - Test against Opensearch 3.0, drop Opensearch 1.x ([#702](https://github.com/opensearch-project/opensearch-go/pull/702))
+- Add new fields for Opensearch 3.0 ([#702](https://github.com/opensearch-project/opensearch-go/pull/702))
 ### Deprecated
 ### Removed
 ### Fixed

--- a/opensearchapi/api_cluster-state.go
+++ b/opensearchapi/api_cluster-state.go
@@ -194,6 +194,7 @@ type ClusterStateMetaDataStream struct {
 type ClusterStateRoutingIndex struct {
 	State                    string  `json:"state"`
 	Primary                  bool    `json:"primary"`
+	SearchOnly               bool    `json:"searchOnly"`
 	Node                     *string `json:"node"`
 	RelocatingNode           *string `json:"relocating_node"`
 	Shard                    int     `json:"shard"`

--- a/opensearchapi/api_cluster-stats.go
+++ b/opensearchapi/api_cluster-stats.go
@@ -194,6 +194,7 @@ type ClusterStatsNodes struct {
 		Master              int `json:"master"`
 		RemoteClusterClient int `json:"remote_cluster_client"`
 		Search              int `json:"search"`
+		Warm                int `json:"warm"`
 	} `json:"count"`
 	Versions []string `json:"versions"`
 	Os       struct {

--- a/opensearchapi/api_nodes-info.go
+++ b/opensearchapi/api_nodes-info.go
@@ -71,28 +71,29 @@ func (r NodesInfoResp) Inspect() Inspect {
 
 // NodesInfo is a sub type of NodesInfoResp containing information about nodes and their stats
 type NodesInfo struct {
-	Name                string                         `json:"name"`
-	TransportAddress    string                         `json:"transport_address"`
-	Host                string                         `json:"host"`
-	IP                  string                         `json:"ip"`
-	Version             string                         `json:"version"`
-	BuildType           string                         `json:"build_type"`
-	BuildHash           string                         `json:"build_hash"`
-	TotalIndexingBuffer int64                          `json:"total_indexing_buffer"`
-	Roles               []string                       `json:"roles"`
-	Attributes          map[string]string              `json:"attributes"`
-	Settings            json.RawMessage                `json:"settings"` // Won't parse as it may contain fields that we can't know
-	OS                  NodesInfoOS                    `json:"os"`
-	Process             NodesInfoProcess               `json:"process"`
-	JVM                 NodesInfoJVM                   `json:"jvm"`
-	ThreadPool          map[string]NodesInfoThreadPool `json:"thread_pool"`
-	Transport           NodesInfoTransport             `json:"transport"`
-	HTTP                NodesInfoHTTP                  `json:"http"`
-	Plugins             []NodesInfoPlugin              `json:"plugins"`
-	Modules             []NodesInfoPlugin              `json:"modules"`
-	Ingest              NodesInfoIngest                `json:"ingest"`
-	Aggregations        map[string]NodesInfoAgg        `json:"aggregations"`
-	SearchPipelines     NodesInfoSearchPipelines       `json:"search_pipelines"`
+	Name                       string                         `json:"name"`
+	TransportAddress           string                         `json:"transport_address"`
+	Host                       string                         `json:"host"`
+	IP                         string                         `json:"ip"`
+	Version                    string                         `json:"version"`
+	BuildType                  string                         `json:"build_type"`
+	BuildHash                  string                         `json:"build_hash"`
+	TotalIndexingBuffer        int64                          `json:"total_indexing_buffer"`
+	TotalIndexingBufferInBytes int64                          `json:"total_indexing_buffer_in_bytes"`
+	Roles                      []string                       `json:"roles"`
+	Attributes                 map[string]string              `json:"attributes"`
+	Settings                   json.RawMessage                `json:"settings"` // Won't parse as it may contain fields that we can't know
+	OS                         NodesInfoOS                    `json:"os"`
+	Process                    NodesInfoProcess               `json:"process"`
+	JVM                        NodesInfoJVM                   `json:"jvm"`
+	ThreadPool                 map[string]NodesInfoThreadPool `json:"thread_pool"`
+	Transport                  NodesInfoTransport             `json:"transport"`
+	HTTP                       NodesInfoHTTP                  `json:"http"`
+	Plugins                    []NodesInfoPlugin              `json:"plugins"`
+	Modules                    []NodesInfoPlugin              `json:"modules"`
+	Ingest                     NodesInfoIngest                `json:"ingest"`
+	Aggregations               map[string]NodesInfoAgg        `json:"aggregations"`
+	SearchPipelines            NodesInfoSearchPipelines       `json:"search_pipelines"`
 }
 
 // NodesInfoOS is a sub type of NodesInfo containing information about the Operating System

--- a/opensearchapi/api_nodes-stats.go
+++ b/opensearchapi/api_nodes-stats.go
@@ -624,6 +624,7 @@ type NodesStatsSearchBackpressure struct {
 			CancellationCount             int `json:"cancellation_count"`
 			CancellationLimitReachedCount int `json:"cancellation_limit_reached_count"`
 		} `json:"cancellation_stats"`
+		CompletionCount int `json:"completion_count"`
 	} `json:"search_task"`
 	SearchShardTask struct {
 		ResourceTrackerStats struct {
@@ -640,6 +641,7 @@ type NodesStatsSearchBackpressure struct {
 			CancellationCount             int `json:"cancellation_count"`
 			CancellationLimitReachedCount int `json:"cancellation_limit_reached_count"`
 		} `json:"cancellation_stats"`
+		CompletionCount int `json:"completion_count"`
 	} `json:"search_shard_task"`
 	Mode string `json:"mode"`
 }
@@ -678,10 +680,14 @@ type NodesStatsSearchPipeline struct {
 
 // NodesStatsTaskCancellation is a sub type of NodesStats containing stats about canceled tasks
 type NodesStatsTaskCancellation struct {
-	SearchShardTask struct {
-		CurrentCountPostCancel int `json:"current_count_post_cancel"`
-		TotalCountPostCancel   int `json:"total_count_post_cancel"`
-	} `json:"search_shard_task"`
+	SearchTask      NodesStatsTaskCancellationValues `json:"search_task"`
+	SearchShardTask NodesStatsTaskCancellationValues `json:"search_shard_task"`
+}
+
+// NodesStatsTaskCancellationValues is a sub type of NodesStatsTaskCancellation
+type NodesStatsTaskCancellationValues struct {
+	CurrentCountPostCancel int `json:"current_count_post_cancel"`
+	TotalCountPostCancel   int `json:"total_count_post_cancel"`
 }
 
 // NodesStatsIndicesSearchRequest is a sub type of NodesStatsIndices containing stats about search requests

--- a/opensearchapi/api_search_shards.go
+++ b/opensearchapi/api_search_shards.go
@@ -72,6 +72,7 @@ type SearchShardsResp struct {
 	Shards  [][]struct {
 		State                    string  `json:"state"`
 		Primary                  bool    `json:"primary"`
+		SearchOnly               bool    `json:"searchOnly"`
 		Node                     string  `json:"node"`
 		RelocatingNode           *string `json:"relocating_node"`
 		Shard                    int     `json:"shard"`


### PR DESCRIPTION
### Description
- Fix CI issues
- Add Opensearch 3.0 fields
- Replace Opensearch CI tests against 1.x with 3.x

### Issues Resolved
Related https://github.com/opensearch-project/opensearch-go/issues/697

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
