### PR TITLE
fix(api): alias api creates index when index name is nill

### DIFF
--- a/opensearchapi/api_indices-alias.go
+++ b/opensearchapi/api_indices-alias.go
@@ -9,6 +9,7 @@ package opensearchapi
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -156,6 +157,9 @@ type AliasPutReq struct {
 
 // GetRequest returns the *http.Request that gets executed by the client
 func (r AliasPutReq) GetRequest() (*http.Request, error) {
+	if len(r.Indices) == 0 {
+		return nil, fmt.Errorf("at least one index must be specified for alias operation")
+	}
 	indices := strings.Join(r.Indices, ",")
 
 	var path strings.Builder


### PR DESCRIPTION
### Description
When Alias PUT api is called with an empty index name i.e `""`, the `BuildRequest` function parses characters after the double quote and before the next `/` as hostname for the request i.e `_alias` and request becomes `https://localhost:9200/{aliasname} -H _alias -XPUT` which actually creates an index. 

The fix returns an error when a nil index is passed.

Note -
This is intended to be a temporary fix, however a better fix would be to parse the complete URL i.e instead of creating http request just with path parameters (i.e `/<target>/_alias/<alias-name>`) at `BuildRequest`, it would be better to provide the complete URL (i.e `https://localhost:9200/<target>/_alias/<alias-name>`). This however, requires a redesign of the API system.

### Issues Resolved
#650 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
