### PR TITLE
Fix pool replacement orphaning resurrection goroutines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
+- Fix pool replacement orphaning resurrection goroutines during node discovery, causing connections to become permanently dead with no active health checker ([#786](https://github.com/opensearch-project/opensearch-go/pull/786))
+- Extract `newMultiServerPoolFromClientWithLock` as single source of truth for Client-to-pool settings propagation ([#786](https://github.com/opensearch-project/opensearch-go/pull/786))
 - Fix discovery pool wipe when all cluster nodes time out during `/_nodes/http` fan-out: parse `_nodes` metadata envelope and return `errDiscoveryEmpty` when `successful == 0`, preserving the existing connection pool for retry ([#821](https://github.com/opensearch-project/opensearch-go/pull/821))
 - Fix flaky `TestDefaultHealthCheck_RetryAfterMaxRetry`: replace wall-clock `time.Sleep` + `atomic.Int64` synchronization with context cancellation (`ctx.Done()`), and widen `maxRetryClusterHealth` to 5s so the baseline HTTP round-trip cannot race past the retry interval ([#787](https://github.com/opensearch-project/opensearch-go/pull/787))
 - Fix connection lifecycle bug in multiServerPool.OnFailure where connections were scheduled for resurrection before being moved from ready to dead list, causing potential race conditions

--- a/opensearchtransport/discovery.go
+++ b/opensearchtransport/discovery.go
@@ -852,8 +852,8 @@ func (c *Client) createOrUpdateSingleNodePool(readyConnections, deadConnections 
 
 	// Preserve metrics from existing single connection pool
 	var metrics *metrics
-	if existingPool, ok := c.mu.connectionPool.(*singleServerPool); ok {
-		metrics = existingPool.metrics
+	if existingSinglePool, ok := c.mu.connectionPool.(*singleServerPool); ok {
+		metrics = existingSinglePool.metrics
 	}
 
 	return &singleServerPool{
@@ -893,37 +893,6 @@ func (c *Client) createOrUpdateMultiNodePoolWithLock(readyConnections, deadConne
 		allDeadConns = append(allDeadConns, conn)
 	}
 
-	// Preserve settings and metrics from existing multiServerPool,
-	// or use client-configured settings for new pools
-	resurrectTimeoutInitial := c.resurrectTimeoutInitial
-	resurrectTimeoutMax := c.resurrectTimeoutMax
-	resurrectTimeoutFactorCutoff := c.resurrectTimeoutFactorCutoff
-	minimumResurrectTimeout := c.minimumResurrectTimeout
-	jitterScale := c.jitterScale
-	serverMaxNewConnsPerSec := c.serverMaxNewConnsPerSec
-	clientsPerServer := c.clientsPerServer
-	healthCheck := c.healthCheck
-	activeListCap := c.activeListCap
-	activeListCapConfig := c.activeListCapConfig
-	standbyPromotionChecks := c.standbyPromotionChecks
-	var metrics *metrics
-
-	if existingPool, ok := c.mu.connectionPool.(*multiServerPool); ok {
-		// Preserve settings from existing pool (should match client settings)
-		resurrectTimeoutInitial = existingPool.resurrectTimeoutInitial
-		resurrectTimeoutMax = existingPool.resurrectTimeoutMax
-		resurrectTimeoutFactorCutoff = existingPool.resurrectTimeoutFactorCutoff
-		minimumResurrectTimeout = existingPool.minimumResurrectTimeout
-		jitterScale = existingPool.jitterScale
-		serverMaxNewConnsPerSec = existingPool.serverMaxNewConnsPerSec
-		clientsPerServer = existingPool.clientsPerServer
-		healthCheck = existingPool.healthCheck
-		activeListCap = existingPool.activeListCap
-		activeListCapConfig = existingPool.activeListCapConfig
-		standbyPromotionChecks = existingPool.standbyPromotionChecks
-		metrics = existingPool.metrics
-	}
-
 	// Shuffle connections for load distribution unless disabled
 	if !c.skipConnectionShuffle && len(allReadyConns) > 1 {
 		rand.Shuffle(len(allReadyConns), func(i, j int) {
@@ -931,30 +900,39 @@ func (c *Client) createOrUpdateMultiNodePoolWithLock(readyConnections, deadConne
 		})
 	}
 
-	allConnsPool := &multiServerPool{
-		name:                         "allConns",
-		ctx:                          c.ctx,
-		resurrectTimeoutInitial:      resurrectTimeoutInitial,
-		resurrectTimeoutMax:          resurrectTimeoutMax,
-		resurrectTimeoutFactorCutoff: resurrectTimeoutFactorCutoff,
-		minimumResurrectTimeout:      minimumResurrectTimeout,
-		jitterScale:                  jitterScale,
-		serverMaxNewConnsPerSec:      serverMaxNewConnsPerSec,
-		clientsPerServer:             clientsPerServer,
-		healthCheck:                  healthCheck,
-		metrics:                      metrics,
-		activeListCap:                activeListCap,
-		activeListCapConfig:          activeListCapConfig,
-		standbyPromotionChecks:       standbyPromotionChecks,
-	}
-	allConnsPool.mu.ready = allReadyConns
-	allConnsPool.mu.members = make(map[*Connection]struct{}, max(len(allReadyConns)+len(allDeadConns), defaultMembersCapacity))
-	for _, conn := range allReadyConns {
-		allConnsPool.mu.members[conn] = struct{}{}
-	}
-	for _, conn := range allDeadConns {
-		allConnsPool.mu.members[conn] = struct{}{}
-		allConnsPool.appendToDeadWithLock(conn)
+	// Reuse the existing multiServerPool when possible. Updating in-place
+	// preserves the pool pointer that resurrection goroutines captured via
+	// scheduleResurrect's `cp` parameter. If we created a new pool, those
+	// goroutines would find their connection absent from the old pool's
+	// dead list (stillInPool check) and exit, orphaning the connection
+	// with no health check goroutine.
+	var allConnsPool *multiServerPool
+	if existingMultiPool, ok := c.mu.connectionPool.(*multiServerPool); ok {
+		allConnsPool = existingMultiPool
+
+		allConnsPool.mu.Lock()
+		allConnsPool.mu.ready = allReadyConns
+		allConnsPool.mu.dead = nil
+		allConnsPool.mu.members = make(map[*Connection]struct{}, max(len(allReadyConns)+len(allDeadConns), defaultMembersCapacity))
+		for _, conn := range allReadyConns {
+			allConnsPool.mu.members[conn] = struct{}{}
+		}
+		for _, conn := range allDeadConns {
+			allConnsPool.mu.members[conn] = struct{}{}
+			allConnsPool.appendToDeadWithLock(conn)
+		}
+		allConnsPool.mu.Unlock()
+	} else {
+		allConnsPool = c.newMultiServerPoolFromClientWithLock("allConns", nil)
+		allConnsPool.mu.ready = allReadyConns
+		allConnsPool.mu.members = make(map[*Connection]struct{}, max(len(allReadyConns)+len(allDeadConns), defaultMembersCapacity))
+		for _, conn := range allReadyConns {
+			allConnsPool.mu.members[conn] = struct{}{}
+		}
+		for _, conn := range allDeadConns {
+			allConnsPool.mu.members[conn] = struct{}{}
+			allConnsPool.appendToDeadWithLock(conn)
+		}
 	}
 
 	// Recalculate activeListCap and warmup parameters for the allConns pool before

--- a/opensearchtransport/opensearchtransport.go
+++ b/opensearchtransport/opensearchtransport.go
@@ -2220,6 +2220,39 @@ func initUserAgent() string {
 	return b.String()
 }
 
+// newMultiServerPoolFromClientWithLock creates a multiServerPool initialized
+// with the client's current settings (timeouts, health check, cap, etc.). The
+// pool's mu-protected fields (ready, dead, members, activeCount) are left at
+// zero values — the caller is responsible for populating them.
+//
+// This is the single source of truth for client → pool settings propagation.
+// Used by promoteConnectionPoolWithLock (single→multi promotion) and
+// createOrUpdateMultiNodePoolWithLock (first multi-node discovery).
+//
+// Caller must hold c.mu.Lock().
+func (c *Client) newMultiServerPoolFromClientWithLock(name string, m *metrics) *multiServerPool {
+	pool := &multiServerPool{
+		name:                         name,
+		ctx:                          c.ctx,
+		resurrectTimeoutInitial:      c.resurrectTimeoutInitial,
+		resurrectTimeoutMax:          c.resurrectTimeoutMax,
+		resurrectTimeoutFactorCutoff: c.resurrectTimeoutFactorCutoff,
+		minimumResurrectTimeout:      c.minimumResurrectTimeout,
+		jitterScale:                  c.jitterScale,
+		serverMaxNewConnsPerSec:      c.serverMaxNewConnsPerSec,
+		clientsPerServer:             c.clientsPerServer,
+		healthCheck:                  c.healthCheck,
+		metrics:                      m,
+		activeListCap:                c.activeListCap,
+		activeListCapConfig:          c.activeListCapConfig,
+		standbyPromotionChecks:       c.standbyPromotionChecks,
+	}
+	if obs := c.observer.Load(); obs != nil {
+		pool.observer.Store(obs)
+	}
+	return pool
+}
+
 // promoteConnectionPoolWithLock converts a singleServerPool to multiServerPool while preserving
 // metrics, timeout settings, and client configuration. MUST be called while holding client write lock.
 // Returns existing pool unchanged if already a multiServerPool.
@@ -2227,8 +2260,6 @@ func (c *Client) promoteConnectionPoolWithLock(readyConnections, deadConnections
 	switch currentPool := c.mu.connectionPool.(type) {
 	case *singleServerPool:
 		// Promote from single to multi-node pool using client-configured timeouts
-		metrics := currentPool.metrics
-
 		filteredReady := make([]*Connection, 0, len(readyConnections))
 		filteredDead := make([]*Connection, 0, len(deadConnections))
 		c.applyConnectionFiltering(readyConnections, deadConnections, &filteredReady, &filteredDead)
@@ -2240,25 +2271,7 @@ func (c *Client) promoteConnectionPoolWithLock(readyConnections, deadConnections
 			})
 		}
 
-		// Use client-configured timeouts (from Config or defaults)
-		pool := &multiServerPool{
-			ctx:                          c.ctx,
-			resurrectTimeoutInitial:      c.resurrectTimeoutInitial,
-			resurrectTimeoutMax:          c.resurrectTimeoutMax,
-			resurrectTimeoutFactorCutoff: c.resurrectTimeoutFactorCutoff,
-			minimumResurrectTimeout:      c.minimumResurrectTimeout,
-			jitterScale:                  c.jitterScale,
-			serverMaxNewConnsPerSec:      c.serverMaxNewConnsPerSec,
-			clientsPerServer:             c.clientsPerServer,
-			healthCheck:                  c.healthCheck,
-			metrics:                      metrics,
-			activeListCap:                c.activeListCap,
-			activeListCapConfig:          c.activeListCapConfig,
-			standbyPromotionChecks:       c.standbyPromotionChecks,
-		}
-		if obs := c.observer.Load(); obs != nil {
-			pool.observer.Store(obs)
-		}
+		pool := c.newMultiServerPoolFromClientWithLock("allConns", currentPool.metrics)
 		pool.mu.ready = filteredReady
 		pool.mu.dead = filteredDead
 		pool.mu.members = make(map[*Connection]struct{}, max(len(filteredReady)+len(filteredDead), defaultMembersCapacity))

--- a/opensearchtransport/opensearchtransport_internal_test.go
+++ b/opensearchtransport/opensearchtransport_internal_test.go
@@ -1564,6 +1564,93 @@ func TestConnectionPoolPromotion(t *testing.T) {
 	})
 }
 
+func TestNewMultiServerPoolFromClientWithLock(t *testing.T) {
+	t.Run("copies all client settings to pool", func(t *testing.T) {
+		u, _ := url.Parse("http://localhost:9200")
+		client, err := New(Config{
+			URLs:                         []*url.URL{u},
+			EnableMetrics:                true,
+			ResurrectTimeoutInitial:      42 * time.Second,
+			ResurrectTimeoutMax:          300 * time.Second,
+			ResurrectTimeoutFactorCutoff: 7,
+			MinimumResurrectTimeout:      100 * time.Millisecond,
+			ActiveListCap:                3,
+			StandbyPromotionChecks:       5,
+		})
+		require.NoError(t, err)
+
+		client.mu.Lock()
+		pool := client.newMultiServerPoolFromClientWithLock("test-pool", client.metrics)
+		client.mu.Unlock()
+
+		require.Equal(t, "test-pool", pool.name)
+		require.Equal(t, 42*time.Second, pool.resurrectTimeoutInitial)
+		require.Equal(t, 300*time.Second, pool.resurrectTimeoutMax)
+		require.Equal(t, 7, pool.resurrectTimeoutFactorCutoff)
+		require.Equal(t, 100*time.Millisecond, pool.minimumResurrectTimeout)
+		require.Equal(t, 3, pool.activeListCap)
+		require.Equal(t, int64(5), pool.standbyPromotionChecks)
+		require.NotNil(t, pool.ctx, "pool should inherit client context")
+		require.NotNil(t, pool.healthCheck, "pool should inherit client health check")
+		require.Equal(t, client.metrics, pool.metrics, "pool should use provided metrics")
+	})
+
+	t.Run("nil metrics does not panic", func(t *testing.T) {
+		u, _ := url.Parse("http://localhost:9200")
+		client, err := New(Config{URLs: []*url.URL{u}})
+		require.NoError(t, err)
+
+		client.mu.Lock()
+		pool := client.newMultiServerPoolFromClientWithLock("nil-metrics", nil)
+		client.mu.Unlock()
+
+		require.Nil(t, pool.metrics)
+		require.NotNil(t, pool.ctx)
+	})
+
+	t.Run("observer is propagated", func(t *testing.T) {
+		u, _ := url.Parse("http://localhost:9200")
+		obs := &BaseConnectionObserver{}
+		client, err := New(Config{
+			URLs:     []*url.URL{u},
+			Observer: obs,
+		})
+		require.NoError(t, err)
+
+		client.mu.Lock()
+		pool := client.newMultiServerPoolFromClientWithLock("obs-pool", nil)
+		client.mu.Unlock()
+
+		stored := pool.observer.Load()
+		require.NotNil(t, stored, "observer should be propagated to pool")
+	})
+
+	t.Run("promote from singleServerPool preserves metrics via helper", func(t *testing.T) {
+		u, _ := url.Parse("http://localhost:9200")
+		client, err := New(Config{
+			URLs:          []*url.URL{u},
+			EnableMetrics: true,
+		})
+		require.NoError(t, err)
+
+		// Verify singleServerPool has metrics
+		singlePool, ok := client.mu.connectionPool.(*singleServerPool)
+		require.True(t, ok)
+		require.NotNil(t, singlePool.metrics)
+		originalMetrics := singlePool.metrics
+
+		client.mu.Lock()
+		newConn := &Connection{URL: &url.URL{Host: "new:9200"}, Name: "new-node"}
+		multiPool := client.promoteConnectionPoolWithLock([]*Connection{newConn}, []*Connection{})
+		client.mu.Unlock()
+
+		require.Equal(t, originalMetrics, multiPool.metrics,
+			"promotion should carry singleServerPool metrics into multiServerPool")
+		require.Equal(t, client.resurrectTimeoutInitial, multiPool.resurrectTimeoutInitial,
+			"promotion should use client settings via helper")
+	})
+}
+
 func TestConnectionPoolPromotionIntegration(t *testing.T) {
 	t.Run("discovery promotes single to multi-node pool", func(t *testing.T) {
 		// Create mock server for nodes discovery

--- a/opensearchtransport/shard_routing_integration_test.go
+++ b/opensearchtransport/shard_routing_integration_test.go
@@ -51,14 +51,29 @@ func TestMurmur3ShardRouting_Integration(t *testing.T) {
 			"number_of_replicas": 0
 		}
 	}`, numShards)
-	createReq, err := http.NewRequestWithContext(ctx, http.MethodPut,
-		fmt.Sprintf("/%s", index),
-		bytes.NewReader([]byte(createBody)))
-	require.NoError(t, err)
-	createReq.Header.Set("Content-Type", "application/json")
 
-	createResp, err := transport.Perform(createReq)
-	require.NoError(t, err)
+	// Retry index creation — transient HTTP 500 can occur while the cluster
+	// is still settling after heavy discovery/warmup activity.
+	var createResp *http.Response
+	require.Eventually(t, func() bool {
+		createReq, reqErr := http.NewRequestWithContext(ctx, http.MethodPut,
+			fmt.Sprintf("/%s", index),
+			bytes.NewReader([]byte(createBody)))
+		if reqErr != nil {
+			return false
+		}
+		createReq.Header.Set("Content-Type", "application/json")
+		resp, perfErr := transport.Perform(createReq)
+		if perfErr != nil {
+			return false
+		}
+		if resp.StatusCode >= 500 {
+			resp.Body.Close()
+			return false
+		}
+		createResp = resp
+		return true
+	}, 30*time.Second, 500*time.Millisecond, "failed to create index %s", index)
 	require.Equal(t, http.StatusOK, createResp.StatusCode,
 		"failed to create index %s", index)
 	createResp.Body.Close()
@@ -232,13 +247,6 @@ func TestShardExactRouting_FullPipeline_Integration(t *testing.T) {
 	testutil.WaitForCluster(t)
 	testutil.SkipIfSingleNode(t, 2) // 1 replica requires at least 2 nodes for green health
 
-	// OpenSearch 2.1.0 with the security plugin returns HTTP 500 on search
-	// requests routed to specific shard-hosting nodes. The insecure 2.1.0
-	// compat job passes; this is a server-side security plugin bug.
-	if testutil.IsSecure(t) {
-		testutil.SkipIfVersion(t, "=", "2.1.0", "shard-exact pipeline (security plugin HTTP 500)")
-	}
-
 	u := testutil.GetTestURL(t)
 
 	// --- Observer that captures RouteEvent per request ---
@@ -291,14 +299,29 @@ func TestShardExactRouting_FullPipeline_Integration(t *testing.T) {
 			"number_of_replicas": 1
 		}
 	}`, numShards)
-	createReq, err := http.NewRequestWithContext(ctx, http.MethodPut,
-		fmt.Sprintf("/%s", index),
-		bytes.NewReader([]byte(createBody)))
-	require.NoError(t, err)
-	createReq.Header.Set("Content-Type", "application/json")
 
-	createResp, err := transport.Perform(createReq)
-	require.NoError(t, err)
+	// Retry index creation — transient HTTP 500 can occur while the cluster
+	// is still settling after heavy discovery/warmup activity.
+	var createResp *http.Response
+	require.Eventually(t, func() bool {
+		createReq, reqErr := http.NewRequestWithContext(ctx, http.MethodPut,
+			fmt.Sprintf("/%s", index),
+			bytes.NewReader([]byte(createBody)))
+		if reqErr != nil {
+			return false
+		}
+		createReq.Header.Set("Content-Type", "application/json")
+		resp, perfErr := transport.Perform(createReq)
+		if perfErr != nil {
+			return false
+		}
+		if resp.StatusCode >= 500 {
+			resp.Body.Close()
+			return false
+		}
+		createResp = resp
+		return true
+	}, 30*time.Second, 500*time.Millisecond, "failed to create index %s", index)
 	require.Equal(t, http.StatusOK, createResp.StatusCode,
 		"failed to create index %s", index)
 	createResp.Body.Close()

--- a/opensearchtransport/standby_rotation_integration_test.go
+++ b/opensearchtransport/standby_rotation_integration_test.go
@@ -22,6 +22,13 @@ import (
 	"github.com/opensearch-project/opensearch-go/v4/opensearchtransport"
 )
 
+// discoveryPause is the delay between DiscoverNodes calls in retry loops.
+// Each DiscoverNodes creates a new pool generation and cancels the previous
+// generation's context. Resurrection goroutines from the old generation need
+// time to exit before the next cycle; this pause ensures they process the
+// context cancellation and clean up checkStartedAt state.
+const discoveryPause = 500 * time.Millisecond
+
 // rotationObserver records standby promotion and demotion events using the
 // ConnectionObserver interface. This gives deterministic visibility into
 // rotation behavior without relying on which node happens to serve a request
@@ -183,6 +190,14 @@ func discoverWithStandby(t *testing.T, transport *opensearchtransport.Client) op
 		if err != nil {
 			lastErr = err
 			t.Logf("Discovery attempt %d failed: %v", attempt, err)
+			// Brief pause before retry — gives resurrection goroutines
+			// time to complete health checks before the next DiscoverNodes
+			// replaces the pool and cancels the old generation's context.
+			select {
+			case <-ctx.Done():
+				return m
+			case <-time.After(discoveryPause):
+			}
 			continue
 		}
 		lastErr = nil
@@ -199,6 +214,14 @@ func discoverWithStandby(t *testing.T, transport *opensearchtransport.Client) op
 
 		if m.StandbyConnections >= 2 {
 			return m
+		}
+
+		// Pause between cycles — gives resurrection goroutines time to
+		// process context cancellation before the next DiscoverNodes.
+		select {
+		case <-ctx.Done():
+			return m
+		case <-time.After(discoveryPause):
 		}
 	}
 
@@ -333,6 +356,7 @@ func TestStandbyRotation(t *testing.T) {
 			err := transport.DiscoverNodes(t.Context())
 			if err != nil {
 				t.Logf("Rotation attempt %d: discovery failed: %v", attempt+1, err)
+				time.Sleep(discoveryPause)
 				continue
 			}
 			drainWarmup(transport)
@@ -345,6 +369,7 @@ func TestStandbyRotation(t *testing.T) {
 			if promotions > basePromotions && demotions > baseDemotions {
 				break
 			}
+			time.Sleep(discoveryPause)
 		}
 
 		// Rotation should have occurred: observer recorded new promotion + demotion events.
@@ -408,7 +433,20 @@ func TestStandbyRotation(t *testing.T) {
 		//  2. Call DiscoverNodes which triggers rotateStandbyConnections at the end.
 		//  3. Drain warmup so deferredCapEnforcement can fire.
 		//  4. Check if the observer recorded a new promotion.
+		//
+		// Guard against exceeding the test timeout. Each cycle includes
+		// discoverWithStandby (30s max) plus inner retries with discoveryPause.
+		// On slow CI runners this can exceed the default 5m test timeout.
+		deadline, hasDeadline := t.Deadline()
+		if !hasDeadline {
+			deadline = time.Now().Add(4 * time.Minute)
+		}
 		for cycle := range 12 {
+			if time.Until(deadline) < 30*time.Second {
+				t.Logf("Deadline approaching after %d cycles, stopping early", cycle)
+				break
+			}
+
 			prevPromotions := obs.promotionCount()
 
 			// Ensure standby partition is populated before attempting rotation.
@@ -421,6 +459,7 @@ func TestStandbyRotation(t *testing.T) {
 				err := transport.DiscoverNodes(t.Context())
 				if err != nil {
 					t.Logf("Cycle %d attempt %d: discovery failed: %v", cycle+1, attempt+1, err)
+					time.Sleep(discoveryPause)
 					continue
 				}
 				drainWarmup(transport)
@@ -432,6 +471,7 @@ func TestStandbyRotation(t *testing.T) {
 				if promotions > prevPromotions {
 					break
 				}
+				time.Sleep(discoveryPause)
 			}
 		}
 


### PR DESCRIPTION
## Summary

- Fix pool replacement orphaning resurrection goroutines during `DiscoverNodes`, causing connections to become permanently dead (0/0/0 metrics)
- Extract `newMultiServerPoolFromClientWithLock` helper as single source of truth for Client to pool settings propagation
- Remove bogus version skip masking the bug on OpenSearch 2.1.0
- Harden integration tests against transient 5xx during index creation and rapid discovery churn

## Problem

`createOrUpdateMultiNodePoolWithLock` allocates a new `multiServerPool` struct on every `DiscoverNodes` call, even when one already exists. Resurrection goroutines capture the pool pointer (`cp`) at spawn time and use it for all pool-state checks (`slices.Contains(cp.mu.dead, conn)`).

When a new pool replaces the old one mid-health-check:

1. Original Pool spawns resurrection goroutine for `conn`, sets `checkStartedAt`
2. `DiscoverNodes` allocates a new Pool with the same `*Connection` (matched via `canReuseConnection`)
3. New Pool calls `scheduleResurrect(conn)` and sees `checkStartedAt` is set, then returns (i.e. a no-op)
4. Old Pool's goroutine completes health check, checks `slices.Contains(Pool₁.mu.dead, conn)` == **false** (conn is in New Pool) and exits
5. Goroutine's `defer` clears `checkStartedAt` but nobody calls `scheduleResurrect` again
6. **Connection stuck dead permanently** and metrics show 0/0/0

On fast machines the health check completes before the next discovery cycle. On slow CI runners (observed on `integ-test-compat (true, 2.0.1)`), the race triggers consistently. The `SkipIfVersion` for OpenSearch 2.1.0 secure was masking this same bug and not a server-side security plugin issue.