### PR TITLE
Fix node discovery logic to properly handle dedicated cluster managers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Enhanced cluster readiness checking for improved test reliability: `ostest.NewClient()` now includes readiness validation (health + cluster state + nodes info)
+- Configuration option `IncludeDedicatedClusterManagers` for controlling cluster manager node routing ([#765](https://github.com/opensearch-project/opensearch-go/issues/765))
 
 ### Changed
 - Refactor Client struct to use embedded mutex pattern for improved thread safety ([#775](https://github.com/opensearch-project/opensearch-go/pull/775))
 - Refactor metrics struct to use atomic counters for lock-free request/failure tracking ([#776](https://github.com/opensearch-project/opensearch-go/pull/776))
 - Test against Opensearch 2.19.4, 3.1, 3.3, and 3.4 ([#782](https://github.com/opensearch-project/opensearch-go/pull/782))
+- **BREAKING**: Enhanced node discovery to match OpenSearch server behavior ([#765](https://github.com/opensearch-project/opensearch-go/issues/765))
+  - Dedicated cluster manager nodes are now excluded from client request routing by default (best practice)
+  - Node selection logic now matches Java client `NodeSelector.SKIP_DEDICATED_CLUSTER_MASTERS` behavior
 
 ### Deprecated
 

--- a/opensearchtransport/opensearchtransport.go
+++ b/opensearchtransport/opensearchtransport.go
@@ -83,6 +83,13 @@ type Config struct {
 
 	DiscoverNodesInterval time.Duration
 
+	// IncludeDedicatedClusterManagers includes dedicated cluster manager nodes in request routing.
+	// When false (default), dedicated cluster manager nodes are excluded from client requests,
+	// following best practices and matching the Java client's NodeSelector.SKIP_DEDICATED_CLUSTER_MASTERS behavior.
+	// When true, all nodes including dedicated cluster managers can receive client requests.
+	// Default: false (excludes dedicated cluster managers for better performance)
+	IncludeDedicatedClusterManagers bool
+
 	Transport http.RoundTripper
 	Logger    Logger
 	Selector  Selector
@@ -106,6 +113,8 @@ type Client struct {
 	maxRetries            int
 	retryBackoff          func(attempt int) time.Duration
 	discoverNodesInterval time.Duration
+
+	includeDedicatedClusterManagers bool
 
 	compressRequestBody  bool
 	pooledGzipCompressor *gzipCompressor
@@ -175,6 +184,8 @@ func New(cfg Config) (*Client, error) {
 		maxRetries:            cfg.MaxRetries,
 		retryBackoff:          cfg.RetryBackoff,
 		discoverNodesInterval: cfg.DiscoverNodesInterval,
+
+		includeDedicatedClusterManagers: cfg.IncludeDedicatedClusterManagers,
 
 		compressRequestBody: cfg.CompressRequestBody,
 


### PR DESCRIPTION
## Fix node discovery logic to properly handle dedicated cluster managers

### Summary

Fixes dedicated cluster manager detection by implementing proper role validation and upstream-compatible node filtering logic. Addresses the core issue where nodes with only cluster management roles were
incorrectly being included in the connection pool for client requests.

### Key Features

- Proper role constants matching OpenSearch server definitions
- `isDedicatedClusterManager()` logic matching Java client `NodeSelector.SKIP_DEDICATED_CLUSTER_MASTERS`
- Comprehensive role validation with master role deprecation warnings
- Warm+search role conflict detection for OpenSearch 3.0+ compatibility
- Remote cluster client role support for cross-cluster operations
- `IncludeDedicatedClusterManagers` configuration option for backward compatibility

### Breaking Change

**BEHAVIOR CHANGE**: Dedicated cluster manager nodes are now excluded from client request routing by default to match upstream Java client behavior and follow best practices.

- **Before**: All discovered nodes (including dedicated cluster managers) received client requests
- **After**: Only nodes with "work" roles (data, ingest, warm, search) receive client requests by default
- **Migration**: Set `IncludeDedicatedClusterManagers: true` in transport config to preserve legacy behavior

Fixes #765