### PR TITLE
Add GetConfig for opensearch.client and NewFromClient for opensearchapi.client

### DIFF
--- a/_samples/client_config_retrieval.go
+++ b/_samples/client_config_retrieval.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/opensearch-project/opensearch-go/v4"
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
+)
+
+func main() {
+	if err := example(); err != nil {
+		fmt.Println(fmt.Sprintf("Error: %s", err))
+		os.Exit(1)
+	}
+}
+
+func example() error {
+	// Create a base opensearch.Client
+	osClient, err := opensearch.NewClient(opensearch.Config{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // For testing only. Use certificate for validation.
+		},
+		Addresses: []string{"https://localhost:9200"},
+		Username:  "admin", // For testing only. Don't store credentials in code.
+		Password:  "myStrongPassword123!",
+	})
+	if err != nil {
+		return err
+	}
+
+	// Retrieve the configuration that was used to create the client
+	// This is useful for:
+	// - Inspecting the client's configuration
+	// - Creating a new client with the same or modified configuration
+	// - Logging/debugging configuration details
+	config := osClient.GetConfig()
+
+	fmt.Printf("Original client configuration:\n")
+	fmt.Printf("  Addresses: %v\n", config.Addresses)
+	fmt.Printf("  Username: %s\n", config.Username)
+	fmt.Printf("  DisableRetry: %v\n", config.DisableRetry)
+	fmt.Printf("  MaxRetries: %d\n", config.MaxRetries)
+
+	// Create a new opensearchapi.Client using the retrieved configuration
+	// This creates a completely new client with independent transport/connection pool
+	apiClient, err := opensearchapi.NewClient(opensearchapi.Config{
+		Client: *config,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("\nSuccessfully created opensearchapi.Client using retrieved configuration")
+
+	// You can use the apiClient for high-level operations
+	_ = apiClient
+
+	return nil
+}

--- a/_samples/client_from_existing.go
+++ b/_samples/client_from_existing.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/opensearch-project/opensearch-go/v4"
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
+)
+
+func main() {
+	if err := example(); err != nil {
+		fmt.Println(fmt.Sprintf("Error: %s", err))
+		os.Exit(1)
+	}
+}
+
+func example() error {
+	// Create a base opensearch.Client with custom configuration
+	osClient, err := opensearch.NewClient(opensearch.Config{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // For testing only. Use certificate for validation.
+		},
+		Addresses: []string{"https://localhost:9200"},
+		Username:  "admin", // For testing only. Don't store credentials in code.
+		Password:  "myStrongPassword123!",
+	})
+	if err != nil {
+		return err
+	}
+
+	// Create an opensearchapi.Client directly from the existing opensearch.Client
+	// This is useful when you want to:
+	// - Share the same underlying connection pool between clients
+	// - Wrap an existing client without recreating the transport
+	// - Maintain a single configured client instance
+	apiClient := opensearchapi.NewFromClient(osClient)
+
+	fmt.Println("Successfully created opensearchapi.Client from opensearch.Client")
+	fmt.Printf("Both clients share the same transport and configuration\n")
+
+	// You can use the apiClient for high-level operations
+	_ = apiClient
+
+	return nil
+}

--- a/error.go
+++ b/error.go
@@ -7,6 +7,7 @@
 package opensearch
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -148,6 +149,8 @@ func ParseError(resp *Response) error {
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrReadBody, err)
 	}
+
+	resp.Body = io.NopCloser(bytes.NewReader(body))
 
 	var testResp struct {
 		Status  any `json:"status"`

--- a/error_test.go
+++ b/error_test.go
@@ -301,4 +301,31 @@ func TestError(t *testing.T) {
 			assert.True(t, errors.Is(err, opensearch.ErrJSONUnmarshalBody))
 		})
 	})
+
+	t.Run("ParseError preserves response body", func(t *testing.T) {
+		expectedBody := `{
+			"error":{
+				"type":"resource_already_exists_exception",
+				"reason":"index [test/HU2mN_RMRXGcS38j3yV-VQ] already exists"
+			},
+			"status":400
+		}`
+
+		resp := &opensearch.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       io.NopCloser(strings.NewReader(expectedBody)),
+		}
+
+		// Parse the error
+		err := opensearch.ParseError(resp)
+		require.NotNil(t, err)
+
+		// Verify the body is still readable after ParseError
+		body, readErr := io.ReadAll(resp.Body)
+		require.Nil(t, readErr, "body should be readable after ParseError")
+		require.NotEmpty(t, body, "body should not be empty after ParseError")
+
+		// Verify the body content matches the original
+		require.JSONEq(t, expectedBody, string(body), "body content should match original")
+	})
 }

--- a/opensearch.go
+++ b/opensearch.go
@@ -107,6 +107,7 @@ type Config struct {
 // Client represents the OpenSearch client.
 type Client struct {
 	Transport opensearchtransport.Interface
+	config    *Config
 }
 
 // NewDefaultClient creates a new client with default options.
@@ -189,7 +190,10 @@ func NewClient(cfg Config) (*Client, error) {
 		return nil, fmt.Errorf("%w: %w", ErrCreateTransport, err)
 	}
 
-	client := &Client{Transport: tp}
+	client := &Client{
+		Transport: tp,
+		config:    &cfg,
+	}
 
 	if cfg.DiscoverNodesOnStart {
 		//nolint:errcheck // goroutine discards return values
@@ -291,6 +295,11 @@ func (c *Client) DiscoverNodes() error {
 	}
 
 	return ErrTransportMissingMethodDiscoverNodes
+}
+
+// GetConfig returns the client configuration.
+func (c *Client) GetConfig() *Config {
+	return c.config
 }
 
 // addrsFromEnvironment returns a list of addresses by splitting

--- a/opensearch_integration_test.go
+++ b/opensearch_integration_test.go
@@ -297,3 +297,151 @@ func TestClientAPI(t *testing.T) {
 		}
 	})
 }
+
+func TestClientGetConfigIntegration(t *testing.T) {
+	t.Run("GetConfig returns valid configuration", func(t *testing.T) {
+		// Get test config
+		cfg, err := ostest.ClientConfig()
+		require.Nil(t, err)
+
+		// Create a client with specific configuration
+		osClient, err := opensearch.NewClient(cfg.Client)
+		require.Nil(t, err)
+
+		// Retrieve the config
+		retrievedConfig := osClient.GetConfig()
+
+		// Verify the config matches what was originally provided
+		require.Equal(t, cfg.Client.Addresses, retrievedConfig.Addresses)
+		require.Equal(t, cfg.Client.Username, retrievedConfig.Username)
+		require.Equal(t, cfg.Client.Password, retrievedConfig.Password)
+	})
+
+	t.Run("GetConfig with live client", func(t *testing.T) {
+		// Create a client from test helper
+		apiClient, err := ostest.NewClient(t)
+		require.Nil(t, err)
+
+		// Get config from the underlying opensearch client
+		config := apiClient.Client.GetConfig()
+
+		// Verify config has expected values
+		require.NotEmpty(t, config.Addresses, "addresses should not be empty")
+
+		// Verify we can create a new client with the retrieved config
+		newClient, err := opensearch.NewClient(config)
+		require.Nil(t, err)
+		require.NotNil(t, newClient)
+
+		// Verify the new client works by making a request
+		req, err := opensearch.BuildRequest("GET", "/", nil, nil, nil)
+		require.Nil(t, err)
+
+		resp, err := newClient.Perform(req)
+		require.Nil(t, err)
+		require.NotNil(t, resp)
+		defer resp.Body.Close()
+	})
+}
+
+func TestNewFromClientIntegration(t *testing.T) {
+	t.Run("creates working api client from opensearch client", func(t *testing.T) {
+		// Get test config
+		cfg, err := ostest.ClientConfig()
+		require.Nil(t, err)
+
+		// Create a base opensearch.Client
+		osClient, err := opensearch.NewClient(cfg.Client)
+		require.Nil(t, err)
+		require.NotNil(t, osClient)
+
+		// Create an opensearchapi.Client from the opensearch.Client
+		apiClient := opensearchapi.NewFromClient(osClient)
+		require.NotNil(t, apiClient)
+
+		// Verify the api client can make requests
+		resp, err := apiClient.Info(nil, nil)
+		require.Nil(t, err)
+		require.NotEmpty(t, resp)
+		require.NotEmpty(t, resp.ClusterName)
+	})
+
+	t.Run("shares transport with original client", func(t *testing.T) {
+		// Get test config
+		cfg, err := ostest.ClientConfig()
+		require.Nil(t, err)
+
+		// Create a base opensearch.Client
+		osClient, err := opensearch.NewClient(cfg.Client)
+		require.Nil(t, err)
+
+		// Create an opensearchapi.Client from the opensearch.Client
+		apiClient := opensearchapi.NewFromClient(osClient)
+
+		// Verify both clients share the same transport
+		require.Equal(t, osClient.Transport, apiClient.Client.Transport)
+
+		// Verify both clients can make requests successfully
+		req, err := opensearch.BuildRequest("GET", "/", nil, nil, nil)
+		require.Nil(t, err)
+
+		resp1, err := osClient.Perform(req)
+		require.Nil(t, err)
+		require.NotNil(t, resp1)
+		defer resp1.Body.Close()
+
+		resp2, err := apiClient.Info(nil, nil)
+		require.Nil(t, err)
+		require.NotNil(t, resp2)
+	})
+
+	t.Run("maintains config through wrapped client", func(t *testing.T) {
+		// Get test config
+		cfg, err := ostest.ClientConfig()
+		require.Nil(t, err)
+
+		// Create a base opensearch.Client with specific config
+		osClient, err := opensearch.NewClient(cfg.Client)
+		require.Nil(t, err)
+
+		// Create an opensearchapi.Client from the opensearch.Client
+		apiClient := opensearchapi.NewFromClient(osClient)
+
+		// Retrieve config through the api client's wrapped opensearch client
+		retrievedConfig := apiClient.Client.GetConfig()
+
+		// Verify the config matches the original
+		require.Equal(t, cfg.Client.Addresses, retrievedConfig.Addresses)
+		require.Equal(t, cfg.Client.Username, retrievedConfig.Username)
+		require.Equal(t, cfg.Client.Password, retrievedConfig.Password)
+	})
+
+	t.Run("all sub-clients are functional", func(t *testing.T) {
+		// Get test config
+		cfg, err := ostest.ClientConfig()
+		require.Nil(t, err)
+
+		// Create a base opensearch.Client
+		osClient, err := opensearch.NewClient(cfg.Client)
+		require.Nil(t, err)
+
+		// Create an opensearchapi.Client from the opensearch.Client
+		apiClient := opensearchapi.NewFromClient(osClient)
+
+		// Test a few sub-clients to ensure they're properly initialized
+		// Cat client
+		catResp, err := apiClient.Cat.Health(nil, nil)
+		require.Nil(t, err)
+		require.NotNil(t, catResp)
+
+		// Cluster client
+		clusterResp, err := apiClient.Cluster.Health(nil, nil)
+		require.Nil(t, err)
+		require.NotNil(t, clusterResp)
+
+		// Nodes client
+		nodesResp, err := apiClient.Nodes.Info(nil, nil)
+		require.Nil(t, err)
+		require.NotNil(t, nodesResp)
+	})
+}

--- a/opensearch_integration_test.go
+++ b/opensearch_integration_test.go
@@ -329,7 +329,7 @@ func TestClientGetConfigIntegration(t *testing.T) {
 		require.NotEmpty(t, config.Addresses, "addresses should not be empty")
 
 		// Verify we can create a new client with the retrieved config
-		newClient, err := opensearch.NewClient(config)
+		newClient, err := opensearch.NewClient(*config)
 		require.Nil(t, err)
 		require.NotNil(t, newClient)
 

--- a/opensearch_internal_test.go
+++ b/opensearch_internal_test.go
@@ -421,3 +421,55 @@ func TestToPointer(t *testing.T) {
 	assert.NotNil(t, testPointer)
 	assert.True(t, *testPointer)
 }
+
+func TestClientGetConfig(t *testing.T) {
+	t.Run("returns config", func(t *testing.T) {
+		expectedAddresses := []string{"http://localhost:9200"}
+		expectedUsername := "admin"
+		expectedMaxRetries := 5
+
+		osClient, err := NewClient(Config{
+			Addresses:  expectedAddresses,
+			Username:   expectedUsername,
+			MaxRetries: expectedMaxRetries,
+			Transport:  &mockTransp{},
+		})
+		require.NoError(t, err)
+
+		config := osClient.GetConfig()
+
+		assert.Equal(t, expectedAddresses, config.Addresses)
+		assert.Equal(t, expectedUsername, config.Username)
+		assert.Equal(t, expectedMaxRetries, config.MaxRetries)
+	})
+
+	t.Run("preserves all config fields", func(t *testing.T) {
+		expectedConfig := Config{
+			Addresses:            []string{"http://localhost:9200", "http://localhost:9201"},
+			Username:             "testuser",
+			Password:             "testpass",
+			DisableRetry:         true,
+			MaxRetries:           10,
+			EnableMetrics:        true,
+			EnableDebugLogger:    true,
+			CompressRequestBody:  true,
+			EnableRetryOnTimeout: true,
+			Transport:            &mockTransp{},
+		}
+
+		osClient, err := NewClient(expectedConfig)
+		require.NoError(t, err)
+
+		config := osClient.GetConfig()
+
+		assert.Equal(t, expectedConfig.Addresses, config.Addresses)
+		assert.Equal(t, expectedConfig.Username, config.Username)
+		assert.Equal(t, expectedConfig.Password, config.Password)
+		assert.Equal(t, expectedConfig.DisableRetry, config.DisableRetry)
+		assert.Equal(t, expectedConfig.MaxRetries, config.MaxRetries)
+		assert.Equal(t, expectedConfig.EnableMetrics, config.EnableMetrics)
+		assert.Equal(t, expectedConfig.EnableDebugLogger, config.EnableDebugLogger)
+		assert.Equal(t, expectedConfig.CompressRequestBody, config.CompressRequestBody)
+		assert.Equal(t, expectedConfig.EnableRetryOnTimeout, config.EnableRetryOnTimeout)
+	})
+}

--- a/opensearchapi/opensearchapi.go
+++ b/opensearchapi/opensearchapi.go
@@ -97,6 +97,11 @@ func NewDefaultClient() (*Client, error) {
 	return clientInit(rootClient), nil
 }
 
+// NewFromClient creates an opensearchapi client from an existing opensearch.Client
+func NewFromClient(client *opensearch.Client) *Client {
+	return clientInit(client)
+}
+
 // do calls the opensearch.Client.Do() and checks the response for openseach api errors
 func (c *Client) do(ctx context.Context, req opensearch.Request, dataPointer any) (*opensearch.Response, error) {
 	resp, err := c.Client.Do(ctx, req, dataPointer)

--- a/opensearchapi/opensearchapi_test.go
+++ b/opensearchapi/opensearchapi_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+//go:build !integration
+
+package opensearchapi_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opensearch-project/opensearch-go/v4"
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
+)
+
+type mockTransport struct{}
+
+func (t *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{},
+	}, nil
+}
+
+func TestNewFromClient(t *testing.T) {
+	t.Run("creates api client from opensearch client", func(t *testing.T) {
+		// Create a base opensearch.Client
+		osClient, err := opensearch.NewClient(opensearch.Config{
+			Addresses: []string{"http://localhost:9200"},
+			Username:  "admin",
+			Password:  "password",
+			Transport: &mockTransport{},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, osClient)
+
+		// Create an opensearchapi.Client from the opensearch.Client
+		apiClient := opensearchapi.NewFromClient(osClient)
+
+		// Verify the api client was created successfully
+		require.NotNil(t, apiClient)
+		assert.NotNil(t, apiClient.Client)
+
+		// Verify the underlying client is the same
+		assert.Equal(t, osClient, apiClient.Client)
+
+		// Verify all sub-clients are initialized
+		assert.NotNil(t, apiClient.Cat)
+		assert.NotNil(t, apiClient.Cluster)
+		assert.NotNil(t, apiClient.Dangling)
+		assert.NotNil(t, apiClient.Document)
+		assert.NotNil(t, apiClient.Indices)
+		assert.NotNil(t, apiClient.Nodes)
+		assert.NotNil(t, apiClient.Script)
+		assert.NotNil(t, apiClient.ComponentTemplate)
+		assert.NotNil(t, apiClient.IndexTemplate)
+		assert.NotNil(t, apiClient.Template)
+		assert.NotNil(t, apiClient.DataStream)
+		assert.NotNil(t, apiClient.PointInTime)
+		assert.NotNil(t, apiClient.Ingest)
+		assert.NotNil(t, apiClient.Tasks)
+		assert.NotNil(t, apiClient.Scroll)
+		assert.NotNil(t, apiClient.Snapshot)
+	})
+
+	t.Run("shares transport with original client", func(t *testing.T) {
+		// Create a base opensearch.Client
+		osClient, err := opensearch.NewClient(opensearch.Config{
+			Addresses: []string{"http://localhost:9200"},
+			Transport: &mockTransport{},
+		})
+		require.NoError(t, err)
+
+		// Create an opensearchapi.Client from the opensearch.Client
+		apiClient := opensearchapi.NewFromClient(osClient)
+
+		// Verify both clients share the same transport
+		assert.Equal(t, osClient.Transport, apiClient.Client.Transport)
+	})
+
+	t.Run("can access config from wrapped client", func(t *testing.T) {
+		// Create a base opensearch.Client with specific config
+		expectedAddresses := []string{"http://localhost:9200", "http://localhost:9201"}
+		expectedUsername := "testuser"
+		expectedPassword := "testpass"
+
+		osClient, err := opensearch.NewClient(opensearch.Config{
+			Addresses: expectedAddresses,
+			Username:  expectedUsername,
+			Password:  expectedPassword,
+			Transport: &mockTransport{},
+		})
+		require.NoError(t, err)
+
+		// Create an opensearchapi.Client from the opensearch.Client
+		apiClient := opensearchapi.NewFromClient(osClient)
+
+		// Retrieve the config through the api client's wrapped opensearch client
+		config := apiClient.Client.GetConfig()
+
+		// Verify the config matches what was originally provided
+		assert.Equal(t, expectedAddresses, config.Addresses)
+		assert.Equal(t, expectedUsername, config.Username)
+		assert.Equal(t, expectedPassword, config.Password)
+	})
+}


### PR DESCRIPTION
# Problem
Inability to wrap existing opensearch.Client

Service code often receives or creates an opensearch.Client centrally (via shared factory, dependency injection, etc.) and needs to use the typed opensearchapi request/response structs for ergonomics and type safety.

However, opensearchapi.NewClient() only accepts a Config, forcing recreation of the entire client:
  - Creates new transport layer
  - Establishes new connection pool
  - Duplicates configuration

The internal clientInit() function already wraps an existing opensearch.Client, but it wasn't exported for external use.

## No way to retrieve client configuration
Once an opensearch.Client is created, there's no way to retrieve its configuration for inspection, logging, or creating derivative clients.

## ParseError consumes response body
ParseError() reads the response body to parse errors but doesn't restore it, making the body unavailable for subsequent reads (logging, debugging, custom error handling).

### Issues Resolved
#792 #793 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
