### PR TITLE
Add polymorphic Status field to task response structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add `DocumentError` type for structured per-item error information in multi-document responses
 - Add `BulkByScrollFailure` type for structured failure information in `_delete_by_query`, `_update_by_query`, and `_reindex` responses
 - Add `Routing` and `Fields` to `MGetResp.Docs` to match the full OpenSearch `_mget` response format
+- Add `ForcedRefresh` field to `IndexResp`, `DocumentDeleteResp`, and `UpdateResp` for consistency with `DocumentCreateResp`
+- Add `Status` and `Primary` fields to `ResponseShardsFailure` for shard failure diagnostics
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,10 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   - `cluster.homogeneous` removes all overrides to reset to default configuration
   - `cluster.status` now shows per-node roles and allocated processors via `_nodes/http,os`
 - Add request routing guide (`guides/routing.md`) consolidating routing architecture, connection scoring, pool lifecycle, cost model, and configuration reference ([#786](https://github.com/opensearch-project/opensearch-go/pull/786))
+- Add per-item `Error` field to `MGetResp`, `MTermvectorsResp`, and `MSearchResp` for detecting partial failures in multi-document operations ([#797](https://github.com/opensearch-project/opensearch-go/issues/797))
+- Add `DocumentError` type for structured per-item error information in multi-document responses
+- Add `BulkByScrollFailure` type for structured failure information in `_delete_by_query`, `_update_by_query`, and `_reindex` responses
+- Add `Routing` and `Fields` to `MGetResp.Docs` to match the full OpenSearch `_mget` response format
 
 ### Changed
 
@@ -141,6 +145,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   - Constructor now takes `aws.Config` instead of `session.Options`
   - See USER_GUIDE.md for details required to migrate
   - Users who need access to the existing `signer/awsv2` API can still use it, however they are encouraged to migrate to `signer/aws`
+- **BREAKING**: Replace `[]json.RawMessage` with typed `[]BulkByScrollFailure` for `Failures` field in `DocumentDeleteByQueryResp`, `UpdateByQueryResp`, and `ReindexResp` ([#797](https://github.com/opensearch-project/opensearch-go/issues/797)). This is a compile-time change only — callers that were not accessing `.Failures` are unaffected, and callers that were manually unmarshaling `json.RawMessage` can now access typed fields directly.
+- Replace inline `_shards` struct with `ResponseShards` in `IndexResp`, `DocumentCreateResp`, `DocumentDeleteResp`, `UpdateResp`, `IndicesRefreshResp`, and `IndicesCountResp` to expose shard `Failures` and `Skipped` fields ([#797](https://github.com/opensearch-project/opensearch-go/issues/797)). Code accessing `resp.Shards.Total`, `resp.Shards.Successful`, or `resp.Shards.Failed` compiles unchanged.
+- Add `omitempty` to all deprecated `_type` JSON tags so empty values are omitted during marshaling
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add per-attempt `RequestTimeout` to bound individual HTTP round-trips, preventing indefinite hangs on stalled connections ([#786](https://github.com/opensearch-project/opensearch-go/issues/786))
 - Add `opensearchutil/shardhash` package with exported `Hash` and `ForRouting` functions for computing OpenSearch shard routing
 - Enhanced cluster readiness checking for improved test reliability: `testutil.NewClient()` now includes readiness validation (health + cluster state + nodes info)
+- Add `Status` field (`json.RawMessage`) to `TasksGetResp`, `TasksListTask`, and `TaskCancelInfo` for polymorphic task status data; add typed status structs matching the OpenSearch API specification: `BulkByScrollTaskStatus`, `ReplicationTaskStatus`, `ResyncTaskStatus`, `PersistentTaskStatus`; add `Parse*` helpers and `BulkByScrollTaskStatusOrException` for sliced task status ([#788](https://github.com/opensearch-project/opensearch-go/issues/788))
 - Test parallelization support via TEST_PARALLEL environment variable (default: CPU cores - 1, minimum 1)
 - opensearchapi/testutil package with test suite, client helpers, and JSON comparison utilities
 - opensearchtransport/testutil package with PollUntil helper for eventual consistency testing (ISM policies, index readiness, cluster state changes)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -5,6 +5,12 @@
     - [Import path](#import-path)
     - [Error types](#error-types)
     - [AWS signer](#aws-signer)
+    - [Typed failure arrays in by-query and reindex responses](#typed-failure-arrays-in-by-query-and-reindex-responses)
+    - [Inline _shards structs replaced with ResponseShards](#inline-_shards-structs-replaced-with-responseshards)
+    - [_type field tags now include omitempty](#_type-field-tags-now-include-omitempty)
+    - [Import path](#import-path)
+    - [Error types](#error-types)
+    - [AWS signer](#aws-signer)
   - [Upgrading to >= 3.0.0](#upgrading-to->=-3.0.0)
     - [Client creation](#client-creation)
     - [Requests](#requests)
@@ -153,6 +159,41 @@ awsSigner, err := signer.NewSigner(cfg)
 ```
 
 The `signer/awsv2` package (which already used AWS SDK v2) remains available at `github.com/opensearch-project/opensearch-go/v4/signer/awsv2` with the same API.
+
+### Typed Failure Arrays in By-Query and Reindex Responses
+
+The `Failures` field in `DocumentDeleteByQueryResp`, `UpdateByQueryResp`, and `ReindexResp` changed from `[]json.RawMessage` to `[]BulkByScrollFailure`.
+
+**Who is affected:** Only callers that directly access the `.Failures` slice. Code that ignores failures or only checks `len(resp.Failures) > 0` compiles without changes.
+
+Before:
+
+```go
+for _, raw := range resp.Failures {
+    var f MyFailureType
+    if err := json.Unmarshal(raw, &f); err != nil { ... }
+    // use f.Index, f.Status, etc.
+}
+```
+
+After:
+
+```go
+for _, f := range resp.Failures {
+    // Fields are available directly — no unmarshaling needed.
+    fmt.Println(f.Index, f.Status, f.Cause)
+}
+```
+
+### Inline _shards Structs Replaced with ResponseShards
+
+The `Shards` field in `IndexResp`, `DocumentCreateResp`, `DocumentDeleteResp`, `UpdateResp`, `IndicesRefreshResp`, and `IndicesCountResp` changed from an anonymous inline struct to the named `ResponseShards` type.
+
+**Who is affected:** Code accessing `resp.Shards.Total`, `resp.Shards.Successful`, or `resp.Shards.Failed` compiles unchanged. The only theoretical break is code using reflection or type assertions on the `Shards` field itself. The new type additionally exposes `Failures []ResponseShardsFailure` and `Skipped int` which were previously unavailable.
+
+### `_type` Field Tags Now Include `omitempty`
+
+All deprecated `_type` fields across response structs now use `json:"_type,omitempty"`. Mapping types were deprecated in Elasticsearch 6.0 (2017), reduced to the single `_doc` type in Elasticsearch 7.0 (2019), and completely removed from the OpenSearch server in 2.0.0 (May 2022). OpenSearch forked from Elasticsearch 7.10.2, so the deprecation was inherited from day one. This change means the empty string is no longer emitted when marshaling response structs back to JSON. Deserialization behavior is unchanged.
 
 ## Upgrading to >= 3.0.0
 

--- a/_samples/tasks.go
+++ b/_samples/tasks.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/opensearch-project/opensearch-go/v4"
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
+)
+
+func main() {
+	if err := example(); err != nil {
+		fmt.Println(fmt.Sprintf("Error: %s", err))
+		os.Exit(1)
+	}
+}
+
+func example() error {
+	// Initialize the client with SSL/TLS enabled.
+	client, err := opensearchapi.NewClient(
+		opensearchapi.Config{
+			Client: opensearch.Config{
+				InsecureSkipVerify: true, // For testing only. Use certificate for validation.
+				Addresses:          []string{"https://localhost:9200"},
+				Username:           "admin", // For testing only. Don't store credentials in code.
+				Password:           "myStrongPassword123!",
+			},
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	sourceIndex := "task-source"
+	destIndex := "task-dest"
+
+	// Create source index with test data.
+	_, err = client.Indices.Create(ctx, opensearchapi.IndicesCreateReq{
+		Index: sourceIndex,
+		Body:  strings.NewReader(`{"settings": {"number_of_shards": 1, "number_of_replicas": 0}}`),
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Index(ctx, opensearchapi.IndexReq{
+		Index: sourceIndex,
+		Body:  strings.NewReader(`{"title": "Test Document", "year": 2024}`),
+		Params: opensearchapi.IndexParams{
+			Refresh: "true",
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	// Submit an async reindex task.
+	reindexResp, err := client.Reindex(ctx, opensearchapi.ReindexReq{
+		Body: strings.NewReader(fmt.Sprintf(
+			`{"source":{"index":"%s"},"dest":{"index":"%s"}}`,
+			sourceIndex, destIndex,
+		)),
+		Params: opensearchapi.ReindexParams{
+			WaitForCompletion: opensearchapi.ToPointer(false),
+		},
+	})
+	if err != nil {
+		return err
+	}
+	taskID := reindexResp.Task
+	fmt.Printf("Task submitted: %s\n", taskID)
+
+	// Poll for completion.
+	var taskResp *opensearchapi.TasksGetResp
+	for {
+		taskResp, err = client.Tasks.Get(ctx, opensearchapi.TasksGetReq{TaskID: taskID})
+		if err != nil {
+			return err
+		}
+		if taskResp.Completed {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	fmt.Printf("Task completed: action=%s\n", taskResp.Task.Action)
+
+	// Parse the BulkByScroll status.
+	status, err := opensearchapi.ParseBulkByScrollTaskStatus(taskResp.Task.Status)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Total: %d\n", status.Total)
+	fmt.Printf("Created: %d\n", status.Created)
+	fmt.Printf("Updated: %d\n", status.Updated)
+	fmt.Printf("Deleted: %d\n", status.Deleted)
+	fmt.Printf("Batches: %d\n", status.Batches)
+	fmt.Printf("Version conflicts: %d\n", status.VersionConflicts)
+	fmt.Printf("Noops: %d\n", status.Noops)
+	fmt.Printf("Retries (bulk): %d\n", status.Retries.Bulk)
+	fmt.Printf("Retries (search): %d\n", status.Retries.Search)
+
+	// For tasks without a dedicated type, unmarshal as generic JSON.
+	if taskResp.Task.Status != nil {
+		var raw map[string]any
+		if err := json.Unmarshal(taskResp.Task.Status, &raw); err != nil {
+			return err
+		}
+		fmt.Printf("Raw status: %v\n", raw)
+	}
+
+	// List all running tasks.
+	listResp, err := client.Tasks.List(ctx, nil)
+	if err != nil {
+		return err
+	}
+	for nodeID, node := range listResp.Nodes {
+		fmt.Printf("Node %s (%s): %d tasks\n", node.Name, nodeID, len(node.Tasks))
+	}
+
+	// Cleanup.
+	delResp, err := client.Indices.Delete(ctx, opensearchapi.IndicesDeleteReq{
+		Indices: []string{sourceIndex, destIndex},
+		Params:  opensearchapi.IndicesDeleteParams{IgnoreUnavailable: opensearchapi.ToPointer(true)},
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Deleted: %t\n", delResp.Acknowledged)
+
+	return nil
+}

--- a/_samples/tasks.go
+++ b/_samples/tasks.go
@@ -10,7 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/opensearch-project/opensearch-go/v4"
@@ -19,7 +21,7 @@ import (
 
 func main() {
 	if err := example(); err != nil {
-		fmt.Println(fmt.Sprintf("Error: %s", err))
+		fmt.Printf("Error: %s\n", err)
 		os.Exit(1)
 	}
 }
@@ -40,7 +42,10 @@ func example() error {
 		return err
 	}
 
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
 
 	sourceIndex := "task-source"
 	destIndex := "task-dest"
@@ -82,6 +87,9 @@ func example() error {
 	fmt.Printf("Task submitted: %s\n", taskID)
 
 	// Poll for completion.
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
 	var taskResp *opensearchapi.TasksGetResp
 	for {
 		taskResp, err = client.Tasks.Get(ctx, opensearchapi.TasksGetReq{TaskID: taskID})
@@ -91,7 +99,11 @@ func example() error {
 		if taskResp.Completed {
 			break
 		}
-		time.Sleep(500 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
 	}
 	fmt.Printf("Task completed: action=%s\n", taskResp.Task.Action)
 

--- a/_samples/tasks.go
+++ b/_samples/tasks.go
@@ -108,7 +108,7 @@ func example() error {
 	fmt.Printf("Task completed: action=%s\n", taskResp.Task.Action)
 
 	// Parse the BulkByScroll status.
-	status, err := opensearchapi.ParseBulkByScrollTaskStatus(taskResp.Task.Status)
+	status, err := opensearchapi.ParseTaskStatus[opensearchapi.BulkByScrollTaskStatus](taskResp.Task.Status)
 	if err != nil {
 		return err
 	}

--- a/guides/tasks.md
+++ b/guides/tasks.md
@@ -104,10 +104,10 @@ The `Status` field on a task is a `json.RawMessage` because its shape depends on
 
 ### BulkByScroll Tasks (reindex, delete_by_query, update_by_query)
 
-For reindex, delete_by_query, and update_by_query tasks, use `ParseBulkByScrollTaskStatus` to unmarshal the status into a typed struct:
+For reindex, delete_by_query, and update_by_query tasks, use `ParseTaskStatus` to unmarshal the status into a typed struct:
 
 ```go
-	status, err := opensearchapi.ParseBulkByScrollTaskStatus(taskResp.Task.Status)
+	status, err := opensearchapi.ParseTaskStatus[opensearchapi.BulkByScrollTaskStatus](taskResp.Task.Status)
 	if err != nil {
 		return err
 	}
@@ -138,10 +138,10 @@ For sliced requests, the `Slices` field contains per-slice status. Each element 
 
 ### Replication Tasks
 
-For replication tasks (e.g. index, delete, bulk shard operations), use `ParseReplicationTaskStatus`:
+For replication tasks (e.g. index, delete, bulk shard operations), use `ParseTaskStatus`:
 
 ```go
-	replStatus, err := opensearchapi.ParseReplicationTaskStatus(taskResp.Task.Status)
+	replStatus, err := opensearchapi.ParseTaskStatus[opensearchapi.ReplicationTaskStatus](taskResp.Task.Status)
 	if err != nil {
 		return err
 	}
@@ -150,10 +150,10 @@ For replication tasks (e.g. index, delete, bulk shard operations), use `ParseRep
 
 ### Primary-Replica Resync Tasks
 
-For primary-replica resync tasks, use `ParseResyncTaskStatus`:
+For primary-replica resync tasks, use `ParseTaskStatus`:
 
 ```go
-	resyncStatus, err := opensearchapi.ParseResyncTaskStatus(taskResp.Task.Status)
+	resyncStatus, err := opensearchapi.ParseTaskStatus[opensearchapi.ResyncTaskStatus](taskResp.Task.Status)
 	if err != nil {
 		return err
 	}
@@ -165,10 +165,10 @@ For primary-replica resync tasks, use `ParseResyncTaskStatus`:
 
 ### Persistent Tasks
 
-For persistent task executors, use `ParsePersistentTaskStatus`:
+For persistent task executors, use `ParseTaskStatus`:
 
 ```go
-	persistStatus, err := opensearchapi.ParsePersistentTaskStatus(taskResp.Task.Status)
+	persistStatus, err := opensearchapi.ParseTaskStatus[opensearchapi.PersistentTaskStatus](taskResp.Task.Status)
 	if err != nil {
 		return err
 	}
@@ -223,14 +223,24 @@ Long-running tasks can be cancelled by task ID:
 
 The OpenSearch server returns different status structures depending on the task type. All status types have been present since OpenSearch 1.0.0.
 
-| Task Type                                 | Parse Helper                  | Status Struct            | Key Fields                                                                |
-| ----------------------------------------- | ----------------------------- | ------------------------ | ------------------------------------------------------------------------- |
-| reindex, delete_by_query, update_by_query | `ParseBulkByScrollTaskStatus` | `BulkByScrollTaskStatus` | total, created, updated, deleted, batches, retries, throttle info, slices |
-| replication (index, delete, bulk shard)   | `ParseReplicationTaskStatus`  | `ReplicationTaskStatus`  | phase                                                                     |
-| primary-replica resync                    | `ParseResyncTaskStatus`       | `ResyncTaskStatus`       | phase, totalOperations, resyncedOperations, skippedOperations             |
-| persistent task executor                  | `ParsePersistentTaskStatus`   | `PersistentTaskStatus`   | state                                                                     |
+| Task Type                                 | Call                                      | Status Struct            | Key Fields                                                                |
+| ----------------------------------------- | ----------------------------------------- | ------------------------ | ------------------------------------------------------------------------- |
+| reindex, delete_by_query, update_by_query | `ParseTaskStatus[BulkByScrollTaskStatus]` | `BulkByScrollTaskStatus` | total, created, updated, deleted, batches, retries, throttle info, slices |
+| replication (index, delete, bulk shard)   | `ParseTaskStatus[ReplicationTaskStatus]`  | `ReplicationTaskStatus`  | phase                                                                     |
+| primary-replica resync                    | `ParseTaskStatus[ResyncTaskStatus]`       | `ResyncTaskStatus`       | phase, totalOperations, resyncedOperations, skippedOperations             |
+| persistent task executor                  | `ParseTaskStatus[PersistentTaskStatus]`   | `PersistentTaskStatus`   | state                                                                     |
 
 For any unrecognized task type, the `Status` field remains available as `json.RawMessage` for direct unmarshaling.
+
+### Shorthand Helpers
+
+If you parse the same status type frequently, you can define a short alias in your own code:
+
+```go
+func parseBulkByScrollStatus(raw json.RawMessage) (*opensearchapi.BulkByScrollTaskStatus, error) {
+	return opensearchapi.ParseTaskStatus[opensearchapi.BulkByScrollTaskStatus](raw)
+}
+```
 
 ## Cleanup
 

--- a/guides/tasks.md
+++ b/guides/tasks.md
@@ -1,0 +1,249 @@
+# Tasks
+
+In this guide, you'll learn how to use the OpenSearch Golang Client API to manage asynchronous tasks. You'll learn how to submit long-running operations asynchronously, poll for their completion, and inspect task status.
+
+## Setup
+
+Assuming you have OpenSearch running locally on port 9200, you can create a client instance with the following code:
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
+)
+
+func main() {
+	if err := example(); err != nil {
+		fmt.Println(fmt.Sprintf("Error: %s", err))
+		os.Exit(1)
+	}
+}
+
+func example() error {
+	client, err := opensearchapi.NewDefaultClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+```
+
+Next, create a source index with some test data:
+
+```go
+	sourceIndex := "task-source"
+	destIndex := "task-dest"
+
+	client.Indices.Create(ctx, opensearchapi.IndicesCreateReq{
+		Index: sourceIndex,
+		Body:  strings.NewReader(`{"settings": {"number_of_shards": 1, "number_of_replicas": 0}}`),
+	})
+
+	// Index a document
+	client.Index(ctx, opensearchapi.IndexReq{
+		Index: sourceIndex,
+		Body:  strings.NewReader(`{"title": "Test Document", "year": 2024}`),
+		Params: opensearchapi.IndexParams{
+			Refresh: "true",
+		},
+	})
+```
+
+## Submitting Async Tasks
+
+Long-running operations like reindex, delete_by_query, and update_by_query can be submitted asynchronously by setting `WaitForCompletion` to `false`. The response contains a task ID that can be used to poll for completion.
+
+### Async Reindex
+
+```go
+	reindexResp, err := client.Reindex(ctx, opensearchapi.ReindexReq{
+		Body: strings.NewReader(fmt.Sprintf(
+			`{"source":{"index":"%s"},"dest":{"index":"%s"}}`,
+			sourceIndex, destIndex,
+		)),
+		Params: opensearchapi.ReindexParams{
+			WaitForCompletion: opensearchapi.ToPointer(false),
+		},
+	})
+	if err != nil {
+		return err
+	}
+	taskID := reindexResp.Task
+	fmt.Printf("Task submitted: %s\n", taskID)
+```
+
+## Polling for Completion
+
+Use `Tasks.Get` to poll a task by ID. The `Completed` field indicates whether the task has finished.
+
+```go
+	var taskResp *opensearchapi.TasksGetResp
+	for {
+		taskResp, err = client.Tasks.Get(ctx, opensearchapi.TasksGetReq{TaskID: taskID})
+		if err != nil {
+			return err
+		}
+		if taskResp.Completed {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	fmt.Printf("Task completed: action=%s\n", taskResp.Task.Action)
+```
+
+## Inspecting Task Status
+
+The `Status` field on a task is a `json.RawMessage` because its shape depends on the task type. The client provides typed structs and parse helpers for each known status type.
+
+### BulkByScroll Tasks (reindex, delete_by_query, update_by_query)
+
+For reindex, delete_by_query, and update_by_query tasks, use `ParseBulkByScrollTaskStatus` to unmarshal the status into a typed struct:
+
+```go
+	status, err := opensearchapi.ParseBulkByScrollTaskStatus(taskResp.Task.Status)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Total: %d\n", status.Total)
+	fmt.Printf("Created: %d\n", status.Created)
+	fmt.Printf("Updated: %d\n", status.Updated)
+	fmt.Printf("Deleted: %d\n", status.Deleted)
+	fmt.Printf("Batches: %d\n", status.Batches)
+	fmt.Printf("Version conflicts: %d\n", status.VersionConflicts)
+	fmt.Printf("Noops: %d\n", status.Noops)
+	fmt.Printf("Retries (bulk): %d\n", status.Retries.Bulk)
+	fmt.Printf("Retries (search): %d\n", status.Retries.Search)
+```
+
+For sliced requests, the `Slices` field contains per-slice status. Each element is a `BulkByScrollTaskStatusOrException` — either a nested `BulkByScrollTaskStatus` (on success) or a `BulkByScrollTaskException` (on failure):
+
+```go
+	for i, slice := range status.Slices {
+		if slice.Status != nil {
+			fmt.Printf("Slice %d: %d total\n", i, slice.Status.Total)
+		}
+		if slice.Exception != nil {
+			fmt.Printf("Slice %d failed: %s\n", i, slice.Exception.Reason)
+		}
+	}
+```
+
+### Replication Tasks
+
+For replication tasks (e.g. index, delete, bulk shard operations), use `ParseReplicationTaskStatus`:
+
+```go
+	replStatus, err := opensearchapi.ParseReplicationTaskStatus(taskResp.Task.Status)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Phase: %s\n", replStatus.Phase)
+```
+
+### Primary-Replica Resync Tasks
+
+For primary-replica resync tasks, use `ParseResyncTaskStatus`:
+
+```go
+	resyncStatus, err := opensearchapi.ParseResyncTaskStatus(taskResp.Task.Status)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Phase: %s\n", resyncStatus.Phase)
+	fmt.Printf("Total operations: %d\n", resyncStatus.TotalOperations)
+	fmt.Printf("Resynced: %d\n", resyncStatus.ResyncedOperations)
+	fmt.Printf("Skipped: %d\n", resyncStatus.SkippedOperations)
+```
+
+### Persistent Tasks
+
+For persistent task executors, use `ParsePersistentTaskStatus`:
+
+```go
+	persistStatus, err := opensearchapi.ParsePersistentTaskStatus(taskResp.Task.Status)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("State: %s\n", persistStatus.State)
+```
+
+### Unknown Task Types
+
+For task types without a dedicated struct, unmarshal the raw JSON directly:
+
+```go
+	if taskResp.Task.Status != nil {
+		var raw map[string]any
+		if err := json.Unmarshal(taskResp.Task.Status, &raw); err != nil {
+			return err
+		}
+		fmt.Printf("Raw status: %v\n", raw)
+	}
+```
+
+## Listing Tasks
+
+Use `Tasks.List` to see all running tasks on the cluster:
+
+```go
+	listResp, err := client.Tasks.List(ctx, nil)
+	if err != nil {
+		return err
+	}
+	for nodeID, node := range listResp.Nodes {
+		fmt.Printf("Node %s (%s): %d tasks\n", node.Name, nodeID, len(node.Tasks))
+	}
+```
+
+## Cancelling Tasks
+
+Long-running tasks can be cancelled by task ID:
+
+```go
+	cancelResp, err := client.Tasks.Cancel(ctx, opensearchapi.TasksCancelReq{TaskID: taskID})
+	if err != nil {
+		return err
+	}
+	for _, node := range cancelResp.Nodes {
+		for id := range node.Tasks {
+			fmt.Printf("Cancelled task: %s\n", id)
+		}
+	}
+```
+
+## Status Type Reference
+
+The OpenSearch server returns different status structures depending on the task type. All status types have been present since OpenSearch 1.0.0.
+
+| Task Type                                 | Parse Helper                  | Status Struct            | Key Fields                                                                |
+| ----------------------------------------- | ----------------------------- | ------------------------ | ------------------------------------------------------------------------- |
+| reindex, delete_by_query, update_by_query | `ParseBulkByScrollTaskStatus` | `BulkByScrollTaskStatus` | total, created, updated, deleted, batches, retries, throttle info, slices |
+| replication (index, delete, bulk shard)   | `ParseReplicationTaskStatus`  | `ReplicationTaskStatus`  | phase                                                                     |
+| primary-replica resync                    | `ParseResyncTaskStatus`       | `ResyncTaskStatus`       | phase, totalOperations, resyncedOperations, skippedOperations             |
+| persistent task executor                  | `ParsePersistentTaskStatus`   | `PersistentTaskStatus`   | state                                                                     |
+
+For any unrecognized task type, the `Status` field remains available as `json.RawMessage` for direct unmarshaling.
+
+## Cleanup
+
+```go
+	delResp, err := client.Indices.Delete(ctx, opensearchapi.IndicesDeleteReq{
+		Indices: []string{sourceIndex, destIndex},
+		Params:  opensearchapi.IndicesDeleteParams{IgnoreUnavailable: opensearchapi.ToPointer(true)},
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Deleted: %t\n", delResp.Acknowledged)
+
+	return nil
+}
+```

--- a/opensearchapi/api_bulk.go
+++ b/opensearchapi/api_bulk.go
@@ -71,7 +71,7 @@ type BulkRespItem struct {
 	Index   string `json:"_index"`
 	ID      string `json:"_id"`
 	Version int    `json:"_version"`
-	Type    string `json:"_type"` // Deprecated field
+	Type    string `json:"_type,omitempty"` // Deprecated: ES 6.0, removed in OS 2.0
 	Result  string `json:"result"`
 	Shards  struct {
 		Total      int `json:"total"`

--- a/opensearchapi/api_document-create.go
+++ b/opensearchapi/api_document-create.go
@@ -44,20 +44,16 @@ func (r DocumentCreateReq) GetRequest() (*http.Request, error) {
 
 // DocumentCreateResp represents the returned struct of the /_doc response
 type DocumentCreateResp struct {
-	Index         string `json:"_index"`
-	ID            string `json:"_id"`
-	Version       int    `json:"_version"`
-	Result        string `json:"result"`
-	Type          string `json:"_type"` // Deprecated field
-	ForcedRefresh bool   `json:"forced_refresh"`
-	Shards        struct {
-		Total      int `json:"total"`
-		Successful int `json:"successful"`
-		Failed     int `json:"failed"`
-	} `json:"_shards"`
-	SeqNo       int `json:"_seq_no"`
-	PrimaryTerm int `json:"_primary_term"`
-	response    *opensearch.Response
+	Index         string         `json:"_index"`
+	ID            string         `json:"_id"`
+	Version       int            `json:"_version"`
+	Result        string         `json:"result"`
+	Type          string         `json:"_type,omitempty"` // Deprecated: ES 6.0, removed in OS 2.0
+	ForcedRefresh bool           `json:"forced_refresh"`
+	Shards        ResponseShards `json:"_shards"`
+	SeqNo         int            `json:"_seq_no"`
+	PrimaryTerm   int            `json:"_primary_term"`
+	response      *opensearch.Response
 }
 
 // Inspect returns the Inspect type containing the raw *opensearch.Response

--- a/opensearchapi/api_document-delete.go
+++ b/opensearchapi/api_document-delete.go
@@ -41,18 +41,14 @@ func (r DocumentDeleteReq) GetRequest() (*http.Request, error) {
 
 // DocumentDeleteResp represents the returned struct of the /<index>/_doc/<DocID> response
 type DocumentDeleteResp struct {
-	Index   string `json:"_index"`
-	ID      string `json:"_id"`
-	Version int    `json:"_version"`
-	Result  string `json:"result"`
-	Type    string `json:"_type"` // Deprecated field
-	Shards  struct {
-		Total      int `json:"total"`
-		Successful int `json:"successful"`
-		Failed     int `json:"failed"`
-	} `json:"_shards"`
-	SeqNo       int `json:"_seq_no"`
-	PrimaryTerm int `json:"_primary_term"`
+	Index       string         `json:"_index"`
+	ID          string         `json:"_id"`
+	Version     int            `json:"_version"`
+	Result      string         `json:"result"`
+	Type        string         `json:"_type,omitempty"` // Deprecated: ES 6.0, removed in OS 2.0
+	Shards      ResponseShards `json:"_shards"`
+	SeqNo       int            `json:"_seq_no"`
+	PrimaryTerm int            `json:"_primary_term"`
 	response    *opensearch.Response
 }
 

--- a/opensearchapi/api_document-delete.go
+++ b/opensearchapi/api_document-delete.go
@@ -41,15 +41,16 @@ func (r DocumentDeleteReq) GetRequest() (*http.Request, error) {
 
 // DocumentDeleteResp represents the returned struct of the /<index>/_doc/<DocID> response
 type DocumentDeleteResp struct {
-	Index       string         `json:"_index"`
-	ID          string         `json:"_id"`
-	Version     int            `json:"_version"`
-	Result      string         `json:"result"`
-	Type        string         `json:"_type,omitempty"` // Deprecated: ES 6.0, removed in OS 2.0
-	Shards      ResponseShards `json:"_shards"`
-	SeqNo       int            `json:"_seq_no"`
-	PrimaryTerm int            `json:"_primary_term"`
-	response    *opensearch.Response
+	Index         string         `json:"_index"`
+	ID            string         `json:"_id"`
+	Version       int            `json:"_version"`
+	Result        string         `json:"result"`
+	ForcedRefresh bool           `json:"forced_refresh"`
+	Type          string         `json:"_type,omitempty"` // Deprecated: ES 6.0, removed in OS 2.0
+	Shards        ResponseShards `json:"_shards"`
+	SeqNo         int            `json:"_seq_no"`
+	PrimaryTerm   int            `json:"_primary_term"`
+	response      *opensearch.Response
 }
 
 // Inspect returns the Inspect type containing the raw *opensearch.Response

--- a/opensearchapi/api_document-delete_by_query.go
+++ b/opensearchapi/api_document-delete_by_query.go
@@ -7,7 +7,6 @@
 package opensearchapi
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -50,11 +49,11 @@ type DocumentDeleteByQueryResp struct {
 		Bulk   int `json:"bulk"`
 		Search int `json:"search"`
 	} `json:"retries"`
-	ThrottledMillis      int               `json:"throttled_millis"`
-	RequestsPerSecond    float32           `json:"requests_per_second"`
-	ThrottledUntilMillis int               `json:"throttled_until_millis"`
-	Failures             []json.RawMessage `json:"failures"`       // Unknow struct, open an issue with an example response so we can add it
-	Task                 string            `json:"task,omitempty"` // Needed when wait_for_completion is set to false
+	ThrottledMillis      int                   `json:"throttled_millis"`
+	RequestsPerSecond    float32               `json:"requests_per_second"`
+	ThrottledUntilMillis int                   `json:"throttled_until_millis"`
+	Failures             []BulkByScrollFailure `json:"failures"`
+	Task                 string                `json:"task,omitempty"` // Needed when wait_for_completion is set to false
 	response             *opensearch.Response
 }
 

--- a/opensearchapi/api_document-explain.go
+++ b/opensearchapi/api_document-explain.go
@@ -40,7 +40,7 @@ func (r DocumentExplainReq) GetRequest() (*http.Request, error) {
 type DocumentExplainResp struct {
 	Index       string                 `json:"_index"`
 	ID          string                 `json:"_id"`
-	Type        string                 `json:"_type"` // Deprecated field
+	Type        string                 `json:"_type,omitempty"` // Deprecated: ES 6.0, removed in OS 2.0
 	Matched     bool                   `json:"matched"`
 	Explanation DocumentExplainDetails `json:"explanation"`
 	response    *opensearch.Response

--- a/opensearchapi/api_document-get.go
+++ b/opensearchapi/api_document-get.go
@@ -42,7 +42,7 @@ type DocumentGetResp struct {
 	SeqNo       int             `json:"_seq_no"`
 	PrimaryTerm int             `json:"_primary_term"`
 	Found       bool            `json:"found"`
-	Type        string          `json:"_type"` // Deprecated field
+	Type        string          `json:"_type,omitempty"` // Deprecated: ES 6.0, removed in OS 2.0
 	Source      json.RawMessage `json:"_source"`
 	Fields      json.RawMessage `json:"fields"`
 	response    *opensearch.Response

--- a/opensearchapi/api_index.go
+++ b/opensearchapi/api_index.go
@@ -60,15 +60,16 @@ func (r IndexReq) GetRequest() (*http.Request, error) {
 
 // IndexResp represents the returned struct of the /_doc response
 type IndexResp struct {
-	Index       string         `json:"_index"`
-	ID          string         `json:"_id"`
-	Version     int            `json:"_version"`
-	Result      string         `json:"result"`
-	Shards      ResponseShards `json:"_shards"`
-	SeqNo       int            `json:"_seq_no"`
-	PrimaryTerm int            `json:"_primary_term"`
-	Type        string         `json:"_type,omitempty"` // Deprecated: ES 6.0, removed in OS 2.0
-	response    *opensearch.Response
+	Index         string         `json:"_index"`
+	ID            string         `json:"_id"`
+	Version       int            `json:"_version"`
+	Result        string         `json:"result"`
+	ForcedRefresh bool           `json:"forced_refresh"`
+	Shards        ResponseShards `json:"_shards"`
+	SeqNo         int            `json:"_seq_no"`
+	PrimaryTerm   int            `json:"_primary_term"`
+	Type          string         `json:"_type,omitempty"` // Deprecated: ES 6.0, removed in OS 2.0
+	response      *opensearch.Response
 }
 
 // Inspect returns the Inspect type containing the raw *opensearch.Response

--- a/opensearchapi/api_index.go
+++ b/opensearchapi/api_index.go
@@ -60,18 +60,14 @@ func (r IndexReq) GetRequest() (*http.Request, error) {
 
 // IndexResp represents the returned struct of the /_doc response
 type IndexResp struct {
-	Index   string `json:"_index"`
-	ID      string `json:"_id"`
-	Version int    `json:"_version"`
-	Result  string `json:"result"`
-	Shards  struct {
-		Total      int `json:"total"`
-		Successful int `json:"successful"`
-		Failed     int `json:"failed"`
-	} `json:"_shards"`
-	SeqNo       int    `json:"_seq_no"`
-	PrimaryTerm int    `json:"_primary_term"`
-	Type        string `json:"_type"` // Deprecated field
+	Index       string         `json:"_index"`
+	ID          string         `json:"_id"`
+	Version     int            `json:"_version"`
+	Result      string         `json:"result"`
+	Shards      ResponseShards `json:"_shards"`
+	SeqNo       int            `json:"_seq_no"`
+	PrimaryTerm int            `json:"_primary_term"`
+	Type        string         `json:"_type,omitempty"` // Deprecated: ES 6.0, removed in OS 2.0
 	response    *opensearch.Response
 }
 

--- a/opensearchapi/api_indices-count.go
+++ b/opensearchapi/api_indices-count.go
@@ -46,13 +46,8 @@ func (r IndicesCountReq) GetRequest() (*http.Request, error) {
 
 // IndicesCountResp represents the returned struct of the index shrink response
 type IndicesCountResp struct {
-	Shards struct {
-		Total      int `json:"total"`
-		Successful int `json:"successful"`
-		Skipped    int `json:"skipped"`
-		Failed     int `json:"failed"`
-	} `json:"_shards"`
-	Count    int `json:"count"`
+	Shards   ResponseShards `json:"_shards"`
+	Count    int            `json:"count"`
 	response *opensearch.Response
 }
 

--- a/opensearchapi/api_indices-refresh.go
+++ b/opensearchapi/api_indices-refresh.go
@@ -43,11 +43,7 @@ func (r IndicesRefreshReq) GetRequest() (*http.Request, error) {
 
 // IndicesRefreshResp represents the returned struct of the index shrink response
 type IndicesRefreshResp struct {
-	Shards struct {
-		Total      int `json:"total"`
-		Successful int `json:"successful"`
-		Failed     int `json:"failed"`
-	} `json:"_shards"`
+	Shards   ResponseShards `json:"_shards"`
 	response *opensearch.Response
 }
 

--- a/opensearchapi/api_mget.go
+++ b/opensearchapi/api_mget.go
@@ -66,8 +66,11 @@ type MGetResp struct {
 		SeqNo       int             `json:"_seq_no"`
 		PrimaryTerm int             `json:"_primary_term"`
 		Found       bool            `json:"found"`
-		Type        string          `json:"_type"`
+		Routing     string          `json:"_routing,omitempty"`
+		Type        string          `json:"_type,omitempty"` // Deprecated: ES 6.0, removed in OS 2.0
 		Source      json.RawMessage `json:"_source"`
+		Fields      json.RawMessage `json:"fields,omitempty"`
+		Error       *DocumentError  `json:"error,omitempty"`
 	} `json:"docs"`
 	response *opensearch.Response
 }

--- a/opensearchapi/api_msearch.go
+++ b/opensearchapi/api_msearch.go
@@ -75,6 +75,7 @@ type MSearchResp struct {
 		} `json:"hits"`
 		Status       int             `json:"status"`
 		Aggregations json.RawMessage `json:"aggregations"`
+		Error        *DocumentError  `json:"error,omitempty"`
 	} `json:"responses"`
 	response *opensearch.Response
 }

--- a/opensearchapi/api_mtermvectors.go
+++ b/opensearchapi/api_mtermvectors.go
@@ -65,8 +65,9 @@ type MTermvectorsResp struct {
 		Version     int             `json:"_version"`
 		Found       bool            `json:"found"`
 		Took        int             `json:"took"`
-		Type        string          `json:"_type"` // Deprecated field
+		Type        string          `json:"_type,omitempty"` // Deprecated: ES 6.0, removed in OS 2.0
 		TermVectors json.RawMessage `json:"term_vectors"`
+		Error       *DocumentError  `json:"error,omitempty"`
 	} `json:"docs"`
 	response *opensearch.Response
 }

--- a/opensearchapi/api_reindex.go
+++ b/opensearchapi/api_reindex.go
@@ -8,7 +8,6 @@ package opensearchapi
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"net/http"
 
@@ -62,11 +61,11 @@ type ReindexResp struct {
 		Bulk   int `json:"bulk"`
 		Search int `json:"search"`
 	} `json:"retries"`
-	ThrottledMillis      int               `json:"throttled_millis"`
-	RequestsPerSecond    float64           `json:"requests_per_second"`
-	ThrottledUntilMillis int               `json:"throttled_until_millis"`
-	Failures             []json.RawMessage `json:"failures"`
-	Task                 string            `json:"task"`
+	ThrottledMillis      int                   `json:"throttled_millis"`
+	RequestsPerSecond    float64               `json:"requests_per_second"`
+	ThrottledUntilMillis int                   `json:"throttled_until_millis"`
+	Failures             []BulkByScrollFailure `json:"failures"`
+	Task                 string                `json:"task"`
 	response             *opensearch.Response
 }
 

--- a/opensearchapi/api_search.go
+++ b/opensearchapi/api_search.go
@@ -102,7 +102,7 @@ type SearchHit struct {
 	InnerHits map[string]struct {
 		Hits SearchHits `json:"hits"`
 	} `json:"inner_hits"`
-	Type           string                  `json:"_type"` // Deprecated field
+	Type           string                  `json:"_type,omitempty"` // Deprecated: ES 6.0, removed in OS 2.0
 	Sort           []any                   `json:"sort"`
 	Explanation    *DocumentExplainDetails `json:"_explanation"`
 	SeqNo          *int                    `json:"_seq_no"`
@@ -123,7 +123,7 @@ type Suggest struct {
 type SuggestOptions struct {
 	Text            string              `json:"text"`
 	Index           string              `json:"_index"`
-	Type            string              `json:"_type"`
+	Type            string              `json:"_type,omitempty"` // Deprecated: ES 6.0, removed in OS 2.0
 	ID              string              `json:"_id"`
 	Score           float64             `json:"score"`  // term suggesters uses "score"
 	ScoreUnderscore float64             `json:"_score"` // completion and context suggesters uses "_score"

--- a/opensearchapi/api_tasks-cancel.go
+++ b/opensearchapi/api_tasks-cancel.go
@@ -76,4 +76,5 @@ type TaskCancelInfo struct {
 	Cancellable            bool            `json:"cancellable"`
 	Cancelled              bool            `json:"cancelled"`
 	Headers                json.RawMessage `json:"headers"`
+	Status                 json.RawMessage `json:"status,omitempty"` // Polymorphic; shape depends on task action.
 }

--- a/opensearchapi/api_tasks-get.go
+++ b/opensearchapi/api_tasks-get.go
@@ -70,8 +70,7 @@ type TasksGetResp struct {
 			} `json:"thread_info"`
 		} `json:"resource_stats"`
 		// Status is polymorphic; its shape depends on the task action.
-		// Use ParseBulkByScrollTaskStatus for reindex, delete_by_query,
-		// and update_by_query tasks.
+		// Use ParseTaskStatus[T] to unmarshal into a concrete type.
 		Status json.RawMessage `json:"status,omitempty"`
 	} `json:"task"`
 	response *opensearch.Response

--- a/opensearchapi/api_tasks-get.go
+++ b/opensearchapi/api_tasks-get.go
@@ -69,6 +69,10 @@ type TasksGetResp struct {
 				ActiveThreads    int `json:"active_threads"`
 			} `json:"thread_info"`
 		} `json:"resource_stats"`
+		// Status is polymorphic; its shape depends on the task action.
+		// Use ParseBulkByScrollTaskStatus for reindex, delete_by_query,
+		// and update_by_query tasks.
+		Status json.RawMessage `json:"status,omitempty"`
 	} `json:"task"`
 	response *opensearch.Response
 }

--- a/opensearchapi/api_tasks-list.go
+++ b/opensearchapi/api_tasks-list.go
@@ -7,6 +7,7 @@
 package opensearchapi
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/opensearch-project/opensearch-go/v4"
@@ -67,6 +68,7 @@ type TasksListTask struct {
 	CancellationTimeMillis *int64                 `json:"cancellation_time_millis,omitempty"` // Added in OpenSearch 2.8.0
 	Headers                map[string]string      `json:"headers"`
 	ResourceStats          TasksListResourceStats `json:"resource_stats"`
+	Status                 json.RawMessage        `json:"status,omitempty"` // Polymorphic; shape depends on task action.
 	ParentTaskID           string                 `json:"parent_task_id"`
 	Children               []TasksListTask        `json:"children,omitempty"`
 }

--- a/opensearchapi/api_tasks_test.go
+++ b/opensearchapi/api_tasks_test.go
@@ -183,6 +183,17 @@ func TestTasksClient(t *testing.T) {
 					require.NoError(t, err)
 					require.NotNil(t, res)
 					assert.NotNil(t, res.Inspect().Response)
+
+					// Verify Status field is populated for reindex tasks
+					// and can be unmarshaled into BulkByScrollTaskStatus.
+					taskResp, ok := res.(*opensearchapi.TasksGetResp)
+					require.True(t, ok)
+					require.NotNil(t, taskResp.Task.Status, "reindex task should have a status")
+
+					status, err := opensearchapi.ParseBulkByScrollTaskStatus(taskResp.Task.Status)
+					require.NoError(t, err, "status should parse as BulkByScrollTaskStatus")
+					assert.GreaterOrEqual(t, status.Total, int64(0), "total should be non-negative")
+					assert.GreaterOrEqual(t, status.Batches, int32(0), "batches should be non-negative")
 				}
 			})
 		}

--- a/opensearchapi/api_tasks_test.go
+++ b/opensearchapi/api_tasks_test.go
@@ -190,7 +190,7 @@ func TestTasksClient(t *testing.T) {
 					require.True(t, ok)
 					require.NotNil(t, taskResp.Task.Status, "reindex task should have a status")
 
-					status, err := opensearchapi.ParseBulkByScrollTaskStatus(taskResp.Task.Status)
+					status, err := opensearchapi.ParseTaskStatus[opensearchapi.BulkByScrollTaskStatus](taskResp.Task.Status)
 					require.NoError(t, err, "status should parse as BulkByScrollTaskStatus")
 					assert.GreaterOrEqual(t, status.Total, int64(0), "total should be non-negative")
 					assert.GreaterOrEqual(t, status.Batches, int32(0), "batches should be non-negative")

--- a/opensearchapi/api_tasks_types.go
+++ b/opensearchapi/api_tasks_types.go
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package opensearchapi
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// BulkByScrollTaskStatus represents the status of reindex, delete_by_query,
+// and update_by_query tasks as defined by the OpenSearch API specification.
+//
+// All fields are present since OpenSearch 1.0.0 (inherited from Elasticsearch 5.x).
+// Fields marked omitempty are conditionally present based on runtime state, not
+// server version.
+type BulkByScrollTaskStatus struct {
+	// SliceID identifies the sub-slice when the request is parallelized.
+	// Only present on sub-slice worker tasks; absent on the parent task.
+	// Since OpenSearch 1.0.0.
+	SliceID *int32 `json:"slice_id,omitempty"`
+
+	// Total is the number of documents that were successfully processed.
+	// Since OpenSearch 1.0.0.
+	Total int64 `json:"total"`
+
+	// Updated is the number of documents successfully updated.
+	// Since OpenSearch 1.0.0.
+	Updated int64 `json:"updated"`
+
+	// Created is the number of documents successfully created.
+	// Since OpenSearch 1.0.0.
+	Created int64 `json:"created"`
+
+	// Deleted is the number of documents successfully deleted.
+	// Since OpenSearch 1.0.0.
+	Deleted int64 `json:"deleted"`
+
+	// Batches is the number of scroll responses pulled back by the operation.
+	// Since OpenSearch 1.0.0.
+	Batches int32 `json:"batches"`
+
+	// VersionConflicts is the number of version conflicts encountered.
+	// Since OpenSearch 1.0.0.
+	VersionConflicts int64 `json:"version_conflicts"`
+
+	// Noops is the number of documents that were ignored.
+	// Since OpenSearch 1.0.0.
+	Noops int64 `json:"noops"`
+
+	// Retries contains the retry counts for bulk and search sub-operations.
+	// Since OpenSearch 1.0.0.
+	Retries BulkByScrollTaskStatusRetries `json:"retries"`
+
+	// ThrottledMillis is the total time the request was throttled, in milliseconds.
+	// Since OpenSearch 1.0.0.
+	ThrottledMillis int64 `json:"throttled_millis"`
+
+	// Throttled is the human-readable throttle duration string.
+	// Only present when the request includes ?human=true.
+	// Since OpenSearch 1.0.0.
+	Throttled string `json:"throttled,omitempty"`
+
+	// RequestsPerSecond is the effective request rate. A value of -1 means unlimited.
+	// Since OpenSearch 1.0.0.
+	RequestsPerSecond float32 `json:"requests_per_second"`
+
+	// Canceled is the reason the task was cancelled.
+	// Only present when the task has been cancelled.
+	// Since OpenSearch 1.0.0.
+	Canceled string `json:"canceled,omitempty"`
+
+	// ThrottledUntilMillis is when the next throttle window opens, in milliseconds.
+	// Since OpenSearch 1.0.0.
+	ThrottledUntilMillis int64 `json:"throttled_until_millis"`
+
+	// ThrottledUntil is the human-readable duration until the next throttle window.
+	// Only present when the request includes ?human=true.
+	// Since OpenSearch 1.0.0.
+	ThrottledUntil string `json:"throttled_until,omitempty"`
+
+	// Slices contains per-slice status when the request is parallelized.
+	// Each element is either a BulkByScrollTaskStatus (success) or a
+	// BulkByScrollTaskException (failure).
+	// Only present when the request was sliced.
+	// Since OpenSearch 1.0.0.
+	Slices []BulkByScrollTaskStatusOrException `json:"slices,omitempty"`
+}
+
+// BulkByScrollTaskStatusRetries contains retry statistics for bulk and search
+// sub-operations. Since OpenSearch 1.0.0.
+type BulkByScrollTaskStatusRetries struct {
+	Bulk   int64 `json:"bulk"`
+	Search int64 `json:"search"`
+}
+
+// BulkByScrollTaskStatusOrException represents either a BulkByScrollTaskStatus
+// or an error cause, used in the Slices array. When a slice succeeds, Status is
+// populated. When a slice fails, Exception is populated.
+// Since OpenSearch 1.0.0.
+type BulkByScrollTaskStatusOrException struct {
+	Status    *BulkByScrollTaskStatus
+	Exception *BulkByScrollTaskException
+}
+
+// BulkByScrollTaskException represents an error from a failed bulk-by-scroll slice.
+// Since OpenSearch 1.0.0.
+type BulkByScrollTaskException struct {
+	Type     string          `json:"type"`
+	Reason   string          `json:"reason"`
+	CausedBy json.RawMessage `json:"caused_by,omitempty"`
+}
+
+// UnmarshalJSON implements custom unmarshaling for BulkByScrollTaskStatusOrException.
+// The server returns either a status object (with "total" field) or an error cause
+// (with "type" field but no "total").
+func (s *BulkByScrollTaskStatusOrException) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
+
+	var probe struct {
+		Type  *string `json:"type"`
+		Total *int64  `json:"total"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return fmt.Errorf("failed to probe BulkByScrollTaskStatusOrException: %w", err)
+	}
+
+	if probe.Type != nil && probe.Total == nil {
+		var exc BulkByScrollTaskException
+		if err := json.Unmarshal(data, &exc); err != nil {
+			return fmt.Errorf("failed to unmarshal BulkByScrollTaskException: %w", err)
+		}
+		s.Exception = &exc
+		return nil
+	}
+
+	var status BulkByScrollTaskStatus
+	if err := json.Unmarshal(data, &status); err != nil {
+		return fmt.Errorf("failed to unmarshal BulkByScrollTaskStatus: %w", err)
+	}
+	s.Status = &status
+	return nil
+}
+
+// MarshalJSON implements custom marshaling for BulkByScrollTaskStatusOrException.
+func (s BulkByScrollTaskStatusOrException) MarshalJSON() ([]byte, error) {
+	if s.Exception != nil {
+		return json.Marshal(s.Exception)
+	}
+	if s.Status != nil {
+		return json.Marshal(s.Status)
+	}
+	return []byte("null"), nil
+}
+
+// ReplicationTaskStatus represents the status of a replication task.
+// The phase field indicates the current replication phase (e.g. "starting",
+// "indexing", "translog", "finalizing", "done").
+// Since OpenSearch 1.0.0.
+type ReplicationTaskStatus struct {
+	Phase string `json:"phase"`
+}
+
+// ResyncTaskStatus represents the status of a primary-replica resync task.
+// Since OpenSearch 1.0.0.
+type ResyncTaskStatus struct {
+	// Phase is the current resync phase.
+	// Since OpenSearch 1.0.0.
+	Phase string `json:"phase"`
+
+	// TotalOperations is the total number of operations to resync.
+	// Since OpenSearch 1.0.0.
+	TotalOperations int `json:"totalOperations"`
+
+	// ResyncedOperations is the number of operations already resynced.
+	// Since OpenSearch 1.0.0.
+	ResyncedOperations int `json:"resyncedOperations"`
+
+	// SkippedOperations is the number of operations skipped during resync.
+	// Since OpenSearch 1.0.0.
+	SkippedOperations int `json:"skippedOperations"`
+}
+
+// PersistentTaskStatus represents the status of a persistent task executor.
+// The state field contains the executor state (e.g. "STARTED", "COMPLETED",
+// "PENDING_CANCEL").
+// Since OpenSearch 1.0.0.
+type PersistentTaskStatus struct {
+	State string `json:"state"`
+}
+
+// ParseBulkByScrollTaskStatus unmarshals a task's raw Status field into a
+// BulkByScrollTaskStatus. Use this for reindex, delete_by_query, and
+// update_by_query tasks.
+//
+// Returns an error if status is nil or cannot be unmarshaled.
+func ParseBulkByScrollTaskStatus(status json.RawMessage) (*BulkByScrollTaskStatus, error) {
+	if status == nil {
+		return nil, fmt.Errorf("status is nil")
+	}
+
+	var s BulkByScrollTaskStatus
+	if err := json.Unmarshal(status, &s); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal BulkByScrollTaskStatus: %w", err)
+	}
+
+	return &s, nil
+}
+
+// ParseReplicationTaskStatus unmarshals a task's raw Status field into a
+// ReplicationTaskStatus.
+//
+// Returns an error if status is nil or cannot be unmarshaled.
+func ParseReplicationTaskStatus(status json.RawMessage) (*ReplicationTaskStatus, error) {
+	if status == nil {
+		return nil, fmt.Errorf("status is nil")
+	}
+
+	var s ReplicationTaskStatus
+	if err := json.Unmarshal(status, &s); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal ReplicationTaskStatus: %w", err)
+	}
+
+	return &s, nil
+}
+
+// ParseResyncTaskStatus unmarshals a task's raw Status field into a
+// ResyncTaskStatus. Use this for primary-replica resync tasks.
+//
+// Returns an error if status is nil or cannot be unmarshaled.
+func ParseResyncTaskStatus(status json.RawMessage) (*ResyncTaskStatus, error) {
+	if status == nil {
+		return nil, fmt.Errorf("status is nil")
+	}
+
+	var s ResyncTaskStatus
+	if err := json.Unmarshal(status, &s); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal ResyncTaskStatus: %w", err)
+	}
+
+	return &s, nil
+}
+
+// ParsePersistentTaskStatus unmarshals a task's raw Status field into a
+// PersistentTaskStatus.
+//
+// Returns an error if status is nil or cannot be unmarshaled.
+func ParsePersistentTaskStatus(status json.RawMessage) (*PersistentTaskStatus, error) {
+	if status == nil {
+		return nil, fmt.Errorf("status is nil")
+	}
+
+	var s PersistentTaskStatus
+	if err := json.Unmarshal(status, &s); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal PersistentTaskStatus: %w", err)
+	}
+
+	return &s, nil
+}

--- a/opensearchapi/api_tasks_types.go
+++ b/opensearchapi/api_tasks_types.go
@@ -8,8 +8,13 @@ package opensearchapi
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
+
+// ErrNilTaskStatus is returned when a nil json.RawMessage is passed to a
+// Parse*TaskStatus function.
+var ErrNilTaskStatus = errors.New("task status is nil")
 
 // BulkByScrollTaskStatus represents the status of reindex, delete_by_query,
 // and update_by_query tasks as defined by the OpenSearch API specification.
@@ -200,16 +205,7 @@ type PersistentTaskStatus struct {
 //
 // Returns an error if status is nil or cannot be unmarshaled.
 func ParseBulkByScrollTaskStatus(status json.RawMessage) (*BulkByScrollTaskStatus, error) {
-	if status == nil {
-		return nil, fmt.Errorf("status is nil")
-	}
-
-	var s BulkByScrollTaskStatus
-	if err := json.Unmarshal(status, &s); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal BulkByScrollTaskStatus: %w", err)
-	}
-
-	return &s, nil
+	return parseTaskStatus[BulkByScrollTaskStatus](status)
 }
 
 // ParseReplicationTaskStatus unmarshals a task's raw Status field into a
@@ -217,16 +213,7 @@ func ParseBulkByScrollTaskStatus(status json.RawMessage) (*BulkByScrollTaskStatu
 //
 // Returns an error if status is nil or cannot be unmarshaled.
 func ParseReplicationTaskStatus(status json.RawMessage) (*ReplicationTaskStatus, error) {
-	if status == nil {
-		return nil, fmt.Errorf("status is nil")
-	}
-
-	var s ReplicationTaskStatus
-	if err := json.Unmarshal(status, &s); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal ReplicationTaskStatus: %w", err)
-	}
-
-	return &s, nil
+	return parseTaskStatus[ReplicationTaskStatus](status)
 }
 
 // ParseResyncTaskStatus unmarshals a task's raw Status field into a
@@ -234,16 +221,7 @@ func ParseReplicationTaskStatus(status json.RawMessage) (*ReplicationTaskStatus,
 //
 // Returns an error if status is nil or cannot be unmarshaled.
 func ParseResyncTaskStatus(status json.RawMessage) (*ResyncTaskStatus, error) {
-	if status == nil {
-		return nil, fmt.Errorf("status is nil")
-	}
-
-	var s ResyncTaskStatus
-	if err := json.Unmarshal(status, &s); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal ResyncTaskStatus: %w", err)
-	}
-
-	return &s, nil
+	return parseTaskStatus[ResyncTaskStatus](status)
 }
 
 // ParsePersistentTaskStatus unmarshals a task's raw Status field into a
@@ -251,14 +229,16 @@ func ParseResyncTaskStatus(status json.RawMessage) (*ResyncTaskStatus, error) {
 //
 // Returns an error if status is nil or cannot be unmarshaled.
 func ParsePersistentTaskStatus(status json.RawMessage) (*PersistentTaskStatus, error) {
-	if status == nil {
-		return nil, fmt.Errorf("status is nil")
-	}
+	return parseTaskStatus[PersistentTaskStatus](status)
+}
 
-	var s PersistentTaskStatus
-	if err := json.Unmarshal(status, &s); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal PersistentTaskStatus: %w", err)
+func parseTaskStatus[T any](raw json.RawMessage) (*T, error) {
+	if raw == nil {
+		return nil, ErrNilTaskStatus
 	}
-
+	var s T
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nil, fmt.Errorf("unmarshaling %T: %w", s, err)
+	}
 	return &s, nil
 }

--- a/opensearchapi/api_tasks_types.go
+++ b/opensearchapi/api_tasks_types.go
@@ -199,40 +199,15 @@ type PersistentTaskStatus struct {
 	State string `json:"state"`
 }
 
-// ParseBulkByScrollTaskStatus unmarshals a task's raw Status field into a
-// BulkByScrollTaskStatus. Use this for reindex, delete_by_query, and
-// update_by_query tasks.
+// ParseTaskStatus unmarshals a task's raw Status field into a concrete type.
+// The Status field is polymorphic; its shape depends on the task action.
 //
-// Returns an error if status is nil or cannot be unmarshaled.
-func ParseBulkByScrollTaskStatus(status json.RawMessage) (*BulkByScrollTaskStatus, error) {
-	return parseTaskStatus[BulkByScrollTaskStatus](status)
-}
-
-// ParseReplicationTaskStatus unmarshals a task's raw Status field into a
-// ReplicationTaskStatus.
+// Supported types: BulkByScrollTaskStatus (reindex, delete_by_query,
+// update_by_query), ReplicationTaskStatus, ResyncTaskStatus,
+// PersistentTaskStatus, or any struct that can be unmarshaled from JSON.
 //
-// Returns an error if status is nil or cannot be unmarshaled.
-func ParseReplicationTaskStatus(status json.RawMessage) (*ReplicationTaskStatus, error) {
-	return parseTaskStatus[ReplicationTaskStatus](status)
-}
-
-// ParseResyncTaskStatus unmarshals a task's raw Status field into a
-// ResyncTaskStatus. Use this for primary-replica resync tasks.
-//
-// Returns an error if status is nil or cannot be unmarshaled.
-func ParseResyncTaskStatus(status json.RawMessage) (*ResyncTaskStatus, error) {
-	return parseTaskStatus[ResyncTaskStatus](status)
-}
-
-// ParsePersistentTaskStatus unmarshals a task's raw Status field into a
-// PersistentTaskStatus.
-//
-// Returns an error if status is nil or cannot be unmarshaled.
-func ParsePersistentTaskStatus(status json.RawMessage) (*PersistentTaskStatus, error) {
-	return parseTaskStatus[PersistentTaskStatus](status)
-}
-
-func parseTaskStatus[T any](raw json.RawMessage) (*T, error) {
+// Returns ErrNilTaskStatus if raw is nil.
+func ParseTaskStatus[T any](raw json.RawMessage) (*T, error) {
 	if raw == nil {
 		return nil, ErrNilTaskStatus
 	}

--- a/opensearchapi/api_tasks_types_test.go
+++ b/opensearchapi/api_tasks_types_test.go
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+package opensearchapi_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
+)
+
+func TestParseBulkByScrollTaskStatus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil status returns error", func(t *testing.T) {
+		t.Parallel()
+		result, err := opensearchapi.ParseBulkByScrollTaskStatus(nil)
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.Contains(t, err.Error(), "status is nil")
+	})
+
+	t.Run("valid JSON with all required fields", func(t *testing.T) {
+		t.Parallel()
+		raw := json.RawMessage(`{
+			"total": 100,
+			"created": 50,
+			"updated": 30,
+			"deleted": 20,
+			"batches": 5,
+			"version_conflicts": 2,
+			"noops": 3,
+			"retries": {"bulk": 1, "search": 0},
+			"throttled_millis": 500,
+			"requests_per_second": -1,
+			"throttled_until_millis": 0
+		}`)
+
+		result, err := opensearchapi.ParseBulkByScrollTaskStatus(raw)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		require.Equal(t, int64(100), result.Total)
+		require.Equal(t, int64(50), result.Created)
+		require.Equal(t, int64(30), result.Updated)
+		require.Equal(t, int64(20), result.Deleted)
+		require.Equal(t, int32(5), result.Batches)
+		require.Equal(t, int64(2), result.VersionConflicts)
+		require.Equal(t, int64(3), result.Noops)
+		require.Equal(t, int64(1), result.Retries.Bulk)
+		require.Equal(t, int64(0), result.Retries.Search)
+		require.Equal(t, int64(500), result.ThrottledMillis)
+		require.InDelta(t, float32(-1), result.RequestsPerSecond, 0.001)
+		require.Equal(t, int64(0), result.ThrottledUntilMillis)
+		require.Nil(t, result.SliceID)
+		require.Empty(t, result.Canceled)
+		require.Nil(t, result.Slices)
+	})
+
+	t.Run("conditional fields present", func(t *testing.T) {
+		t.Parallel()
+		raw := json.RawMessage(`{
+			"slice_id": 3,
+			"total": 50,
+			"updated": 0,
+			"created": 50,
+			"deleted": 0,
+			"batches": 2,
+			"version_conflicts": 0,
+			"noops": 0,
+			"retries": {"bulk": 0, "search": 0},
+			"throttled_millis": 0,
+			"throttled": "0s",
+			"requests_per_second": -1,
+			"canceled": "by user request",
+			"throttled_until_millis": 0,
+			"throttled_until": "0s"
+		}`)
+
+		result, err := opensearchapi.ParseBulkByScrollTaskStatus(raw)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		require.NotNil(t, result.SliceID)
+		require.Equal(t, int32(3), *result.SliceID)
+		require.Equal(t, "by user request", result.Canceled)
+		require.Equal(t, "0s", result.Throttled)
+		require.Equal(t, "0s", result.ThrottledUntil)
+	})
+
+	t.Run("slices with mixed status and exception", func(t *testing.T) {
+		t.Parallel()
+		raw := json.RawMessage(`{
+			"total": 200,
+			"updated": 0,
+			"created": 200,
+			"deleted": 0,
+			"batches": 4,
+			"version_conflicts": 0,
+			"noops": 0,
+			"retries": {"bulk": 0, "search": 0},
+			"throttled_millis": 0,
+			"requests_per_second": -1,
+			"throttled_until_millis": 0,
+			"slices": [
+				{
+					"slice_id": 0,
+					"total": 100,
+					"updated": 0,
+					"created": 100,
+					"deleted": 0,
+					"batches": 2,
+					"version_conflicts": 0,
+					"noops": 0,
+					"retries": {"bulk": 0, "search": 0},
+					"throttled_millis": 0,
+					"requests_per_second": -1,
+					"throttled_until_millis": 0
+				},
+				{
+					"type": "search_phase_execution_exception",
+					"reason": "all shards failed"
+				}
+			]
+		}`)
+
+		result, err := opensearchapi.ParseBulkByScrollTaskStatus(raw)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Len(t, result.Slices, 2)
+
+		// First slice: successful status
+		require.NotNil(t, result.Slices[0].Status)
+		require.Nil(t, result.Slices[0].Exception)
+		require.NotNil(t, result.Slices[0].Status.SliceID)
+		require.Equal(t, int32(0), *result.Slices[0].Status.SliceID)
+		require.Equal(t, int64(100), result.Slices[0].Status.Total)
+
+		// Second slice: exception
+		require.Nil(t, result.Slices[1].Status)
+		require.NotNil(t, result.Slices[1].Exception)
+		require.Equal(t, "search_phase_execution_exception", result.Slices[1].Exception.Type)
+		require.Equal(t, "all shards failed", result.Slices[1].Exception.Reason)
+	})
+
+	t.Run("null slice element", func(t *testing.T) {
+		t.Parallel()
+		raw := json.RawMessage(`{
+			"total": 100,
+			"updated": 0,
+			"created": 100,
+			"deleted": 0,
+			"batches": 2,
+			"version_conflicts": 0,
+			"noops": 0,
+			"retries": {"bulk": 0, "search": 0},
+			"throttled_millis": 0,
+			"requests_per_second": -1,
+			"throttled_until_millis": 0,
+			"slices": [null, null]
+		}`)
+
+		result, err := opensearchapi.ParseBulkByScrollTaskStatus(raw)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Len(t, result.Slices, 2)
+		require.Nil(t, result.Slices[0].Status)
+		require.Nil(t, result.Slices[0].Exception)
+	})
+
+	t.Run("partial JSON uses zero values", func(t *testing.T) {
+		t.Parallel()
+		raw := json.RawMessage(`{"total": 42, "deleted": 10}`)
+
+		result, err := opensearchapi.ParseBulkByScrollTaskStatus(raw)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		require.Equal(t, int64(42), result.Total)
+		require.Equal(t, int64(10), result.Deleted)
+		require.Equal(t, int64(0), result.Created)
+		require.Equal(t, int32(0), result.Batches)
+	})
+
+	t.Run("invalid JSON returns error", func(t *testing.T) {
+		t.Parallel()
+		raw := json.RawMessage(`not valid json`)
+
+		result, err := opensearchapi.ParseBulkByScrollTaskStatus(raw)
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.Contains(t, err.Error(), "failed to unmarshal BulkByScrollTaskStatus")
+	})
+}
+
+func TestParseReplicationTaskStatus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil status returns error", func(t *testing.T) {
+		t.Parallel()
+		result, err := opensearchapi.ParseReplicationTaskStatus(nil)
+		require.Error(t, err)
+		require.Nil(t, result)
+	})
+
+	t.Run("valid JSON", func(t *testing.T) {
+		t.Parallel()
+		raw := json.RawMessage(`{"phase": "indexing"}`)
+
+		result, err := opensearchapi.ParseReplicationTaskStatus(raw)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, "indexing", result.Phase)
+	})
+
+	t.Run("invalid JSON returns error", func(t *testing.T) {
+		t.Parallel()
+		raw := json.RawMessage(`not valid`)
+
+		result, err := opensearchapi.ParseReplicationTaskStatus(raw)
+		require.Error(t, err)
+		require.Nil(t, result)
+	})
+}
+
+func TestParseResyncTaskStatus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil status returns error", func(t *testing.T) {
+		t.Parallel()
+		result, err := opensearchapi.ParseResyncTaskStatus(nil)
+		require.Error(t, err)
+		require.Nil(t, result)
+	})
+
+	t.Run("valid JSON", func(t *testing.T) {
+		t.Parallel()
+		raw := json.RawMessage(`{
+			"phase": "translog",
+			"totalOperations": 500,
+			"resyncedOperations": 350,
+			"skippedOperations": 10
+		}`)
+
+		result, err := opensearchapi.ParseResyncTaskStatus(raw)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, "translog", result.Phase)
+		require.Equal(t, 500, result.TotalOperations)
+		require.Equal(t, 350, result.ResyncedOperations)
+		require.Equal(t, 10, result.SkippedOperations)
+	})
+
+	t.Run("invalid JSON returns error", func(t *testing.T) {
+		t.Parallel()
+		raw := json.RawMessage(`not valid`)
+
+		result, err := opensearchapi.ParseResyncTaskStatus(raw)
+		require.Error(t, err)
+		require.Nil(t, result)
+	})
+}
+
+func TestParsePersistentTaskStatus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil status returns error", func(t *testing.T) {
+		t.Parallel()
+		result, err := opensearchapi.ParsePersistentTaskStatus(nil)
+		require.Error(t, err)
+		require.Nil(t, result)
+	})
+
+	t.Run("valid JSON", func(t *testing.T) {
+		t.Parallel()
+		raw := json.RawMessage(`{"state": "STARTED"}`)
+
+		result, err := opensearchapi.ParsePersistentTaskStatus(raw)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, "STARTED", result.State)
+	})
+
+	t.Run("invalid JSON returns error", func(t *testing.T) {
+		t.Parallel()
+		raw := json.RawMessage(`not valid`)
+
+		result, err := opensearchapi.ParsePersistentTaskStatus(raw)
+		require.Error(t, err)
+		require.Nil(t, result)
+	})
+}

--- a/opensearchapi/api_tasks_types_test.go
+++ b/opensearchapi/api_tasks_types_test.go
@@ -18,281 +18,439 @@ import (
 func TestParseBulkByScrollTaskStatus(t *testing.T) {
 	t.Parallel()
 
-	t.Run("nil status returns error", func(t *testing.T) {
-		t.Parallel()
-		result, err := opensearchapi.ParseBulkByScrollTaskStatus(nil)
-		require.Error(t, err)
-		require.Nil(t, result)
-		require.Contains(t, err.Error(), "status is nil")
-	})
+	tests := []struct {
+		name  string
+		input json.RawMessage
+		check func(t *testing.T, got *opensearchapi.BulkByScrollTaskStatus, err error)
+	}{
+		{
+			name:  "nil status",
+			input: nil,
+			check: func(t *testing.T, got *opensearchapi.BulkByScrollTaskStatus, err error) {
+				t.Helper()
+				require.ErrorIs(t, err, opensearchapi.ErrNilTaskStatus)
+				require.Nil(t, got)
+			},
+		},
+		{
+			name: "all required fields",
+			input: json.RawMessage(`{
+				"total": 100, "created": 50, "updated": 30, "deleted": 20,
+				"batches": 5, "version_conflicts": 2, "noops": 3,
+				"retries": {"bulk": 1, "search": 0},
+				"throttled_millis": 500, "requests_per_second": -1,
+				"throttled_until_millis": 0
+			}`),
+			check: func(t *testing.T, got *opensearchapi.BulkByScrollTaskStatus, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				require.Equal(t, int64(100), got.Total)
+				require.Equal(t, int64(50), got.Created)
+				require.Equal(t, int64(30), got.Updated)
+				require.Equal(t, int64(20), got.Deleted)
+				require.Equal(t, int32(5), got.Batches)
+				require.Equal(t, int64(2), got.VersionConflicts)
+				require.Equal(t, int64(3), got.Noops)
+				require.Equal(t, int64(1), got.Retries.Bulk)
+				require.Equal(t, int64(0), got.Retries.Search)
+				require.Equal(t, int64(500), got.ThrottledMillis)
+				require.InDelta(t, float32(-1), got.RequestsPerSecond, 0.001)
+				require.Equal(t, int64(0), got.ThrottledUntilMillis)
+				require.Nil(t, got.SliceID)
+				require.Empty(t, got.Canceled)
+				require.Nil(t, got.Slices)
+			},
+		},
+		{
+			name: "conditional fields present",
+			input: json.RawMessage(`{
+				"slice_id": 3, "total": 50, "updated": 0, "created": 50,
+				"deleted": 0, "batches": 2, "version_conflicts": 0, "noops": 0,
+				"retries": {"bulk": 0, "search": 0},
+				"throttled_millis": 0, "throttled": "0s",
+				"requests_per_second": -1,
+				"canceled": "by user request",
+				"throttled_until_millis": 0, "throttled_until": "0s"
+			}`),
+			check: func(t *testing.T, got *opensearchapi.BulkByScrollTaskStatus, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				require.NotNil(t, got.SliceID)
+				require.Equal(t, int32(3), *got.SliceID)
+				require.Equal(t, "by user request", got.Canceled)
+				require.Equal(t, "0s", got.Throttled)
+				require.Equal(t, "0s", got.ThrottledUntil)
+			},
+		},
+		{
+			name: "slices with mixed status and exception",
+			input: json.RawMessage(`{
+				"total": 200, "updated": 0, "created": 200, "deleted": 0,
+				"batches": 4, "version_conflicts": 0, "noops": 0,
+				"retries": {"bulk": 0, "search": 0},
+				"throttled_millis": 0, "requests_per_second": -1,
+				"throttled_until_millis": 0,
+				"slices": [
+					{
+						"slice_id": 0, "total": 100, "updated": 0, "created": 100,
+						"deleted": 0, "batches": 2, "version_conflicts": 0, "noops": 0,
+						"retries": {"bulk": 0, "search": 0},
+						"throttled_millis": 0, "requests_per_second": -1,
+						"throttled_until_millis": 0
+					},
+					{"type": "search_phase_execution_exception", "reason": "all shards failed"}
+				]
+			}`),
+			check: func(t *testing.T, got *opensearchapi.BulkByScrollTaskStatus, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				require.Len(t, got.Slices, 2)
 
-	t.Run("valid JSON with all required fields", func(t *testing.T) {
-		t.Parallel()
-		raw := json.RawMessage(`{
-			"total": 100,
-			"created": 50,
-			"updated": 30,
-			"deleted": 20,
-			"batches": 5,
-			"version_conflicts": 2,
-			"noops": 3,
-			"retries": {"bulk": 1, "search": 0},
-			"throttled_millis": 500,
-			"requests_per_second": -1,
-			"throttled_until_millis": 0
-		}`)
+				require.NotNil(t, got.Slices[0].Status)
+				require.Nil(t, got.Slices[0].Exception)
+				require.NotNil(t, got.Slices[0].Status.SliceID)
+				require.Equal(t, int32(0), *got.Slices[0].Status.SliceID)
+				require.Equal(t, int64(100), got.Slices[0].Status.Total)
 
-		result, err := opensearchapi.ParseBulkByScrollTaskStatus(raw)
-		require.NoError(t, err)
-		require.NotNil(t, result)
+				require.Nil(t, got.Slices[1].Status)
+				require.NotNil(t, got.Slices[1].Exception)
+				require.Equal(t, "search_phase_execution_exception", got.Slices[1].Exception.Type)
+				require.Equal(t, "all shards failed", got.Slices[1].Exception.Reason)
+			},
+		},
+		{
+			name: "null slice elements",
+			input: json.RawMessage(`{
+				"total": 100, "updated": 0, "created": 100, "deleted": 0,
+				"batches": 2, "version_conflicts": 0, "noops": 0,
+				"retries": {"bulk": 0, "search": 0},
+				"throttled_millis": 0, "requests_per_second": -1,
+				"throttled_until_millis": 0,
+				"slices": [null, null]
+			}`),
+			check: func(t *testing.T, got *opensearchapi.BulkByScrollTaskStatus, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				require.Len(t, got.Slices, 2)
+				require.Nil(t, got.Slices[0].Status)
+				require.Nil(t, got.Slices[0].Exception)
+			},
+		},
+		{
+			name:  "partial JSON uses zero values",
+			input: json.RawMessage(`{"total": 42, "deleted": 10}`),
+			check: func(t *testing.T, got *opensearchapi.BulkByScrollTaskStatus, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				require.Equal(t, int64(42), got.Total)
+				require.Equal(t, int64(10), got.Deleted)
+				require.Equal(t, int64(0), got.Created)
+				require.Equal(t, int32(0), got.Batches)
+			},
+		},
+		{
+			name:  "invalid JSON",
+			input: json.RawMessage(`not valid json`),
+			check: func(t *testing.T, got *opensearchapi.BulkByScrollTaskStatus, err error) {
+				t.Helper()
+				require.Error(t, err)
+				require.Nil(t, got)
+				require.ErrorContains(t, err, "unmarshaling opensearchapi.BulkByScrollTaskStatus")
+			},
+		},
+	}
 
-		require.Equal(t, int64(100), result.Total)
-		require.Equal(t, int64(50), result.Created)
-		require.Equal(t, int64(30), result.Updated)
-		require.Equal(t, int64(20), result.Deleted)
-		require.Equal(t, int32(5), result.Batches)
-		require.Equal(t, int64(2), result.VersionConflicts)
-		require.Equal(t, int64(3), result.Noops)
-		require.Equal(t, int64(1), result.Retries.Bulk)
-		require.Equal(t, int64(0), result.Retries.Search)
-		require.Equal(t, int64(500), result.ThrottledMillis)
-		require.InDelta(t, float32(-1), result.RequestsPerSecond, 0.001)
-		require.Equal(t, int64(0), result.ThrottledUntilMillis)
-		require.Nil(t, result.SliceID)
-		require.Empty(t, result.Canceled)
-		require.Nil(t, result.Slices)
-	})
-
-	t.Run("conditional fields present", func(t *testing.T) {
-		t.Parallel()
-		raw := json.RawMessage(`{
-			"slice_id": 3,
-			"total": 50,
-			"updated": 0,
-			"created": 50,
-			"deleted": 0,
-			"batches": 2,
-			"version_conflicts": 0,
-			"noops": 0,
-			"retries": {"bulk": 0, "search": 0},
-			"throttled_millis": 0,
-			"throttled": "0s",
-			"requests_per_second": -1,
-			"canceled": "by user request",
-			"throttled_until_millis": 0,
-			"throttled_until": "0s"
-		}`)
-
-		result, err := opensearchapi.ParseBulkByScrollTaskStatus(raw)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-
-		require.NotNil(t, result.SliceID)
-		require.Equal(t, int32(3), *result.SliceID)
-		require.Equal(t, "by user request", result.Canceled)
-		require.Equal(t, "0s", result.Throttled)
-		require.Equal(t, "0s", result.ThrottledUntil)
-	})
-
-	t.Run("slices with mixed status and exception", func(t *testing.T) {
-		t.Parallel()
-		raw := json.RawMessage(`{
-			"total": 200,
-			"updated": 0,
-			"created": 200,
-			"deleted": 0,
-			"batches": 4,
-			"version_conflicts": 0,
-			"noops": 0,
-			"retries": {"bulk": 0, "search": 0},
-			"throttled_millis": 0,
-			"requests_per_second": -1,
-			"throttled_until_millis": 0,
-			"slices": [
-				{
-					"slice_id": 0,
-					"total": 100,
-					"updated": 0,
-					"created": 100,
-					"deleted": 0,
-					"batches": 2,
-					"version_conflicts": 0,
-					"noops": 0,
-					"retries": {"bulk": 0, "search": 0},
-					"throttled_millis": 0,
-					"requests_per_second": -1,
-					"throttled_until_millis": 0
-				},
-				{
-					"type": "search_phase_execution_exception",
-					"reason": "all shards failed"
-				}
-			]
-		}`)
-
-		result, err := opensearchapi.ParseBulkByScrollTaskStatus(raw)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-		require.Len(t, result.Slices, 2)
-
-		// First slice: successful status
-		require.NotNil(t, result.Slices[0].Status)
-		require.Nil(t, result.Slices[0].Exception)
-		require.NotNil(t, result.Slices[0].Status.SliceID)
-		require.Equal(t, int32(0), *result.Slices[0].Status.SliceID)
-		require.Equal(t, int64(100), result.Slices[0].Status.Total)
-
-		// Second slice: exception
-		require.Nil(t, result.Slices[1].Status)
-		require.NotNil(t, result.Slices[1].Exception)
-		require.Equal(t, "search_phase_execution_exception", result.Slices[1].Exception.Type)
-		require.Equal(t, "all shards failed", result.Slices[1].Exception.Reason)
-	})
-
-	t.Run("null slice element", func(t *testing.T) {
-		t.Parallel()
-		raw := json.RawMessage(`{
-			"total": 100,
-			"updated": 0,
-			"created": 100,
-			"deleted": 0,
-			"batches": 2,
-			"version_conflicts": 0,
-			"noops": 0,
-			"retries": {"bulk": 0, "search": 0},
-			"throttled_millis": 0,
-			"requests_per_second": -1,
-			"throttled_until_millis": 0,
-			"slices": [null, null]
-		}`)
-
-		result, err := opensearchapi.ParseBulkByScrollTaskStatus(raw)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-		require.Len(t, result.Slices, 2)
-		require.Nil(t, result.Slices[0].Status)
-		require.Nil(t, result.Slices[0].Exception)
-	})
-
-	t.Run("partial JSON uses zero values", func(t *testing.T) {
-		t.Parallel()
-		raw := json.RawMessage(`{"total": 42, "deleted": 10}`)
-
-		result, err := opensearchapi.ParseBulkByScrollTaskStatus(raw)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-
-		require.Equal(t, int64(42), result.Total)
-		require.Equal(t, int64(10), result.Deleted)
-		require.Equal(t, int64(0), result.Created)
-		require.Equal(t, int32(0), result.Batches)
-	})
-
-	t.Run("invalid JSON returns error", func(t *testing.T) {
-		t.Parallel()
-		raw := json.RawMessage(`not valid json`)
-
-		result, err := opensearchapi.ParseBulkByScrollTaskStatus(raw)
-		require.Error(t, err)
-		require.Nil(t, result)
-		require.Contains(t, err.Error(), "failed to unmarshal BulkByScrollTaskStatus")
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := opensearchapi.ParseBulkByScrollTaskStatus(tt.input)
+			tt.check(t, got, err)
+		})
+	}
 }
 
 func TestParseReplicationTaskStatus(t *testing.T) {
 	t.Parallel()
 
-	t.Run("nil status returns error", func(t *testing.T) {
-		t.Parallel()
-		result, err := opensearchapi.ParseReplicationTaskStatus(nil)
-		require.Error(t, err)
-		require.Nil(t, result)
-	})
+	tests := []struct {
+		name  string
+		input json.RawMessage
+		check func(t *testing.T, got *opensearchapi.ReplicationTaskStatus, err error)
+	}{
+		{
+			name:  "nil status",
+			input: nil,
+			check: func(t *testing.T, got *opensearchapi.ReplicationTaskStatus, err error) {
+				t.Helper()
+				require.ErrorIs(t, err, opensearchapi.ErrNilTaskStatus)
+				require.Nil(t, got)
+			},
+		},
+		{
+			name:  "valid JSON",
+			input: json.RawMessage(`{"phase": "indexing"}`),
+			check: func(t *testing.T, got *opensearchapi.ReplicationTaskStatus, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				require.Equal(t, "indexing", got.Phase)
+			},
+		},
+		{
+			name:  "invalid JSON",
+			input: json.RawMessage(`not valid`),
+			check: func(t *testing.T, got *opensearchapi.ReplicationTaskStatus, err error) {
+				t.Helper()
+				require.Error(t, err)
+				require.Nil(t, got)
+			},
+		},
+	}
 
-	t.Run("valid JSON", func(t *testing.T) {
-		t.Parallel()
-		raw := json.RawMessage(`{"phase": "indexing"}`)
-
-		result, err := opensearchapi.ParseReplicationTaskStatus(raw)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-		require.Equal(t, "indexing", result.Phase)
-	})
-
-	t.Run("invalid JSON returns error", func(t *testing.T) {
-		t.Parallel()
-		raw := json.RawMessage(`not valid`)
-
-		result, err := opensearchapi.ParseReplicationTaskStatus(raw)
-		require.Error(t, err)
-		require.Nil(t, result)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := opensearchapi.ParseReplicationTaskStatus(tt.input)
+			tt.check(t, got, err)
+		})
+	}
 }
 
 func TestParseResyncTaskStatus(t *testing.T) {
 	t.Parallel()
 
-	t.Run("nil status returns error", func(t *testing.T) {
-		t.Parallel()
-		result, err := opensearchapi.ParseResyncTaskStatus(nil)
-		require.Error(t, err)
-		require.Nil(t, result)
-	})
+	tests := []struct {
+		name  string
+		input json.RawMessage
+		check func(t *testing.T, got *opensearchapi.ResyncTaskStatus, err error)
+	}{
+		{
+			name:  "nil status",
+			input: nil,
+			check: func(t *testing.T, got *opensearchapi.ResyncTaskStatus, err error) {
+				t.Helper()
+				require.ErrorIs(t, err, opensearchapi.ErrNilTaskStatus)
+				require.Nil(t, got)
+			},
+		},
+		{
+			name: "valid JSON",
+			input: json.RawMessage(`{
+				"phase": "translog",
+				"totalOperations": 500,
+				"resyncedOperations": 350,
+				"skippedOperations": 10
+			}`),
+			check: func(t *testing.T, got *opensearchapi.ResyncTaskStatus, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				require.Equal(t, "translog", got.Phase)
+				require.Equal(t, 500, got.TotalOperations)
+				require.Equal(t, 350, got.ResyncedOperations)
+				require.Equal(t, 10, got.SkippedOperations)
+			},
+		},
+		{
+			name:  "invalid JSON",
+			input: json.RawMessage(`not valid`),
+			check: func(t *testing.T, got *opensearchapi.ResyncTaskStatus, err error) {
+				t.Helper()
+				require.Error(t, err)
+				require.Nil(t, got)
+			},
+		},
+	}
 
-	t.Run("valid JSON", func(t *testing.T) {
-		t.Parallel()
-		raw := json.RawMessage(`{
-			"phase": "translog",
-			"totalOperations": 500,
-			"resyncedOperations": 350,
-			"skippedOperations": 10
-		}`)
-
-		result, err := opensearchapi.ParseResyncTaskStatus(raw)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-		require.Equal(t, "translog", result.Phase)
-		require.Equal(t, 500, result.TotalOperations)
-		require.Equal(t, 350, result.ResyncedOperations)
-		require.Equal(t, 10, result.SkippedOperations)
-	})
-
-	t.Run("invalid JSON returns error", func(t *testing.T) {
-		t.Parallel()
-		raw := json.RawMessage(`not valid`)
-
-		result, err := opensearchapi.ParseResyncTaskStatus(raw)
-		require.Error(t, err)
-		require.Nil(t, result)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := opensearchapi.ParseResyncTaskStatus(tt.input)
+			tt.check(t, got, err)
+		})
+	}
 }
 
 func TestParsePersistentTaskStatus(t *testing.T) {
 	t.Parallel()
 
-	t.Run("nil status returns error", func(t *testing.T) {
-		t.Parallel()
-		result, err := opensearchapi.ParsePersistentTaskStatus(nil)
-		require.Error(t, err)
-		require.Nil(t, result)
-	})
+	tests := []struct {
+		name  string
+		input json.RawMessage
+		check func(t *testing.T, got *opensearchapi.PersistentTaskStatus, err error)
+	}{
+		{
+			name:  "nil status",
+			input: nil,
+			check: func(t *testing.T, got *opensearchapi.PersistentTaskStatus, err error) {
+				t.Helper()
+				require.ErrorIs(t, err, opensearchapi.ErrNilTaskStatus)
+				require.Nil(t, got)
+			},
+		},
+		{
+			name:  "valid JSON",
+			input: json.RawMessage(`{"state": "STARTED"}`),
+			check: func(t *testing.T, got *opensearchapi.PersistentTaskStatus, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				require.Equal(t, "STARTED", got.State)
+			},
+		},
+		{
+			name:  "invalid JSON",
+			input: json.RawMessage(`not valid`),
+			check: func(t *testing.T, got *opensearchapi.PersistentTaskStatus, err error) {
+				t.Helper()
+				require.Error(t, err)
+				require.Nil(t, got)
+			},
+		},
+	}
 
-	t.Run("valid JSON", func(t *testing.T) {
-		t.Parallel()
-		raw := json.RawMessage(`{"state": "STARTED"}`)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := opensearchapi.ParsePersistentTaskStatus(tt.input)
+			tt.check(t, got, err)
+		})
+	}
+}
 
-		result, err := opensearchapi.ParsePersistentTaskStatus(raw)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-		require.Equal(t, "STARTED", result.State)
-	})
+func TestBulkByScrollTaskStatusOrException_MarshalJSON(t *testing.T) {
+	t.Parallel()
 
-	t.Run("invalid JSON returns error", func(t *testing.T) {
-		t.Parallel()
-		raw := json.RawMessage(`not valid`)
+	sliceID := int32(0)
+	roundtripSliceID := int32(2)
 
-		result, err := opensearchapi.ParsePersistentTaskStatus(raw)
-		require.Error(t, err)
-		require.Nil(t, result)
-	})
+	tests := []struct {
+		name  string
+		input opensearchapi.BulkByScrollTaskStatusOrException
+		check func(t *testing.T, data []byte, err error)
+	}{
+		{
+			name: "status",
+			input: opensearchapi.BulkByScrollTaskStatusOrException{
+				Status: &opensearchapi.BulkByScrollTaskStatus{
+					SliceID: &sliceID,
+					Total:   100,
+					Created: 100,
+					Retries: opensearchapi.BulkByScrollTaskStatusRetries{},
+				},
+			},
+			check: func(t *testing.T, data []byte, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				var got map[string]any
+				require.NoError(t, json.Unmarshal(data, &got))
+				require.InDelta(t, float64(100), got["total"], 0)
+				require.InDelta(t, float64(0), got["slice_id"], 0)
+			},
+		},
+		{
+			name: "exception",
+			input: opensearchapi.BulkByScrollTaskStatusOrException{
+				Exception: &opensearchapi.BulkByScrollTaskException{
+					Type:   "search_phase_execution_exception",
+					Reason: "all shards failed",
+				},
+			},
+			check: func(t *testing.T, data []byte, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				var got map[string]any
+				require.NoError(t, json.Unmarshal(data, &got))
+				require.Equal(t, "search_phase_execution_exception", got["type"])
+				require.Equal(t, "all shards failed", got["reason"])
+			},
+		},
+		{
+			name:  "empty produces null",
+			input: opensearchapi.BulkByScrollTaskStatusOrException{},
+			check: func(t *testing.T, data []byte, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				require.Equal(t, "null", string(data))
+			},
+		},
+		{
+			name: "roundtrip preserves fields",
+			input: opensearchapi.BulkByScrollTaskStatusOrException{
+				Status: &opensearchapi.BulkByScrollTaskStatus{
+					SliceID:           &roundtripSliceID,
+					Total:             50,
+					Created:           30,
+					Updated:           20,
+					Batches:           3,
+					VersionConflicts:  1,
+					Retries:           opensearchapi.BulkByScrollTaskStatusRetries{Bulk: 2, Search: 1},
+					RequestsPerSecond: -1,
+				},
+			},
+			check: func(t *testing.T, data []byte, err error) {
+				t.Helper()
+				require.NoError(t, err)
+
+				var got opensearchapi.BulkByScrollTaskStatusOrException
+				require.NoError(t, json.Unmarshal(data, &got))
+
+				require.NotNil(t, got.Status)
+				require.Nil(t, got.Exception)
+				require.Equal(t, int64(50), got.Status.Total)
+				require.Equal(t, int64(30), got.Status.Created)
+				require.NotNil(t, got.Status.SliceID)
+				require.Equal(t, int32(2), *got.Status.SliceID)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			data, err := json.Marshal(tt.input)
+			tt.check(t, data, err)
+		})
+	}
+}
+
+func TestBulkByScrollTaskStatusOrException_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input json.RawMessage
+		check func(t *testing.T, got opensearchapi.BulkByScrollTaskStatusOrException, err error)
+	}{
+		{
+			name:  "probe unmarshal error",
+			input: json.RawMessage(`42`),
+			check: func(t *testing.T, got opensearchapi.BulkByScrollTaskStatusOrException, err error) {
+				t.Helper()
+				require.ErrorContains(t, err, "failed to probe")
+			},
+		},
+		{
+			name:  "exception unmarshal error",
+			input: json.RawMessage(`{"type": "some_error", "reason": 123}`),
+			check: func(t *testing.T, got opensearchapi.BulkByScrollTaskStatusOrException, err error) {
+				t.Helper()
+				require.ErrorContains(t, err, "failed to unmarshal BulkByScrollTaskException")
+			},
+		},
+		{
+			name:  "status unmarshal error",
+			input: json.RawMessage(`{"total": 5, "retries": "bad"}`),
+			check: func(t *testing.T, got opensearchapi.BulkByScrollTaskStatusOrException, err error) {
+				t.Helper()
+				require.ErrorContains(t, err, "failed to unmarshal BulkByScrollTaskStatus")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var got opensearchapi.BulkByScrollTaskStatusOrException
+			err := json.Unmarshal(tt.input, &got)
+			tt.check(t, got, err)
+		})
+	}
 }

--- a/opensearchapi/api_tasks_types_test.go
+++ b/opensearchapi/api_tasks_types_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 )
 
-func TestParseBulkByScrollTaskStatus(t *testing.T) {
+func TestParseTaskStatus_BulkByScroll(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -163,13 +163,13 @@ func TestParseBulkByScrollTaskStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := opensearchapi.ParseBulkByScrollTaskStatus(tt.input)
+			got, err := opensearchapi.ParseTaskStatus[opensearchapi.BulkByScrollTaskStatus](tt.input)
 			tt.check(t, got, err)
 		})
 	}
 }
 
-func TestParseReplicationTaskStatus(t *testing.T) {
+func TestParseTaskStatus_Replication(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -209,13 +209,13 @@ func TestParseReplicationTaskStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := opensearchapi.ParseReplicationTaskStatus(tt.input)
+			got, err := opensearchapi.ParseTaskStatus[opensearchapi.ReplicationTaskStatus](tt.input)
 			tt.check(t, got, err)
 		})
 	}
 }
 
-func TestParseResyncTaskStatus(t *testing.T) {
+func TestParseTaskStatus_Resync(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -263,13 +263,13 @@ func TestParseResyncTaskStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := opensearchapi.ParseResyncTaskStatus(tt.input)
+			got, err := opensearchapi.ParseTaskStatus[opensearchapi.ResyncTaskStatus](tt.input)
 			tt.check(t, got, err)
 		})
 	}
 }
 
-func TestParsePersistentTaskStatus(t *testing.T) {
+func TestParseTaskStatus_Persistent(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -309,7 +309,7 @@ func TestParsePersistentTaskStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := opensearchapi.ParsePersistentTaskStatus(tt.input)
+			got, err := opensearchapi.ParseTaskStatus[opensearchapi.PersistentTaskStatus](tt.input)
 			tt.check(t, got, err)
 		})
 	}

--- a/opensearchapi/api_termvectors.go
+++ b/opensearchapi/api_termvectors.go
@@ -69,7 +69,7 @@ type TermvectorsResp struct {
 	Version     int             `json:"_version"`
 	Found       bool            `json:"found"`
 	Took        int             `json:"took"`
-	Type        string          `json:"_type"` // Deprecated field
+	Type        string          `json:"_type,omitempty"` // Deprecated: ES 6.0, removed in OS 2.0
 	TermVectors json.RawMessage `json:"term_vectors"`
 	response    *opensearch.Response
 }

--- a/opensearchapi/api_update.go
+++ b/opensearchapi/api_update.go
@@ -52,16 +52,17 @@ func (r UpdateReq) GetRequest() (*http.Request, error) {
 
 // UpdateResp represents the returned struct of the /_update response
 type UpdateResp struct {
-	Index       string           `json:"_index"`
-	ID          string           `json:"_id"`
-	Version     int              `json:"_version"`
-	Result      string           `json:"result"`
-	Shards      ResponseShards   `json:"_shards"`
-	SeqNo       int              `json:"_seq_no"`
-	PrimaryTerm int              `json:"_primary_term"`
-	Type        string           `json:"_type,omitempty"` // Deprecated: ES 6.0, removed in OS 2.0
-	Get         *DocumentGetResp `json:"get,omitempty"`
-	response    *opensearch.Response
+	Index         string           `json:"_index"`
+	ID            string           `json:"_id"`
+	Version       int              `json:"_version"`
+	Result        string           `json:"result"`
+	ForcedRefresh bool             `json:"forced_refresh"`
+	Shards        ResponseShards   `json:"_shards"`
+	SeqNo         int              `json:"_seq_no"`
+	PrimaryTerm   int              `json:"_primary_term"`
+	Type          string           `json:"_type,omitempty"` // Deprecated: ES 6.0, removed in OS 2.0
+	Get           *DocumentGetResp `json:"get,omitempty"`
+	response      *opensearch.Response
 }
 
 // Inspect returns the Inspect type containing the raw *opensearch.Response

--- a/opensearchapi/api_update.go
+++ b/opensearchapi/api_update.go
@@ -52,18 +52,14 @@ func (r UpdateReq) GetRequest() (*http.Request, error) {
 
 // UpdateResp represents the returned struct of the /_update response
 type UpdateResp struct {
-	Index   string `json:"_index"`
-	ID      string `json:"_id"`
-	Version int    `json:"_version"`
-	Result  string `json:"result"`
-	Shards  struct {
-		Total      int `json:"total"`
-		Successful int `json:"successful"`
-		Failed     int `json:"failed"`
-	} `json:"_shards"`
+	Index       string           `json:"_index"`
+	ID          string           `json:"_id"`
+	Version     int              `json:"_version"`
+	Result      string           `json:"result"`
+	Shards      ResponseShards   `json:"_shards"`
 	SeqNo       int              `json:"_seq_no"`
 	PrimaryTerm int              `json:"_primary_term"`
-	Type        string           `json:"_type"` // Deprecated field
+	Type        string           `json:"_type,omitempty"` // Deprecated: ES 6.0, removed in OS 2.0
 	Get         *DocumentGetResp `json:"get,omitempty"`
 	response    *opensearch.Response
 }

--- a/opensearchapi/api_update_by_query.go
+++ b/opensearchapi/api_update_by_query.go
@@ -8,7 +8,6 @@ package opensearchapi
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -65,12 +64,12 @@ type UpdateByQueryResp struct {
 		Bulk   int `json:"bulk"`
 		Search int `json:"search"`
 	} `json:"retries"`
-	ThrottledMillis      int               `json:"throttled_millis"`
-	RequestsPerSecond    float32           `json:"requests_per_second"`
-	ThrottledUntilMillis int               `json:"throttled_until_millis"`
-	Failures             []json.RawMessage `json:"failures"`
-	Type                 string            `json:"_type"` // Deprecated field
-	Task                 string            `json:"task"`
+	ThrottledMillis      int                   `json:"throttled_millis"`
+	RequestsPerSecond    float32               `json:"requests_per_second"`
+	ThrottledUntilMillis int                   `json:"throttled_until_millis"`
+	Failures             []BulkByScrollFailure `json:"failures"`
+	Type                 string                `json:"_type,omitempty"` // Deprecated: ES 6.0, removed in OS 2.0
+	Task                 string                `json:"task"`
 	response             *opensearch.Response
 }
 

--- a/opensearchapi/opensearchapi.go
+++ b/opensearchapi/opensearchapi.go
@@ -157,6 +157,29 @@ type ResponseShardsFailure struct {
 	} `json:"reason"`
 }
 
+// DocumentError represents an error for an individual item in a multi-document response.
+// Used by MGet, MTermvectors, MSearch, and similar APIs where each item can fail independently.
+type DocumentError struct {
+	Type      string          `json:"type"`
+	Reason    string          `json:"reason"`
+	Index     string          `json:"index,omitempty"`
+	IndexUUID string          `json:"index_uuid,omitempty"`
+	RootCause []DocumentError `json:"root_cause,omitempty"`
+	CausedBy  *DocumentError  `json:"caused_by,omitempty"`
+}
+
+// BulkByScrollFailure represents a failure item in _delete_by_query, _update_by_query,
+// and _reindex responses. Can represent either a bulk write failure or a search scroll failure.
+type BulkByScrollFailure struct {
+	Index  string         `json:"index"`
+	ID     string         `json:"id,omitempty"`    // Bulk failures only
+	Shard  *int           `json:"shard,omitempty"` // Search failures only
+	Node   string         `json:"node,omitempty"`  // Search failures only
+	Status int            `json:"status"`
+	Cause  *DocumentError `json:"cause,omitempty"`  // Bulk failures: the exception that caused the failure
+	Reason *DocumentError `json:"reason,omitempty"` // Search failures: the exception that caused the failure
+}
+
 // FailuresCause contains information about failure cause
 type FailuresCause struct {
 	Type   string `json:"type"`

--- a/opensearchapi/opensearchapi.go
+++ b/opensearchapi/opensearchapi.go
@@ -148,10 +148,12 @@ type ResponseShards struct {
 
 // ResponseShardsFailure is a sub type of ResponseShards containing information about a failed shard
 type ResponseShardsFailure struct {
-	Shard  int    `json:"shard"`
-	Index  any    `json:"index"`
-	Node   string `json:"node"`
-	Reason struct {
+	Shard   int    `json:"shard"`
+	Index   any    `json:"index"`
+	Node    string `json:"node"`
+	Status  string `json:"status"`
+	Primary bool   `json:"primary"`
+	Reason  struct {
 		Type   string `json:"type"`
 		Reason string `json:"reason"`
 	} `json:"reason"`

--- a/opensearchutil/bulk_indexer_internal_test.go
+++ b/opensearchutil/bulk_indexer_internal_test.go
@@ -31,15 +31,14 @@ package opensearchutil
 import (
 	"bytes"
 	"context"
-	"errors"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"math"
 	"net/http"
 	"os"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -47,11 +46,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/opensearch-project/opensearch-go/v4"
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi/testutil"
 	"github.com/opensearch-project/opensearch-go/v4/opensearchtransport"
-	"github.com/stretchr/testify/require"
 )
 
 var infoBody = `{
@@ -76,878 +76,746 @@ func (t *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.RoundTripFunc(req)
 }
 
-func TestBulkIndexer(t *testing.T) {
-	t.Run("Basic", func(t *testing.T) {
-		var (
-			wg sync.WaitGroup
+func infoResponse() (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Body:       io.NopCloser(strings.NewReader(infoBody)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}, nil
+}
 
-			countReqs int
-			testfile  string
-			numItems  uint64 = 6
-		)
+func TestWriteMeta(t *testing.T) {
+	testIndex := testutil.MustUniqueString(t, "test-index")
 
-		client, _ := opensearchapi.NewClient(opensearchapi.Config{Client: opensearch.Config{Transport: &mockTransport{
-			RoundTripFunc: func(request *http.Request) (*http.Response, error) {
-				if request.URL.Path == "/" {
-					return &http.Response{
-						Header: http.Header{"Content-Type": []string{"application/json"}},
-						Body:   io.NopCloser(strings.NewReader(infoBody)),
-					}, nil
-				}
-
-				countReqs++
-				switch countReqs {
-				case 1:
-					testfile = "testdata/bulk_response_1a.json"
-				case 2:
-					testfile = "testdata/bulk_response_1b.json"
-				case 3:
-					testfile = "testdata/bulk_response_1c.json"
-				}
-				bodyContent, _ := os.ReadFile(testfile)
-				return &http.Response{Body: io.NopCloser(bytes.NewBuffer(bodyContent))}, nil
-			},
-		}}})
-
-		cfg := BulkIndexerConfig{
-			NumWorkers:    1,
-			FlushBytes:    50,
-			FlushInterval: time.Hour, // Disable auto-flushing, because response doesn't match number of items
-			Client:        client,
-		}
-		if testutil.IsDebugEnabled(t) {
-			cfg.DebugLogger = log.New(os.Stdout, "", 0)
-		}
-
-		bi, _ := NewBulkIndexer(cfg)
-
-		for i := 1; i <= int(numItems); i++ {
-			wg.Add(1)
-			go func(i int) {
-				defer wg.Done()
-				err := bi.Add(context.Background(), BulkIndexerItem{
-					Action:     "foo",
-					DocumentID: strconv.Itoa(i),
-					Body:       strings.NewReader(fmt.Sprintf(`{"title":"foo-%d"}`, i)),
-				})
-				if err != nil {
-					t.Errorf("Unexpected error: %s", err)
-					return
-				}
-			}(i)
-		}
-		wg.Wait()
-
-		if err := bi.Close(context.Background()); err != nil {
-			t.Errorf("Unexpected error: %s", err)
-		}
-
-		stats := bi.Stats()
-
-		// added = numitems
-		if stats.NumAdded != numItems {
-			t.Errorf("Unexpected NumAdded: want=%d, got=%d", numItems, stats.NumAdded)
-		}
-
-		// flushed = numitems - 1x conflict + 1x not_found
-		if stats.NumFlushed != numItems-2 {
-			t.Errorf("Unexpected NumFlushed: want=%d, got=%d", numItems-2, stats.NumFlushed)
-		}
-
-		// failed = 1x conflict + 1x not_found
-		if stats.NumFailed != 2 {
-			t.Errorf("Unexpected NumFailed: want=%d, got=%d", 2, stats.NumFailed)
-		}
-
-		// indexed = 1x
-		if stats.NumIndexed != 1 {
-			t.Errorf("Unexpected NumIndexed: want=%d, got=%d", 1, stats.NumIndexed)
-		}
-
-		// created = 1x
-		if stats.NumCreated != 1 {
-			t.Errorf("Unexpected NumCreated: want=%d, got=%d", 1, stats.NumCreated)
-		}
-
-		// deleted = 1x
-		if stats.NumDeleted != 1 {
-			t.Errorf("Unexpected NumDeleted: want=%d, got=%d", 1, stats.NumDeleted)
-		}
-
-		if stats.NumUpdated != 1 {
-			t.Errorf("Unexpected NumUpdated: want=%d, got=%d", 1, stats.NumUpdated)
-		}
-
-		// 3 items * 40 bytes, 2 workers, 1 request per worker
-		if stats.NumRequests != 3 {
-			t.Errorf("Unexpected NumRequests: want=%d, got=%d", 3, stats.NumRequests)
-		}
-	})
-
-	t.Run("Add() Timeout", func(t *testing.T) {
-		client, _ := opensearchapi.NewClient(opensearchapi.Config{Client: opensearch.Config{Transport: &mockTransport{}}})
-		bi, _ := NewBulkIndexer(BulkIndexerConfig{NumWorkers: 1, Client: client})
-		ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
-		defer cancel()
-		time.Sleep(100 * time.Millisecond)
-
-		const numErrors = 10
-		errs := make([]error, 0, numErrors)
-		for range numErrors {
-			errs = append(errs, bi.Add(ctx, BulkIndexerItem{Action: "delete", DocumentID: "timeout"}))
-		}
-		if err := bi.Close(context.Background()); err != nil {
-			t.Errorf("Unexpected error: %s", err)
-		}
-
-		var gotError bool
-		for _, err := range errs {
-			if err != nil && err.Error() == "context deadline exceeded" {
-				gotError = true
+	type args struct {
+		item BulkIndexerItem
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr error
+	}{
+		{
+			name: "without _index and _id",
+			args: args{BulkIndexerItem{Action: "index"}},
+			want: `{"index":{}}` + "\n",
+		},
+		{
+			name: "with _id",
+			args: args{BulkIndexerItem{
+				Action:     "index",
+				DocumentID: "42",
+			}},
+			want: `{"index":{"_id":"42"}}` + "\n",
+		},
+		{
+			name: "with _index",
+			args: args{BulkIndexerItem{
+				Action: "index",
+				Index:  testIndex,
+			}},
+			want: fmt.Sprintf(`{"index":{"_index":"%s"}}`, testIndex) + "\n",
+		},
+		{
+			name: "with _index and _id",
+			args: args{BulkIndexerItem{
+				Action:     "index",
+				DocumentID: "42",
+				Index:      testIndex,
+			}},
+			want: fmt.Sprintf(`{"index":{"_index":"%s","_id":"42"}}`, testIndex) + "\n",
+		},
+		{
+			name: "with if_seq_no and if_primary_term",
+			args: args{BulkIndexerItem{
+				Action:        "index",
+				DocumentID:    "42",
+				Index:         testIndex,
+				IfSeqNum:      int64Pointer(5),
+				IfPrimaryTerm: int64Pointer(1),
+			}},
+			want: fmt.Sprintf(`{"index":{"_index":"%s","_id":"42","if_seq_no":5,"if_primary_term":1}}`, testIndex) + "\n",
+		},
+		{
+			name: "with version and no document, if_seq_no, and if_primary_term",
+			args: args{BulkIndexerItem{
+				Action:  "index",
+				Index:   testIndex,
+				Version: int64Pointer(23),
+			}},
+			want: fmt.Sprintf(`{"index":{"_index":"%s"}}`, testIndex) + "\n",
+		},
+		{
+			name: "with version",
+			args: args{BulkIndexerItem{
+				Action:     "index",
+				DocumentID: "42",
+				Index:      testIndex,
+				Version:    int64Pointer(24),
+			}},
+			want: fmt.Sprintf(`{"index":{"_index":"%s","_id":"42","version":24}}`, testIndex) + "\n",
+		},
+		{
+			name: "with version and version_type",
+			args: args{BulkIndexerItem{
+				Action:      "index",
+				DocumentID:  "42",
+				Index:       testIndex,
+				Version:     int64Pointer(25),
+				VersionType: strPointer("external"),
+			}},
+			want: fmt.Sprintf(`{"index":{"_index":"%s","_id":"42","version":25,"version_type":"external"}}`, testIndex) + "\n",
+		},
+		{
+			name: "wait_for_active_shards",
+			args: args{BulkIndexerItem{
+				Action:              "index",
+				DocumentID:          "42",
+				Index:               testIndex,
+				Version:             int64Pointer(25),
+				VersionType:         strPointer("external"),
+				WaitForActiveShards: 1,
+			}},
+			want: fmt.Sprintf(`{"index":{"_index":"%s","_id":"42","version":25,"version_type":"external","wait_for_active_shards":1}}`, testIndex) + "\n",
+		},
+		{
+			name: "wait_for_active_shards, all",
+			args: args{BulkIndexerItem{
+				Action:              "index",
+				DocumentID:          "42",
+				Index:               testIndex,
+				Version:             int64Pointer(25),
+				VersionType:         strPointer("external"),
+				WaitForActiveShards: "all",
+			}},
+			want: fmt.Sprintf(`{"index":{"_index":"%s","_id":"42","version":25,"version_type":"external","wait_for_active_shards":"all"}}`, testIndex) + "\n",
+		},
+		{
+			name: "with retry_on_conflict",
+			args: args{BulkIndexerItem{
+				Action:          "index",
+				DocumentID:      "42",
+				Index:           testIndex,
+				Version:         int64Pointer(25),
+				VersionType:     strPointer("external"),
+				RetryOnConflict: intPointer(5),
+			}},
+			want: fmt.Sprintf(`{"index":{"_index":"%s","_id":"42","version":25,"version_type":"external","retry_on_conflict":5}}`, testIndex) + "\n",
+		},
+		{
+			name: "_id with angle brackets is not HTML-escaped",
+			args: args{BulkIndexerItem{
+				Action:     "index",
+				DocumentID: "prefix|<root_account>|suffix",
+				Index:      testIndex,
+			}},
+			want: fmt.Sprintf(`{"index":{"_index":"%s","_id":"prefix|<root_account>|suffix"}}`, testIndex) + "\n",
+		},
+		{
+			name: "_id with ampersand is not HTML-escaped",
+			args: args{BulkIndexerItem{
+				Action:     "index",
+				DocumentID: "foo&bar",
+				Index:      testIndex,
+			}},
+			want: fmt.Sprintf(`{"index":{"_index":"%s","_id":"foo&bar"}}`, testIndex) + "\n",
+		},
+		{
+			name: "encode error from unsupported value",
+			args: args{BulkIndexerItem{
+				Action:              "index",
+				DocumentID:          "1",
+				WaitForActiveShards: math.NaN(),
+			}},
+			wantErr: &json.UnsupportedValueError{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bi := &bulkIndexer{
+				metaPoolMaxBytes: defaultMetaBufferPoolMaxBytes,
+				metaPool: sync.Pool{
+					New: func() any { return new(bytes.Buffer) },
+				},
 			}
-		}
-		if !gotError {
-			t.Errorf("Expected timeout error, but none in: %q", errs)
-		}
-	})
-
-	t.Run("Close() Cancel", func(t *testing.T) {
-		client, _ := opensearchapi.NewClient(opensearchapi.Config{Client: opensearch.Config{Transport: &mockTransport{}}})
-		bi, _ := NewBulkIndexer(BulkIndexerConfig{
-			NumWorkers: 1,
-			FlushBytes: 1,
-			Client:     client,
+			w := &worker{
+				bi:  bi,
+				buf: bytes.NewBuffer(make([]byte, 0, 5e+6)),
+			}
+			err := w.writeMeta(tt.args.item)
+			if tt.wantErr != nil {
+				require.ErrorAs(t, err, &tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, w.buf.String())
 		})
+	}
+}
 
-		for range 10 {
-			bi.Add(context.Background(), BulkIndexerItem{Action: "foo"})
-		}
+func TestBulkIndexerLifecycle(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(t *testing.T) BulkIndexerStats
+		want BulkIndexerStats
+	}{
+		{
+			name: "3-batch sequential responses",
+			run: func(t *testing.T) BulkIndexerStats {
+				var (
+					wg        sync.WaitGroup
+					countReqs int
+					testfile  string
+				)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		if err := bi.Close(ctx); err == nil {
-			t.Errorf("Expected context canceled error, but got: %v", err)
-		}
-	})
-
-	t.Run("Indexer Callback", func(t *testing.T) {
-		config := opensearchapi.Config{
-			Client: opensearch.Config{
-				Transport: &mockTransport{
+				client, _ := opensearchapi.NewClient(opensearchapi.Config{Client: opensearch.Config{Transport: &mockTransport{
 					RoundTripFunc: func(request *http.Request) (*http.Response, error) {
 						if request.URL.Path == "/" {
-							return &http.Response{Body: io.NopCloser(strings.NewReader(infoBody))}, nil
-						}
-
-						return nil, fmt.Errorf("Mock transport error")
-					},
-				},
-			},
-		}
-		if testutil.IsDebugEnabled(t) {
-			config.Client.Logger = &opensearchtransport.ColorLogger{
-				Output:             os.Stdout,
-				EnableRequestBody:  true,
-				EnableResponseBody: true,
-			}
-		}
-
-		client, _ := opensearchapi.NewClient(config)
-
-		var (
-			expectedOnErrorCount = 1
-			indexerError         error
-			onErrorCount         int
-		)
-		biCfg := BulkIndexerConfig{
-			NumWorkers: 1,
-			Client:     client,
-			OnError: func(ctx context.Context, err error) {
-				onErrorCount++
-				indexerError = err
-			},
-		}
-		if testutil.IsDebugEnabled(t) {
-			biCfg.DebugLogger = log.New(os.Stdout, "", 0)
-		}
-
-		bi, _ := NewBulkIndexer(biCfg)
-
-		if err := bi.Add(context.Background(), BulkIndexerItem{
-			Action: "foo",
-		}); err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
-
-		if err := bi.Close(context.Background()); err != nil {
-			t.Errorf("Unexpected error: %s", err)
-		}
-
-		if indexerError == nil {
-			t.Errorf("Expected indexerError to not be nil")
-		}
-
-		if onErrorCount != expectedOnErrorCount {
-			t.Errorf("Expected onErrorCount to be %d, got %d", expectedOnErrorCount, onErrorCount)
-		}
-	})
-
-	t.Run("Item Callbacks", func(t *testing.T) {
-		var (
-			countSuccessful      uint64
-			countFailed          uint64
-			failedIDs            []string
-			successfulItemBodies []string
-			failedItemBodies     []string
-
-			numItems             uint64 = 4
-			numFailed            uint64 = 2
-			bodyContent, _              = os.ReadFile("testdata/bulk_response_2.json")
-			bodyFailureCount            = make(map[string]int)
-			bodiesExpectedToFail        = map[string]struct{}{
-				`{"title":"bar"}`: {},
-				`{"title":"baz"}`: {},
-			}
-		)
-
-		client, _ := opensearchapi.NewClient(
-			opensearchapi.Config{
-				Client: opensearch.Config{
-					Transport: &mockTransport{
-						RoundTripFunc: func(request *http.Request) (*http.Response, error) {
-							if request.URL.Path == "/" {
-								return &http.Response{
-									StatusCode: http.StatusOK,
-									Status:     "200 OK",
-									Body:       io.NopCloser(strings.NewReader(infoBody)),
-									Header:     http.Header{"Content-Type": []string{"application/json"}},
-								}, nil
-							}
-
-							return &http.Response{Body: io.NopCloser(bytes.NewBuffer(bodyContent))}, nil
-						},
-					},
-				},
-			},
-		)
-
-		cfg := BulkIndexerConfig{NumWorkers: 1, Client: client}
-		if testutil.IsDebugEnabled(t) {
-			cfg.DebugLogger = log.New(os.Stdout, "", 0)
-		}
-
-		bi, _ := NewBulkIndexer(cfg)
-
-		successFunc := func(ctx context.Context, item BulkIndexerItem, res opensearchapi.BulkRespItem) {
-			atomic.AddUint64(&countSuccessful, 1)
-
-			buf, err := io.ReadAll(item.Body)
-			if err != nil {
-				t.Fatalf("Unexpected error: %s", err)
-			}
-			successfulItemBodies = append(successfulItemBodies, string(buf))
-		}
-
-		failureFunc := func(ctx context.Context, item BulkIndexerItem, res opensearchapi.BulkRespItem, err error) {
-			if err != nil {
-				t.Fatalf("Unexpected error: %s", err)
-			}
-
-			buf, err := io.ReadAll(item.Body)
-			if err != nil {
-				t.Fatalf("Unexpected error: %s", err)
-			}
-
-			countFailed++
-			failedIDs = append(failedIDs, item.DocumentID)
-			failedItemBodies = append(failedItemBodies, string(buf))
-			bodyFailureCount[string(buf)]++
-		}
-
-		if err := bi.Add(context.Background(), BulkIndexerItem{
-			Action:     "index",
-			DocumentID: "1",
-			Body:       strings.NewReader(`{"title":"foo"}`),
-			OnSuccess:  successFunc,
-			OnFailure:  failureFunc,
-		}); err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
-
-		if err := bi.Add(context.Background(), BulkIndexerItem{
-			Action:     "create",
-			DocumentID: "1",
-			Body:       strings.NewReader(`{"title":"bar"}`),
-			OnSuccess:  successFunc,
-			OnFailure:  failureFunc,
-		}); err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
-
-		if err := bi.Add(context.Background(), BulkIndexerItem{
-			Action:     "delete",
-			DocumentID: "2",
-			Body:       strings.NewReader(`{"title":"baz"}`),
-			OnSuccess:  successFunc,
-			OnFailure:  failureFunc,
-		}); err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
-
-		if err := bi.Add(context.Background(), BulkIndexerItem{
-			Action:     "update",
-			DocumentID: "3",
-			Body:       strings.NewReader(`{"doc":{"title":"qux"}}`),
-			OnSuccess:  successFunc,
-			OnFailure:  failureFunc,
-		}); err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
-
-		if err := bi.Close(context.Background()); err != nil {
-			t.Errorf("Unexpected error: %s", err)
-		}
-
-		stats := bi.Stats()
-
-		if stats.NumAdded != numItems {
-			t.Errorf("Unexpected NumAdded: %d", stats.NumAdded)
-		}
-
-		// Two failures are expected:
-		//
-		// * Operation #2: document can't be created, because a document with the same ID already exists.
-		// * Operation #3: document can't be deleted, because it doesn't exist.
-
-		if stats.NumFailed != uint64(len(bodyFailureCount)) {
-			t.Errorf("Expected %v items in the bodyFailureCount map, got %v", numFailed, len(bodyFailureCount))
-		}
-
-		for k, v := range bodyFailureCount {
-			if _, ok := bodiesExpectedToFail[k]; !ok {
-				t.Errorf("Unexpected item body failure: %v", k)
-			}
-			delete(bodiesExpectedToFail, k)
-
-			if v != 1 {
-				t.Errorf("Expected 1 failure callback call for item %v, got %v", k, v)
-			}
-		}
-
-		if len(bodiesExpectedToFail) > 0 {
-			t.Errorf("Expected failure callbacks for the following item bodies: %v", bodiesExpectedToFail)
-		}
-
-		if stats.NumFailed != numFailed {
-			t.Errorf("Unexpected NumFailed: %d", stats.NumFailed)
-		}
-
-		if stats.NumFlushed != 2 {
-			t.Errorf("Unexpected NumFailed: %d", stats.NumFailed)
-		}
-
-		if stats.NumIndexed != 1 {
-			t.Errorf("Unexpected NumIndexed: %d", stats.NumIndexed)
-		}
-
-		if stats.NumUpdated != 1 {
-			t.Errorf("Unexpected NumUpdated: %d", stats.NumUpdated)
-		}
-
-		if countSuccessful != numItems-numFailed {
-			t.Errorf("Unexpected countSuccessful: %d", countSuccessful)
-		}
-
-		if countFailed != numFailed {
-			t.Errorf("Unexpected countFailed: %d", countFailed)
-		}
-
-		if !reflect.DeepEqual(failedIDs, []string{"1", "2"}) {
-			t.Errorf("Unexpected failedIDs: %#v", failedIDs)
-		}
-
-		if !reflect.DeepEqual(successfulItemBodies, []string{`{"title":"foo"}`, `{"doc":{"title":"qux"}}`}) {
-			t.Errorf("Unexpected successfulItemBodies: %#v", successfulItemBodies)
-		}
-
-		if !reflect.DeepEqual(failedItemBodies, []string{`{"title":"bar"}`, `{"title":"baz"}`}) {
-			t.Errorf("Unexpected failedItemBodies: %#v", failedItemBodies)
-		}
-	})
-
-	t.Run("OnFlush callbacks", func(t *testing.T) {
-		type contextKey string
-		client, _ := opensearchapi.NewClient(opensearchapi.Config{Client: opensearch.Config{Transport: &mockTransport{}}})
-		flushIndex := testutil.MustUniqueString(t, "test-flush")
-		bi, _ := NewBulkIndexer(BulkIndexerConfig{
-			Client: client,
-			Index:  flushIndex,
-			OnFlushStart: func(ctx context.Context) context.Context {
-				t.Logf(">>> Flush started")
-				return context.WithValue(ctx, contextKey("start"), time.Now().UTC())
-			},
-			OnFlushEnd: func(ctx context.Context) {
-				var duration time.Duration
-				if v := ctx.Value("start"); v != nil {
-					duration = time.Since(v.(time.Time))
-				}
-				t.Logf(">>> Flush finished (duration: %s)", duration)
-			},
-		})
-
-		err := bi.Add(context.Background(), BulkIndexerItem{
-			Action: "index",
-			Body:   strings.NewReader(`{"title":"foo"}`),
-		})
-		if err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
-
-		if err := bi.Close(context.Background()); err != nil {
-			t.Errorf("Unexpected error: %s", err)
-		}
-
-		stats := bi.Stats()
-
-		if stats.NumAdded != uint64(1) {
-			t.Errorf("Unexpected NumAdded: %d", stats.NumAdded)
-		}
-	})
-
-	t.Run("Automatic flush", func(t *testing.T) {
-		client, _ := opensearchapi.NewClient(opensearchapi.Config{Client: opensearch.Config{Transport: &mockTransport{
-			RoundTripFunc: func(request *http.Request) (*http.Response, error) {
-				if request.URL.Path == "/" {
-					return &http.Response{
-						StatusCode: http.StatusOK,
-						Status:     "200 OK",
-						Body:       io.NopCloser(strings.NewReader(infoBody)),
-						Header:     http.Header{"Content-Type": []string{"application/json"}},
-					}, nil
-				}
-
-				return &http.Response{
-						StatusCode: http.StatusOK,
-						Status:     "200 OK",
-						Body:       io.NopCloser(strings.NewReader(`{"items":[{"index": {}}]}`)),
-					},
-					nil
-			},
-		}}})
-
-		cfg := BulkIndexerConfig{
-			NumWorkers:    1,
-			Client:        client,
-			FlushInterval: 50 * time.Millisecond, // Decrease the flush timeout
-		}
-		if testutil.IsDebugEnabled(t) {
-			cfg.DebugLogger = log.New(os.Stdout, "", 0)
-		}
-
-		bi, _ := NewBulkIndexer(cfg)
-
-		bi.Add(context.Background(),
-			BulkIndexerItem{Action: "index", Body: strings.NewReader(`{"title":"foo"}`)})
-
-		// Allow some time for auto-flush to kick in
-		time.Sleep(250 * time.Millisecond)
-
-		stats := bi.Stats()
-		expected := uint64(1)
-
-		if stats.NumAdded != expected {
-			t.Errorf("Unexpected NumAdded: want=%d, got=%d", expected, stats.NumAdded)
-		}
-
-		if stats.NumFailed != 0 {
-			t.Errorf("Unexpected NumFailed: want=%d, got=%d", 0, stats.NumFlushed)
-		}
-
-		if stats.NumFlushed != expected {
-			t.Errorf("Unexpected NumFlushed: want=%d, got=%d", expected, stats.NumFlushed)
-		}
-
-		if stats.NumIndexed != expected {
-			t.Errorf("Unexpected NumIndexed: want=%d, got=%d", expected, stats.NumIndexed)
-		}
-
-		// Wait some time before closing the indexer to clear the timer
-		time.Sleep(200 * time.Millisecond)
-		bi.Close(context.Background())
-	})
-
-	t.Run("TooManyRequests", func(t *testing.T) {
-		var (
-			wg sync.WaitGroup
-
-			countReqs int
-			numItems  uint64 = 2
-		)
-
-		cfg := opensearchapi.Config{
-			Client: opensearch.Config{
-				Transport: &mockTransport{
-					RoundTripFunc: func(request *http.Request) (*http.Response, error) {
-						if request.URL.Path == "/" {
-							return &http.Response{
-								StatusCode: http.StatusOK,
-								Status:     "200 OK",
-								Body:       io.NopCloser(strings.NewReader(infoBody)),
-								Header:     http.Header{"Content-Type": []string{"application/json"}},
-							}, nil
+							return infoResponse()
 						}
 
 						countReqs++
-						if countReqs <= 4 {
-							return &http.Response{
-									StatusCode: http.StatusTooManyRequests,
-									Status:     "429 TooManyRequests",
-									Body:       io.NopCloser(strings.NewReader(`{"took":1}`)),
-								},
-								nil
+						switch countReqs {
+						case 1:
+							testfile = "testdata/bulk_response_1a.json"
+						case 2:
+							testfile = "testdata/bulk_response_1b.json"
+						case 3:
+							testfile = "testdata/bulk_response_1c.json"
 						}
-						bodyContent, _ := os.ReadFile("testdata/bulk_response_1c.json")
+						bodyContent, _ := os.ReadFile(testfile)
+						return &http.Response{Body: io.NopCloser(bytes.NewBuffer(bodyContent))}, nil
+					},
+				}}})
+
+				cfg := BulkIndexerConfig{
+					NumWorkers:    1,
+					FlushBytes:    50,
+					FlushInterval: time.Hour,
+					Client:        client,
+				}
+				if testutil.IsDebugEnabled(t) {
+					cfg.DebugLogger = log.New(os.Stdout, "", 0)
+				}
+
+				bi, _ := NewBulkIndexer(cfg)
+
+				for i := 1; i <= 6; i++ {
+					wg.Add(1)
+					go func(i int) {
+						defer wg.Done()
+						err := bi.Add(context.Background(), BulkIndexerItem{
+							Action:     "foo",
+							DocumentID: strconv.Itoa(i),
+							Body:       strings.NewReader(fmt.Sprintf(`{"title":"foo-%d"}`, i)),
+						})
+						if err != nil {
+							t.Errorf("Unexpected error: %s", err)
+						}
+					}(i)
+				}
+				wg.Wait()
+
+				require.NoError(t, bi.Close(context.Background()))
+				return bi.Stats()
+			},
+			want: BulkIndexerStats{
+				NumAdded:    6,
+				NumFlushed:  4,
+				NumFailed:   2,
+				NumIndexed:  1,
+				NumCreated:  1,
+				NumDeleted:  1,
+				NumUpdated:  1,
+				NumRequests: 3,
+			},
+		},
+		{
+			name: "automatic flush on interval",
+			run: func(t *testing.T) BulkIndexerStats {
+				client, _ := opensearchapi.NewClient(opensearchapi.Config{Client: opensearch.Config{Transport: &mockTransport{
+					RoundTripFunc: func(request *http.Request) (*http.Response, error) {
+						if request.URL.Path == "/" {
+							return infoResponse()
+						}
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							Status:     "200 OK",
-							Body:       io.NopCloser(bytes.NewBuffer(bodyContent)),
+							Body:       io.NopCloser(strings.NewReader(`{"items":[{"index": {}}]}`)),
 						}, nil
 					},
-				},
+				}}})
 
-				MaxRetries:    5,
-				RetryOnStatus: []int{502, 503, 504, 429},
-				RetryBackoff: func(i int) time.Duration {
-					if testutil.IsDebugEnabled(t) {
-						t.Logf("*** Retry #%d", i)
-					}
-					return time.Duration(i) * 100 * time.Millisecond
-				},
-			},
-		}
-		if testutil.IsDebugEnabled(t) {
-			cfg.Client.Logger = &opensearchtransport.ColorLogger{Output: os.Stdout}
-		}
-		client, _ := opensearchapi.NewClient(cfg)
-
-		biCfg := BulkIndexerConfig{NumWorkers: 1, FlushBytes: 50, Client: client}
-		if testutil.IsDebugEnabled(t) {
-			biCfg.DebugLogger = log.New(os.Stdout, "", 0)
-		}
-
-		bi, _ := NewBulkIndexer(biCfg)
-
-		for i := 1; i <= int(numItems); i++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				err := bi.Add(context.Background(), BulkIndexerItem{
-					Action: "foo",
-					Body:   strings.NewReader(`{"title":"foo"}`),
-				})
-				if err != nil {
-					t.Errorf("Unexpected error: %s", err)
-					return
+				cfg := BulkIndexerConfig{
+					NumWorkers:    1,
+					Client:        client,
+					FlushInterval: 50 * time.Millisecond,
 				}
-			}()
-		}
-		wg.Wait()
+				if testutil.IsDebugEnabled(t) {
+					cfg.DebugLogger = log.New(os.Stdout, "", 0)
+				}
 
-		if err := bi.Close(context.Background()); err != nil {
-			t.Errorf("Unexpected error: %s", err)
-		}
+				bi, _ := NewBulkIndexer(cfg)
 
-		stats := bi.Stats()
+				bi.Add(context.Background(),
+					BulkIndexerItem{Action: "index", Body: strings.NewReader(`{"title":"foo"}`)})
 
-		if stats.NumAdded != numItems {
-			t.Errorf("Unexpected NumAdded: want=%d, got=%d", numItems, stats.NumAdded)
-		}
+				// Allow auto-flush to fire
+				time.Sleep(250 * time.Millisecond)
 
-		if stats.NumFlushed != numItems {
-			t.Errorf("Unexpected NumFlushed: want=%d, got=%d", numItems, stats.NumFlushed)
-		}
+				stats := bi.Stats()
 
-		if stats.NumFailed != 0 {
-			t.Errorf("Unexpected NumFailed: want=%d, got=%d", 0, stats.NumFailed)
-		}
+				// Clear the timer before closing
+				time.Sleep(200 * time.Millisecond)
+				bi.Close(context.Background())
 
-		// Stats don't include the retries in client
-		if stats.NumRequests != 1 {
-			t.Errorf("Unexpected NumRequests: want=%d, got=%d", 3, stats.NumRequests)
-		}
-	})
+				return stats
+			},
+			want: BulkIndexerStats{
+				NumAdded:    1,
+				NumFlushed:  1,
+				NumFailed:   0,
+				NumIndexed:  1,
+				NumRequests: 1,
+			},
+		},
+		{
+			name: "retry on 429 TooManyRequests",
+			run: func(t *testing.T) BulkIndexerStats {
+				var (
+					wg        sync.WaitGroup
+					countReqs int
+				)
 
-	t.Run("Worker.writeMeta()", func(t *testing.T) {
-		testIndex := testutil.MustUniqueString(t, "test-index")
+				cfg := opensearchapi.Config{
+					Client: opensearch.Config{
+						Transport: &mockTransport{
+							RoundTripFunc: func(request *http.Request) (*http.Response, error) {
+								if request.URL.Path == "/" {
+									return infoResponse()
+								}
 
-		type args struct {
-			item BulkIndexerItem
-		}
-		tests := []struct {
-			name    string
-			args    args
-			want    string
-			wantErr error
-		}{
-			{
-				name: "without _index and _id",
-				args: args{BulkIndexerItem{Action: "index"}},
-				want: `{"index":{}}` + "\n",
-			},
-			{
-				name: "with _id",
-				args: args{BulkIndexerItem{
-					Action:     "index",
-					DocumentID: "42",
-				}},
-				want: `{"index":{"_id":"42"}}` + "\n",
-			},
-			{
-				name: "with _index",
-				args: args{BulkIndexerItem{
-					Action: "index",
-					Index:  testIndex,
-				}},
-				want: fmt.Sprintf(`{"index":{"_index":"%s"}}`, testIndex) + "\n",
-			},
-			{
-				name: "with _index and _id",
-				args: args{BulkIndexerItem{
-					Action:     "index",
-					DocumentID: "42",
-					Index:      testIndex,
-				}},
-				want: fmt.Sprintf(`{"index":{"_index":"%s","_id":"42"}}`, testIndex) + "\n",
-			},
-			{
-				name: "with if_seq_no and if_primary_term",
-				args: args{BulkIndexerItem{
-					Action:        "index",
-					DocumentID:    "42",
-					Index:         testIndex,
-					IfSeqNum:      int64Pointer(5),
-					IfPrimaryTerm: int64Pointer(1),
-				}},
-				want: fmt.Sprintf(`{"index":{"_index":"%s","_id":"42","if_seq_no":5,"if_primary_term":1}}`, testIndex) + "\n",
-			},
-			{
-				name: "with version and no document, if_seq_no, and if_primary_term",
-				args: args{BulkIndexerItem{
-					Action:  "index",
-					Index:   testIndex,
-					Version: int64Pointer(23),
-				}},
-				want: fmt.Sprintf(`{"index":{"_index":"%s"}}`, testIndex) + "\n",
-			},
-			{
-				name: "with version",
-				args: args{BulkIndexerItem{
-					Action:     "index",
-					DocumentID: "42",
-					Index:      testIndex,
-					Version:    int64Pointer(24),
-				}},
-				want: fmt.Sprintf(`{"index":{"_index":"%s","_id":"42","version":24}}`, testIndex) + "\n",
-			},
-			{
-				name: "with version and version_type",
-				args: args{BulkIndexerItem{
-					Action:      "index",
-					DocumentID:  "42",
-					Index:       testIndex,
-					Version:     int64Pointer(25),
-					VersionType: strPointer("external"),
-				}},
-				want: fmt.Sprintf(`{"index":{"_index":"%s","_id":"42","version":25,"version_type":"external"}}`, testIndex) + "\n",
-			},
-			{
-				name: "wait_for_active_shards",
-				args: args{BulkIndexerItem{
-					Action:              "index",
-					DocumentID:          "42",
-					Index:               testIndex,
-					Version:             int64Pointer(25),
-					VersionType:         strPointer("external"),
-					WaitForActiveShards: 1,
-				}},
-				want: fmt.Sprintf(`{"index":{"_index":"%s","_id":"42","version":25,"version_type":"external","wait_for_active_shards":1}}`, testIndex) + "\n",
-			},
-			{
-				name: "wait_for_active_shards, all",
-				args: args{BulkIndexerItem{
-					Action:              "index",
-					DocumentID:          "42",
-					Index:               testIndex,
-					Version:             int64Pointer(25),
-					VersionType:         strPointer("external"),
-					WaitForActiveShards: "all",
-				}},
-				want: fmt.Sprintf(`{"index":{"_index":"%s","_id":"42","version":25,"version_type":"external","wait_for_active_shards":"all"}}`, testIndex) + "\n",
-			},
-			{
-				name: "with retry_on_conflict",
-				args: args{BulkIndexerItem{
-					Action:          "index",
-					DocumentID:      "42",
-					Index:           testIndex,
-					Version:         int64Pointer(25),
-					VersionType:     strPointer("external"),
-					RetryOnConflict: intPointer(5),
-				}},
-				want: fmt.Sprintf(`{"index":{"_index":"%s","_id":"42","version":25,"version_type":"external","retry_on_conflict":5}}`, testIndex) + "\n",
-			},
-			{
-				name: "_id with angle brackets is not HTML-escaped",
-				args: args{BulkIndexerItem{
-					Action:     "index",
-					DocumentID: "prefix|<root_account>|suffix",
-					Index:      testIndex,
-				}},
-				want: fmt.Sprintf(`{"index":{"_index":"%s","_id":"prefix|<root_account>|suffix"}}`, testIndex) + "\n",
-			},
-			{
-				name: "_id with ampersand is not HTML-escaped",
-				args: args{BulkIndexerItem{
-					Action:     "index",
-					DocumentID: "foo&bar",
-					Index:      testIndex,
-				}},
-				want: fmt.Sprintf(`{"index":{"_index":"%s","_id":"foo&bar"}}`, testIndex) + "\n",
-			},
-			{
-				name: "encode error from unsupported value",
-				args: args{BulkIndexerItem{
-					Action:              "index",
-					DocumentID:          "1",
-					WaitForActiveShards: math.NaN(),
-				}},
-				wantErr: &json.UnsupportedValueError{},
-			},
-		}
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				bi := &bulkIndexer{
-					metaPoolMaxBytes: defaultMetaBufferPoolMaxBytes,
-					metaPool: sync.Pool{
-						New: func() any { return new(bytes.Buffer) },
+								countReqs++
+								if countReqs <= 4 {
+									return &http.Response{
+										StatusCode: http.StatusTooManyRequests,
+										Status:     "429 TooManyRequests",
+										Body:       io.NopCloser(strings.NewReader(`{"took":1}`)),
+									}, nil
+								}
+								bodyContent, _ := os.ReadFile("testdata/bulk_response_1c.json")
+								return &http.Response{
+									StatusCode: http.StatusOK,
+									Status:     "200 OK",
+									Body:       io.NopCloser(bytes.NewBuffer(bodyContent)),
+								}, nil
+							},
+						},
+
+						MaxRetries:    5,
+						RetryOnStatus: []int{502, 503, 504, 429},
+						RetryBackoff: func(i int) time.Duration {
+							if testutil.IsDebugEnabled(t) {
+								t.Logf("*** Retry #%d", i)
+							}
+							return time.Duration(i) * 100 * time.Millisecond
+						},
 					},
 				}
-				w := &worker{
-					bi:  bi,
-					buf: bytes.NewBuffer(make([]byte, 0, 5e+6)),
+				if testutil.IsDebugEnabled(t) {
+					cfg.Client.Logger = &opensearchtransport.ColorLogger{Output: os.Stdout}
 				}
-				err := w.writeMeta(tt.args.item)
-				if tt.wantErr != nil {
-					require.ErrorAs(t, err, &tt.wantErr)
-					return
+				client, _ := opensearchapi.NewClient(cfg)
+
+				biCfg := BulkIndexerConfig{NumWorkers: 1, FlushBytes: 50, Client: client}
+				if testutil.IsDebugEnabled(t) {
+					biCfg.DebugLogger = log.New(os.Stdout, "", 0)
 				}
-				require.NoError(t, err)
-				require.Equal(t, tt.want, w.buf.String())
-			})
-		}
-	})
 
-	t.Run("Items Failure Callbacks Executed On Bulk Failure", func(t *testing.T) {
-		var (
-			numItems          uint64 = 5
-			idsExpectedToFail        = make(map[string]struct{}, numItems)
-			idsFailureCount          = make(map[string]int)
+				bi, _ := NewBulkIndexer(biCfg)
 
-			onErrorCallCount uint64
-			wg               sync.WaitGroup
-		)
+				for i := 1; i <= 2; i++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						err := bi.Add(context.Background(), BulkIndexerItem{
+							Action: "foo",
+							Body:   strings.NewReader(`{"title":"foo"}`),
+						})
+						if err != nil {
+							t.Errorf("Unexpected error: %s", err)
+						}
+					}()
+				}
+				wg.Wait()
 
-		// if the test takes more than 5 seconds, it's a failure. Want to avoid infinitely waiting for the waitgroup in
-		// the edge case where a failure callback is not executed.
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
+				require.NoError(t, bi.Close(context.Background()))
+				return bi.Stats()
+			},
+			want: BulkIndexerStats{
+				NumAdded:    2,
+				NumFlushed:  2,
+				NumFailed:   0,
+				NumDeleted:  1,
+				NumUpdated:  1,
+				NumRequests: 1,
+			},
+		},
+	}
 
-		client, _ := opensearchapi.NewClient(opensearchapi.Config{
-			Client: opensearch.Config{
-				Transport: &mockTransport{
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.run(t)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBulkIndexerContext(t *testing.T) {
+	tests := []struct {
+		name  string
+		run   func(t *testing.T)
+	}{
+		{
+			name: "Add returns error on expired context",
+			run: func(t *testing.T) {
+				client, _ := opensearchapi.NewClient(opensearchapi.Config{Client: opensearch.Config{Transport: &mockTransport{}}})
+				bi, _ := NewBulkIndexer(BulkIndexerConfig{NumWorkers: 1, Client: client})
+				ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+				defer cancel()
+				time.Sleep(100 * time.Millisecond)
+
+				const numAttempts = 10
+				errs := make([]error, 0, numAttempts)
+				for range numAttempts {
+					errs = append(errs, bi.Add(ctx, BulkIndexerItem{Action: "delete", DocumentID: "timeout"}))
+				}
+				require.NoError(t, bi.Close(context.Background()))
+
+				var gotDeadline bool
+				for _, err := range errs {
+					if errors.Is(err, context.DeadlineExceeded) {
+						gotDeadline = true
+					}
+				}
+				require.True(t, gotDeadline, "expected at least one context.DeadlineExceeded in: %q", errs)
+			},
+		},
+		{
+			name: "Close returns error on cancelled context",
+			run: func(t *testing.T) {
+				client, _ := opensearchapi.NewClient(opensearchapi.Config{Client: opensearch.Config{Transport: &mockTransport{}}})
+				bi, _ := NewBulkIndexer(BulkIndexerConfig{
+					NumWorkers: 1,
+					FlushBytes: 1,
+					Client:     client,
+				})
+
+				for range 10 {
+					bi.Add(context.Background(), BulkIndexerItem{Action: "foo"})
+				}
+
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				require.Error(t, bi.Close(ctx))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.run(t)
+		})
+	}
+}
+
+func TestBulkIndexerCallbacks(t *testing.T) {
+	tests := []struct {
+		name  string
+		run   func(t *testing.T)
+	}{
+		{
+			name: "OnError called on transport failure",
+			run: func(t *testing.T) {
+				config := opensearchapi.Config{
+					Client: opensearch.Config{
+						Transport: &mockTransport{
+							RoundTripFunc: func(request *http.Request) (*http.Response, error) {
+								if request.URL.Path == "/" {
+									return &http.Response{Body: io.NopCloser(strings.NewReader(infoBody))}, nil
+								}
+								return nil, fmt.Errorf("Mock transport error")
+							},
+						},
+					},
+				}
+				if testutil.IsDebugEnabled(t) {
+					config.Client.Logger = &opensearchtransport.ColorLogger{
+						Output:             os.Stdout,
+						EnableRequestBody:  true,
+						EnableResponseBody: true,
+					}
+				}
+				client, _ := opensearchapi.NewClient(config)
+
+				var (
+					indexerError error
+					onErrorCount int
+				)
+				biCfg := BulkIndexerConfig{
+					NumWorkers: 1,
+					Client:     client,
+					OnError: func(ctx context.Context, err error) {
+						onErrorCount++
+						indexerError = err
+					},
+				}
+				if testutil.IsDebugEnabled(t) {
+					biCfg.DebugLogger = log.New(os.Stdout, "", 0)
+				}
+
+				bi, _ := NewBulkIndexer(biCfg)
+
+				require.NoError(t, bi.Add(context.Background(), BulkIndexerItem{Action: "foo"}))
+				require.NoError(t, bi.Close(context.Background()))
+
+				require.NotNil(t, indexerError, "expected indexer OnError to be called")
+				require.Equal(t, 1, onErrorCount, "OnError call count")
+			},
+		},
+		{
+			name: "per-item OnSuccess and OnFailure",
+			run: func(t *testing.T) {
+				var (
+					countSuccessful      uint64
+					countFailed          uint64
+					failedIDs            []string
+					successfulItemBodies []string
+					failedItemBodies     []string
+
+					bodyFailureCount     = make(map[string]int)
+					bodiesExpectedToFail = map[string]struct{}{
+						`{"title":"bar"}`: {},
+						`{"title":"baz"}`: {},
+					}
+				)
+
+				bodyContent, _ := os.ReadFile("testdata/bulk_response_2.json")
+				client, _ := opensearchapi.NewClient(
+					opensearchapi.Config{
+						Client: opensearch.Config{
+							Transport: &mockTransport{
+								RoundTripFunc: func(request *http.Request) (*http.Response, error) {
+									if request.URL.Path == "/" {
+										return infoResponse()
+									}
+									return &http.Response{Body: io.NopCloser(bytes.NewBuffer(bodyContent))}, nil
+								},
+							},
+						},
+					},
+				)
+
+				cfg := BulkIndexerConfig{NumWorkers: 1, Client: client}
+				if testutil.IsDebugEnabled(t) {
+					cfg.DebugLogger = log.New(os.Stdout, "", 0)
+				}
+				bi, _ := NewBulkIndexer(cfg)
+
+				successFunc := func(ctx context.Context, item BulkIndexerItem, res opensearchapi.BulkRespItem) {
+					atomic.AddUint64(&countSuccessful, 1)
+					buf, err := io.ReadAll(item.Body)
+					if err != nil {
+						t.Fatalf("Unexpected error: %s", err)
+					}
+					successfulItemBodies = append(successfulItemBodies, string(buf))
+				}
+
+				failureFunc := func(ctx context.Context, item BulkIndexerItem, res opensearchapi.BulkRespItem, err error) {
+					if err != nil {
+						t.Fatalf("Unexpected error: %s", err)
+					}
+					buf, err := io.ReadAll(item.Body)
+					if err != nil {
+						t.Fatalf("Unexpected error: %s", err)
+					}
+					countFailed++
+					failedIDs = append(failedIDs, item.DocumentID)
+					failedItemBodies = append(failedItemBodies, string(buf))
+					bodyFailureCount[string(buf)]++
+				}
+
+				require.NoError(t, bi.Add(context.Background(), BulkIndexerItem{
+					Action: "index", DocumentID: "1",
+					Body: strings.NewReader(`{"title":"foo"}`), OnSuccess: successFunc, OnFailure: failureFunc,
+				}))
+				require.NoError(t, bi.Add(context.Background(), BulkIndexerItem{
+					Action: "create", DocumentID: "1",
+					Body: strings.NewReader(`{"title":"bar"}`), OnSuccess: successFunc, OnFailure: failureFunc,
+				}))
+				require.NoError(t, bi.Add(context.Background(), BulkIndexerItem{
+					Action: "delete", DocumentID: "2",
+					Body: strings.NewReader(`{"title":"baz"}`), OnSuccess: successFunc, OnFailure: failureFunc,
+				}))
+				require.NoError(t, bi.Add(context.Background(), BulkIndexerItem{
+					Action: "update", DocumentID: "3",
+					Body: strings.NewReader(`{"doc":{"title":"qux"}}`), OnSuccess: successFunc, OnFailure: failureFunc,
+				}))
+
+				require.NoError(t, bi.Close(context.Background()))
+
+				stats := bi.Stats()
+
+				require.Equal(t, uint64(4), stats.NumAdded, "NumAdded")
+				require.Equal(t, uint64(2), stats.NumFailed, "NumFailed")
+				require.Equal(t, uint64(2), stats.NumFlushed, "NumFlushed")
+				require.Equal(t, uint64(1), stats.NumIndexed, "NumIndexed")
+				require.Equal(t, uint64(1), stats.NumUpdated, "NumUpdated")
+				require.Equal(t, uint64(2), countSuccessful, "countSuccessful")
+				require.Equal(t, uint64(2), countFailed, "countFailed")
+
+				require.Equal(t, stats.NumFailed, uint64(len(bodyFailureCount)), "bodyFailureCount length")
+				for k, v := range bodyFailureCount {
+					_, ok := bodiesExpectedToFail[k]
+					require.True(t, ok, "unexpected item body failure: %v", k)
+					delete(bodiesExpectedToFail, k)
+					require.Equal(t, 1, v, "failure callback count for item %v", k)
+				}
+				require.Empty(t, bodiesExpectedToFail, "missing failure callbacks for item bodies")
+
+				require.Equal(t, []string{"1", "2"}, failedIDs)
+				require.Equal(t, []string{`{"title":"foo"}`, `{"doc":{"title":"qux"}}`}, successfulItemBodies)
+				require.Equal(t, []string{`{"title":"bar"}`, `{"title":"baz"}`}, failedItemBodies)
+			},
+		},
+		{
+			name: "OnFlushStart and OnFlushEnd",
+			run: func(t *testing.T) {
+				type contextKey string
+				client, _ := opensearchapi.NewClient(opensearchapi.Config{Client: opensearch.Config{Transport: &mockTransport{
 					RoundTripFunc: func(request *http.Request) (*http.Response, error) {
 						if request.URL.Path == "/" {
-							return &http.Response{
-								StatusCode: http.StatusOK,
-								Status:     "200 OK",
-								Body:       io.NopCloser(strings.NewReader(infoBody)),
-								Header:     http.Header{"Content-Type": []string{"application/json"}},
-							}, nil
+							return infoResponse()
 						}
-
-						return nil, errors.New("simulated bulk request error")
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Status:     "200 OK",
+							Body:       io.NopCloser(strings.NewReader(`{"items":[{"index":{}}]}`)),
+						}, nil
 					},
-				},
-			},
-		})
+				}}})
+				flushIndex := testutil.MustUniqueString(t, "test-flush")
 
-		bi, _ := NewBulkIndexer(BulkIndexerConfig{
-			NumWorkers: 1,
-			FlushBytes: 1,
-			Client:     client,
-			OnError: func(ctx context.Context, err error) {
-				onErrorCallCount++
-				if err.Error() != "flush: simulated bulk request error" {
-					t.Errorf("Unexpected error: %v", err)
+				var flushDuration time.Duration
+				bi, _ := NewBulkIndexer(BulkIndexerConfig{
+					Client: client,
+					Index:  flushIndex,
+					OnFlushStart: func(ctx context.Context) context.Context {
+						return context.WithValue(ctx, contextKey("start"), time.Now().UTC())
+					},
+					OnFlushEnd: func(ctx context.Context) {
+						if v := ctx.Value(contextKey("start")); v != nil {
+							flushDuration = time.Since(v.(time.Time))
+						}
+					},
+				})
+
+				require.NoError(t, bi.Add(context.Background(), BulkIndexerItem{
+					Action: "index",
+					Body:   strings.NewReader(`{"title":"foo"}`),
+				}))
+				require.NoError(t, bi.Close(context.Background()))
+
+				require.Equal(t, uint64(1), bi.Stats().NumAdded, "NumAdded")
+				require.NotZero(t, flushDuration, "OnFlushEnd should have observed the start time set by OnFlushStart")
+			},
+		},
+		{
+			name: "per-item OnFailure on bulk request error",
+			run: func(t *testing.T) {
+				var (
+					numItems          uint64 = 5
+					idsExpectedToFail        = make(map[string]struct{}, numItems)
+					idsFailureCount          = make(map[string]int)
+
+					onErrorCallCount uint64
+					wg               sync.WaitGroup
+				)
+
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+
+				client, _ := opensearchapi.NewClient(opensearchapi.Config{
+					Client: opensearch.Config{
+						Transport: &mockTransport{
+							RoundTripFunc: func(request *http.Request) (*http.Response, error) {
+								if request.URL.Path == "/" {
+									return infoResponse()
+								}
+								return nil, errors.New("simulated bulk request error")
+							},
+						},
+					},
+					})
+
+
+				bi, _ := NewBulkIndexer(BulkIndexerConfig{
+					NumWorkers: 1,
+					FlushBytes: 1,
+					Client:     client,
+					OnError: func(ctx context.Context, err error) {
+						onErrorCallCount++
+						if err.Error() != "flush: simulated bulk request error" {
+							t.Errorf("Unexpected error: %v", err)
+						}
+					},
+				})
+
+				wg.Add(int(numItems))
+				for i := 0; i < int(numItems); i++ {
+					id := fmt.Sprintf("id_%d", i)
+					idsExpectedToFail[id] = struct{}{}
+					require.NoError(t, bi.Add(ctx, BulkIndexerItem{
+						Action:     "index",
+						DocumentID: id,
+						Body:       strings.NewReader(fmt.Sprintf(`{"title":"doc_%d"}`, i)),
+						OnFailure: func(ctx context.Context, item BulkIndexerItem, resp opensearchapi.BulkRespItem, err error) {
+							if err.Error() != "flush: simulated bulk request error" {
+								t.Errorf("Unexpected error in OnFailure: %v", err)
+							}
+							idsFailureCount[item.DocumentID]++
+							wg.Done()
+						},
+					}))
 				}
+
+				require.NoError(t, bi.Close(ctx))
+				wg.Wait()
+
+				stats := bi.Stats()
+
+				require.Equal(t, numItems, onErrorCallCount, "OnError call count")
+				require.Equal(t, numItems, stats.NumFailed, "NumFailed")
+				require.Equal(t, int(numItems), len(idsFailureCount), "idsFailureCount length")
+
+				for k, v := range idsFailureCount {
+					_, ok := idsExpectedToFail[k]
+					require.True(t, ok, "unexpected item ID failure: %v", k)
+					delete(idsExpectedToFail, k)
+					require.Equal(t, 1, v, "failure callback count for item %v", k)
+				}
+				require.Empty(t, idsExpectedToFail, "missing failure callbacks for item IDs")
 			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.run(t)
 		})
-
-		wg.Add(int(numItems))
-		for i := 0; i < int(numItems); i++ {
-			id := fmt.Sprintf("id_%d", i)
-			idsExpectedToFail[id] = struct{}{}
-			if err := bi.Add(ctx, BulkIndexerItem{
-				Action:     "index",
-				DocumentID: id,
-				Body:       strings.NewReader(fmt.Sprintf(`{"title":"doc_%d"}`, i)),
-				OnFailure: func(ctx context.Context, item BulkIndexerItem, resp opensearchapi.BulkRespItem, err error) {
-					if err.Error() != "flush: simulated bulk request error" {
-						t.Errorf("Unexpected error in OnFailure: %v", err)
-					}
-
-					idsFailureCount[item.DocumentID]++
-					wg.Done()
-				},
-			}); err != nil {
-				t.Fatalf("Unexpected error adding item: %v", err)
-			}
-		}
-
-		if err := bi.Close(ctx); err != nil {
-			t.Errorf("Unexpected error: %s", err)
-		}
-
-		wg.Wait()
-
-		if onErrorCallCount != numItems {
-			t.Errorf("Expected %d calls to OnError, got %d", numItems, onErrorCallCount)
-		}
-
-		stats := bi.Stats()
-		if stats.NumFailed != uint64(len(idsFailureCount)) {
-			t.Errorf("Expected %d items in the idsFailureCount map, got %d", numItems, len(idsFailureCount))
-		}
-
-		for k, v := range idsFailureCount {
-			if _, ok := idsExpectedToFail[k]; !ok {
-				t.Errorf("Unexpected item ID failure: %v", k)
-			}
-			delete(idsExpectedToFail, k)
-
-			if v != 1 {
-				t.Errorf("Expected 1 failure callback call for item %v, got %v", k, v)
-			}
-		}
-
-		if len(idsExpectedToFail) > 0 {
-			t.Errorf("Expected failure callbacks for the following item IDs: %v", idsExpectedToFail)
-		}
-
-		if stats.NumFailed != numItems {
-			t.Errorf("Expected NumFailed to be %d, got %d", numItems, stats.NumFailed)
-		}
-	})
+	}
 }
 
 func strPointer(s string) *string {

--- a/opensearchutil/bulk_indexer_internal_test.go
+++ b/opensearchutil/bulk_indexer_internal_test.go
@@ -708,16 +708,16 @@ func TestBulkIndexerCallbacks(t *testing.T) {
 				}}})
 				flushIndex := testutil.MustUniqueString(t, "test-flush")
 
-				var flushDuration time.Duration
+				var flushEndCalled bool
 				bi, _ := NewBulkIndexer(BulkIndexerConfig{
 					Client: client,
 					Index:  flushIndex,
 					OnFlushStart: func(ctx context.Context) context.Context {
-						return context.WithValue(ctx, contextKey("start"), time.Now().UTC())
+						return context.WithValue(ctx, contextKey("flushing"), true)
 					},
 					OnFlushEnd: func(ctx context.Context) {
-						if v := ctx.Value(contextKey("start")); v != nil {
-							flushDuration = time.Since(v.(time.Time))
+						if v, ok := ctx.Value(contextKey("flushing")).(bool); ok && v {
+							flushEndCalled = true
 						}
 					},
 				})
@@ -729,7 +729,7 @@ func TestBulkIndexerCallbacks(t *testing.T) {
 				require.NoError(t, bi.Close(context.Background()))
 
 				require.Equal(t, uint64(1), bi.Stats().NumAdded, "NumAdded")
-				require.NotZero(t, flushDuration, "OnFlushEnd should have observed the start time set by OnFlushStart")
+				require.True(t, flushEndCalled, "OnFlushEnd should have been called with the context from OnFlushStart")
 			},
 		},
 		{


### PR DESCRIPTION
Add `Status` (`json.RawMessage`) to `TasksGetResp`, `TasksListTask`, and `TaskCancelInfo` to capture task-type-specific status data without silently dropping fields for non-bulk-by-scroll task types.

Provide `BulkByScrollTaskStatus` convenience type and `ParseBulkByScrollTaskStatus` helper for the common `reindex`, `delete_by_query`, and `update_by_query` case.

Add tasks guide, sample, and integration test assertions.

Resolves #788

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
