### PR TITLE
Allow users to override signing port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Adds new fields for Opensearch 3.0 ([#702](https://github.com/opensearch-project/opensearch-go/pull/702))
-- Allows users to override signing port ([#717](https://github.com/opensearch-project/opensearch-go/pull/702))
+- Allow users to override signing port ([#717](https://github.com/opensearch-project/opensearch-go/pull/702))
 
 ### Changed
 - Test against Opensearch 3.0 ([#702](https://github.com/opensearch-project/opensearch-go/pull/702))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Adds new fields for Opensearch 3.0 ([#702](https://github.com/opensearch-project/opensearch-go/pull/702))
-- Allow users to override signing port ([#717](https://github.com/opensearch-project/opensearch-go/pull/702))
+- Allow users to override signing port ([#721](https://github.com/opensearch-project/opensearch-go/pull/721))
 
 ### Changed
 - Test against Opensearch 3.0 ([#702](https://github.com/opensearch-project/opensearch-go/pull/702))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Adds new fields for Opensearch 3.0 ([#702](https://github.com/opensearch-project/opensearch-go/pull/702))
+- Allows users to override signing port ([#717](https://github.com/opensearch-project/opensearch-go/pull/702))
 
 ### Changed
 - Test against Opensearch 3.0 ([#702](https://github.com/opensearch-project/opensearch-go/pull/702))

--- a/opensearchtransport/opensearchtransport_internal_test.go
+++ b/opensearchtransport/opensearchtransport_internal_test.go
@@ -42,6 +42,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/opensearch-project/opensearch-go/v4/signer"
 )
 
 var _ = fmt.Print
@@ -65,6 +67,7 @@ type mockSigner struct {
 	SampleValue string
 	ReturnError bool
 	testHook    func(*http.Request)
+	signer.Signer
 }
 
 func (m *mockSigner) SignRequest(req *http.Request) error {

--- a/signer/aws/aws.go
+++ b/signer/aws/aws.go
@@ -72,8 +72,7 @@ func (s *Signer) OverrideSigningPort(port uint16) {
 // SignRequest signs the request using SigV4.
 func (s Signer) SignRequest(req *http.Request) error {
 	if s.signaturePort > 0 {
-		req.URL.Host = fmt.Sprintf("%s:%d", req.URL.Hostname(), s.signaturePort)
-		req.Host = req.URL.Host
+		req.Host = fmt.Sprintf("%s:%d", req.URL.Hostname(), s.signaturePort)
 	}
 
 	return sign(req, s.session.Config.Region, s.service, v4.NewSigner(s.session.Config.Credentials))

--- a/signer/aws/aws.go
+++ b/signer/aws/aws.go
@@ -63,6 +63,8 @@ func NewSignerWithService(opts session.Options, service string) (*Signer, error)
 	}, nil
 }
 
+// OverrideSigningPort allows setting a custom signing por
+// useful when going through an SSH Tunnel which would cause a signature mismatch
 func (s *Signer) OverrideSigningPort(port uint16) {
 	s.signaturePort = port
 }

--- a/signer/aws/aws_test.go
+++ b/signer/aws/aws_test.go
@@ -91,9 +91,10 @@ func TestV4Signer(t *testing.T) {
 		err = signer.SignRequest(req)
 		assert.NoError(t, err)
 
+		assert.Equal(t, "localhost", req.Host) // should have been stripped off given we used a common port
+
 		q := req.Header
 
-		assert.Equal(t, "localhost", req.Host) // should have been stripped off given we used a common port
 		assert.NotEmpty(t, q.Get("Authorization"))
 		assert.NotEmpty(t, q.Get("X-Amz-Date"))
 		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", q.Get("X-Amz-Content-Sha256"))

--- a/signer/awsv2/sdkv2signer.go
+++ b/signer/awsv2/sdkv2signer.go
@@ -34,18 +34,20 @@ const (
 )
 
 type awsSdkV2Signer struct {
-	service string
-	signer  *awsSignerV4.Signer
-	awsCfg  aws.Config
+	service       string
+	signer        *awsSignerV4.Signer
+	awsCfg        aws.Config
+	signaturePort uint16
+	opts          []func(options *awsSignerV4.SignerOptions)
 }
 
 // NewSigner returns an instance of Signer for AWS OpenSearchService
-func NewSigner(cfg aws.Config) (signer.Signer, error) {
-	return NewSignerWithService(cfg, openSearchService)
+func NewSigner(cfg aws.Config, opts ...func(options *awsSignerV4.SignerOptions)) (signer.Signer, error) {
+	return NewSignerWithService(cfg, openSearchService, opts...)
 }
 
 // NewSignerWithService returns an instance of Signer for given service
-func NewSignerWithService(cfg aws.Config, service string) (signer.Signer, error) {
+func NewSignerWithService(cfg aws.Config, service string, opts ...func(options *awsSignerV4.SignerOptions)) (signer.Signer, error) {
 	if len(strings.TrimSpace(service)) < 1 {
 		return nil, errors.New("service cannot be empty")
 	}
@@ -54,7 +56,14 @@ func NewSignerWithService(cfg aws.Config, service string) (signer.Signer, error)
 		service: service,
 		signer:  awsSignerV4.NewSigner(),
 		awsCfg:  cfg,
+		opts:    opts,
 	}, nil
+}
+
+// OverrideSigningPort allows setting a custom signing por
+// useful when going through an SSH Tunnel which would cause a signature mismatch
+func (s *awsSdkV2Signer) OverrideSigningPort(signaturePort uint16) {
+	s.signaturePort = signaturePort
 }
 
 // SignRequest adds headers to the request
@@ -65,6 +74,11 @@ func (s *awsSdkV2Signer) SignRequest(r *http.Request) error {
 	creds, err := s.awsCfg.Credentials.Retrieve(ctx)
 	if err != nil {
 		return err
+	}
+
+	if s.signaturePort > 0 {
+		r.URL.Host = fmt.Sprintf("%s:%d", r.URL.Hostname(), s.signaturePort)
+		r.Host = r.URL.Host
 	}
 
 	if len(s.awsCfg.Region) == 0 {
@@ -78,7 +92,7 @@ func (s *awsSdkV2Signer) SignRequest(r *http.Request) error {
 		return err
 	}
 
-	return s.signer.SignHTTP(ctx, creds, r, hash, s.service, s.awsCfg.Region, t)
+	return s.signer.SignHTTP(ctx, creds, r, hash, s.service, s.awsCfg.Region, t, s.opts...)
 }
 
 func hexEncodedSha256OfRequest(r *http.Request) (string, error) {

--- a/signer/awsv2/sdkv2signer.go
+++ b/signer/awsv2/sdkv2signer.go
@@ -77,8 +77,7 @@ func (s *awsSdkV2Signer) SignRequest(r *http.Request) error {
 	}
 
 	if s.signaturePort > 0 {
-		r.URL.Host = fmt.Sprintf("%s:%d", r.URL.Hostname(), s.signaturePort)
-		r.Host = r.URL.Host
+		r.Host = fmt.Sprintf("%s:%d", r.URL.Hostname(), s.signaturePort)
 	}
 
 	if len(s.awsCfg.Region) == 0 {

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -14,4 +14,5 @@ import "net/http"
 // Signer an interface that will sign http.Request
 type Signer interface {
 	SignRequest(request *http.Request) error
+	OverrideSigningPort(portNumber uint16)
 }


### PR DESCRIPTION
### Description
Use a safe way to not directly manipulate host/port. Followed the same method the opensearch-py was using to override the signing port.

### Issues Resolved
Closes #370 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
