### PR TITLE
Update SuggestOptions in the SearchResp struct to include all the fields for suggesters 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 - Test against Opensearch 3.0 ([#702](https://github.com/opensearch-project/opensearch-go/pull/702))
+- Add more SuggestOptions to SearchResp ([#713](https://github.com/opensearch-project/opensearch-go/pull/713))
 
 ### Deprecated
 

--- a/opensearchapi/api_search.go
+++ b/opensearchapi/api_search.go
@@ -111,14 +111,23 @@ type SearchHit struct {
 
 // Suggest is a sub type of SearchResp containing information of the suggest field
 type Suggest struct {
-	Text    string `json:"text"`
-	Offset  int    `json:"offset"`
-	Length  int    `json:"length"`
-	Options []struct {
-		Text         string  `json:"text"`
-		Score        float32 `json:"score"`
-		Freq         int     `json:"freq"`
-		Highlighted  string  `json:"highlighted"`
-		CollateMatch bool    `json:"collate_match"`
-	} `json:"options"`
+	Text    string           `json:"text"`
+	Offset  int              `json:"offset"`
+	Length  int              `json:"length"`
+	Options []SuggestOptions `json:"options"`
+}
+
+// SuggestOptions is a sub type of Suggest field containing information about suggest options
+type SuggestOptions struct {
+	Text            string              `json:"text"`
+	Index           string              `json:"_index"`
+	Type            string              `json:"_type"`
+	ID              string              `json:"_id"`
+	Score           float64             `json:"score"`  // term suggesters uses "score"
+	ScoreUnderscore float64             `json:"_score"` // completion and context suggesters uses "_score"
+	Freq            int                 `json:"freq"`
+	Highlighted     string              `json:"highlighted"`
+	CollateMatch    bool                `json:"collate_match"`
+	Source          json.RawMessage     `json:"_source"`
+	Contexts        map[string][]string `json:"contexts,omitempty"`
 }

--- a/opensearchapi/api_search_test.go
+++ b/opensearchapi/api_search_test.go
@@ -36,6 +36,14 @@ func TestSearch(t *testing.T) {
 					"properties": {
 						"baz": {
 							"type": "nested"
+						},
+						"foo": {
+							"type": "text",
+							"fields": {
+								"suggestions": {
+									"type": "completion"
+								}
+							}
 						}
 					}
 				}
@@ -196,6 +204,28 @@ func TestSearch(t *testing.T) {
 		  }`)})
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp.Suggest)
+	})
+
+		t.Run("request with completion suggest", func(t *testing.T) {
+		resp, err := client.Search(nil, &opensearchapi.SearchReq{Indices: []string{index}, Body: strings.NewReader(`{
+			"suggest": {
+			  "my-suggest": {
+			  	"text": "bar",
+				"completion": {
+					"field": "foo.suggestions",
+					"skip_duplicates": true
+				} 
+			  }
+			}
+		  }`)})
+		require.Nil(t, err)
+		assert.NotEmpty(t, resp.Suggest)
+		assert.NotEmpty(t, resp.Suggest["my-suggest"])
+		for _,suggestion := range resp.Suggest["my-suggest"] {
+			assert.Equal(t, suggestion.Text, "bar")
+			assert.NotEmpty(t, suggestion.Options)
+			assert.Equal(t, suggestion.Options[0].Text, "bar")
+		}
 	})
 
 	t.Run("request with highlight", func(t *testing.T) {


### PR DESCRIPTION
### Description
`SearchResp` had the `Suggest` field but the `Options ` did not contain all the fields. The previous [PR ](https://github.com/opensearch-project/opensearch-go/pull/602) only covers the response from term suggesters. This change will cover all the fields in response for [term](https://docs.opensearch.org/docs/latest/search-plugins/searching-data/did-you-mean/) or [completion](https://docs.opensearch.org/docs/latest/search-plugins/searching-data/autocomplete/#completion-suggester) suggesters. 

### Issues Resolved
Closes - https://github.com/opensearch-project/opensearch-go/issues/712 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
