### PR TITLE
Add missing Get field in UpdateResp struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Missing "caused by" information in StructError ([#752](https://github.com/opensearch-project/opensearch-go/pull/752))
 - Add missing `ignore_unavailable`, `allow_no_indices`, and `expand_wildcards` params to MSearch ([#757](https://github.com/opensearch-project/opensearch-go/pull/757))
+- Fix `UpdateResp` to correctly parse the `get` field when `_source` is requested in update operations. ([#739](https://github.com/opensearch-project/opensearch-go/pull/739))
 
 ### Security
 

--- a/opensearchapi/api_update.go
+++ b/opensearchapi/api_update.go
@@ -61,9 +61,10 @@ type UpdateResp struct {
 		Successful int `json:"successful"`
 		Failed     int `json:"failed"`
 	} `json:"_shards"`
-	SeqNo       int    `json:"_seq_no"`
-	PrimaryTerm int    `json:"_primary_term"`
-	Type        string `json:"_type"` // Deprecated field
+	SeqNo       int              `json:"_seq_no"`
+	PrimaryTerm int              `json:"_primary_term"`
+	Type        string           `json:"_type"` // Deprecated field
+	Get         *DocumentGetResp `json:"get,omitempty"`
 	response    *opensearch.Response
 }
 

--- a/opensearchapi/api_update_test.go
+++ b/opensearchapi/api_update_test.go
@@ -47,6 +47,7 @@ func TestUpdate(t *testing.T) {
 		resp, err := client.Update(
 			nil,
 			opensearchapi.UpdateReq{
+				Params:     opensearchapi.UpdateParams{Source: true},
 				Index:      testIndex,
 				DocumentID: "1",
 				Body:       strings.NewReader(`{"script":{"source":"ctx._source.counter += params.count","lang":"painless","params":{"count":4}}}`),


### PR DESCRIPTION
### Description
Add missing Get field to UpdateResp struct.

### Issues Resolved
Closes [\[BUG\] Missing Get field in UpdateResp struct #731](https://github.com/opensearch-project/opensearch-go/issues/731)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
