### PR TITLE
fix: prevent double slashes in AliasGetReq path when Indices is empty

### DIFF
--- a/opensearchapi/api_indices-alias.go
+++ b/opensearchapi/api_indices-alias.go
@@ -119,9 +119,13 @@ func (r AliasGetReq) GetRequest() (*http.Request, error) {
 
 	var path strings.Builder
 	path.Grow(9 + len(indices) + len(aliases))
-	path.WriteString("/")
-	path.WriteString(indices)
-	path.WriteString("/_alias/")
+	if indices != "" {
+		path.WriteString("/")
+		path.WriteString(indices)
+		path.WriteString("/_alias/")
+	} else {
+		path.WriteString("/_alias/")
+	}
 	path.WriteString(aliases)
 	return opensearch.BuildRequest(
 		"GET",


### PR DESCRIPTION
## Problem
When calling `AliasGetReq` without specifying `Indices` (or providing an empty `Indices` array/slice), the resulting API path incorrectly contains a double slash.
For example, it might produce `//_alias/test-alias` instead of `/_alias/test-alias`. This double slash causes issues for proxies or when interacting with some clusters, such as Aiven where this causes failures (see #617).

## Solution
I modified the `GetRequest` function in `opensearchapi/api_indices-alias.go` to conditionally append the initial `/` and `indices` string only if `indices` is not empty. If `indices` is empty, it appends only `/_alias/` and the aliases name(s), ensuring the URL path is valid (e.g. `/_alias/test-alias`).

## Testing
- Verified via `make test` that all existing tests pass correctly.

Closes #617