### PR TITLE
Add phase_took feature to Search API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Adds new fields for Opensearch 3.0 ([#702](https://github.com/opensearch-project/opensearch-go/pull/702))
 - Allow users to override signing port ([#721](https://github.com/opensearch-project/opensearch-go/pull/721))
+- Add `phase_took` features supported from OpenSearch 2.12 ([#722](https://github.com/opensearch-project/opensearch-go/pull/722))
 
 ### Changed
 - Test against Opensearch 3.0 ([#702](https://github.com/opensearch-project/opensearch-go/pull/702))

--- a/opensearchapi/api_search-params.go
+++ b/opensearchapi/api_search-params.go
@@ -79,6 +79,7 @@ type SearchParams struct {
 	TrackTotalHits             interface{}
 	TypedKeys                  *bool
 	Version                    *bool
+	PhaseTook                  bool
 
 	Pretty     bool
 	Human      bool
@@ -288,6 +289,10 @@ func (r SearchParams) get() map[string]string {
 
 	if len(r.FilterPath) > 0 {
 		params["filter_path"] = strings.Join(r.FilterPath, ",")
+	}
+
+	if r.PhaseTook {
+		params["phase_took"] = "true"
 	}
 
 	return params

--- a/opensearchapi/api_search-params_test.go
+++ b/opensearchapi/api_search-params_test.go
@@ -69,6 +69,7 @@ func TestSearchParams_get(t *testing.T) {
 		Human                      bool
 		ErrorTrace                 bool
 		FilterPath                 []string
+		PhaseTook                  bool
 	}
 	tests := []struct {
 		name   string
@@ -131,6 +132,7 @@ func TestSearchParams_get(t *testing.T) {
 				TrackTotalHits:             1000,
 				TypedKeys:                  ToPointer(true),
 				Version:                    ToPointer(true),
+				PhaseTook:                  true,
 			},
 			want: map[string]string{
 				"_source":                       "title,date",
@@ -178,6 +180,7 @@ func TestSearchParams_get(t *testing.T) {
 				"track_total_hits":              "1000",
 				"typed_keys":                    "true",
 				"version":                       "true",
+				"phase_took":                    "true",
 			},
 		},
 	}
@@ -229,6 +232,7 @@ func TestSearchParams_get(t *testing.T) {
 				TrackTotalHits:             tt.fields.TrackTotalHits,
 				TypedKeys:                  tt.fields.TypedKeys,
 				Version:                    tt.fields.Version,
+				PhaseTook:                  tt.fields.PhaseTook,
 				Pretty:                     tt.fields.Pretty,
 				Human:                      tt.fields.Human,
 				ErrorTrace:                 tt.fields.ErrorTrace,

--- a/opensearchapi/api_search.go
+++ b/opensearchapi/api_search.go
@@ -135,7 +135,7 @@ type SuggestOptions struct {
 
 // PhaseTook is the phase-level took time values in milliseconds
 type PhaseTook struct {
-	DFSPreQuery int `json:"dfs-pre-query"`
+	DFSPreQuery int `json:"dfs_pre_query"`
 	Query       int `json:"query"`
 	Fetch       int `json:"fetch"`
 	DFSQuery    int `json:"dfs_query"`

--- a/opensearchapi/api_search.go
+++ b/opensearchapi/api_search.go
@@ -64,6 +64,7 @@ func (r SearchReq) GetRequest() (*http.Request, error) {
 // SearchResp represents the returned struct of the /_search response
 type SearchResp struct {
 	Took         int                  `json:"took"`
+	PhaseTook    *PhaseTook           `json:"phase_took,omitempty"`
 	Timeout      bool                 `json:"timed_out"`
 	Shards       ResponseShards       `json:"_shards"`
 	Hits         SearchHits           `json:"hits"`
@@ -130,4 +131,14 @@ type SuggestOptions struct {
 	CollateMatch    bool                `json:"collate_match"`
 	Source          json.RawMessage     `json:"_source"`
 	Contexts        map[string][]string `json:"contexts,omitempty"`
+}
+
+// PhaseTook is the phase-level took time values in milliseconds
+type PhaseTook struct {
+	DFSPreQuery int `json:"dfs-pre-query"`
+	Query       int `json:"query"`
+	Fetch       int `json:"fetch"`
+	DFSQuery    int `json:"dfs_query"`
+	Expand      int `json:"expand"`
+	CanMatch    int `json:"can_match"`
 }

--- a/opensearchapi/api_search_test.go
+++ b/opensearchapi/api_search_test.go
@@ -206,7 +206,7 @@ func TestSearch(t *testing.T) {
 		assert.NotEmpty(t, resp.Suggest)
 	})
 
-		t.Run("request with completion suggest", func(t *testing.T) {
+	t.Run("request with completion suggest", func(t *testing.T) {
 		resp, err := client.Search(nil, &opensearchapi.SearchReq{Indices: []string{index}, Body: strings.NewReader(`{
 			"suggest": {
 			  "my-suggest": {
@@ -221,7 +221,7 @@ func TestSearch(t *testing.T) {
 		require.Nil(t, err)
 		assert.NotEmpty(t, resp.Suggest)
 		assert.NotEmpty(t, resp.Suggest["my-suggest"])
-		for _,suggestion := range resp.Suggest["my-suggest"] {
+		for _, suggestion := range resp.Suggest["my-suggest"] {
 			assert.Equal(t, suggestion.Text, "bar")
 			assert.NotEmpty(t, suggestion.Options)
 			assert.Equal(t, suggestion.Options[0].Text, "bar")
@@ -299,5 +299,30 @@ func TestSearch(t *testing.T) {
 		assert.NotEmpty(t, resp.Hits.Hits[0].InnerHits)
 		assert.NotNil(t, resp.Hits.Hits[0].InnerHits["baz"])
 		assert.NotEmpty(t, resp.Hits.Hits[0].InnerHits["baz"].Hits.Hits)
+	})
+
+	t.Run("request with phase took", func(t *testing.T) {
+		resp, err := client.Search(
+			nil,
+			&opensearchapi.SearchReq{
+				Indices: []string{index},
+				Body: strings.NewReader(`{
+				"query": {
+					"match": {
+						"foo": "bar"
+					}
+				},
+				"fields": [
+					"foo"
+				],
+			"_source": false
+			}`),
+				Params: opensearchapi.SearchParams{
+					PhaseTook: true,
+				},
+			},
+		)
+		require.Nil(t, err)
+		assert.NotNil(t, resp.PhaseTook)
 	})
 }

--- a/opensearchapi/api_search_test.go
+++ b/opensearchapi/api_search_test.go
@@ -302,6 +302,7 @@ func TestSearch(t *testing.T) {
 	})
 
 	t.Run("request with phase took", func(t *testing.T) {
+		ostest.SkipIfBelowVersion(t, client, 2, 12, "request with phase took")
 		resp, err := client.Search(
 			nil,
 			&opensearchapi.SearchReq{


### PR DESCRIPTION
### Description
The change is to add the `phase_took` feature in Search API start from OpenSearch 2.12

Example
```json
GET /my-index-000001/_search?phase_took
{
  "took" : 105,
  "phase_took" : {
    "dfs_pre_query" : 0,
    "query" : 69,
    "fetch" : 22,
    "dfs_query" : 0,
    "expand" : 4,
    "can_match" : 0
  },
  "timed_out" : false,
  "_shards" : {
    "total" : 5,
    "successful" : 5,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
    "value" : 0,
    "relation" : "eq"
  },
  "max_score" : null,
  "hits" : [ ]
}
```

Reference: 
* https://opensearch.org/blog/using-search-latency-monitoring/
* https://docs.opensearch.org/latest/api-reference/search-apis/search/

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
