### PR TITLE
Skip shard routing tests on OpenSearch < 2.2.0 with security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,7 +149,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Extract `newMultiServerPoolFromClientWithLock` as single source of truth for Client-to-pool settings propagation ([#786](https://github.com/opensearch-project/opensearch-go/pull/786))
 - Fix discovery pool wipe when all cluster nodes time out during `/_nodes/http` fan-out: parse `_nodes` metadata envelope and return `errDiscoveryEmpty` when `successful == 0`, preserving the existing connection pool for retry ([#821](https://github.com/opensearch-project/opensearch-go/pull/821))
 - Fix flaky `TestDefaultHealthCheck_RetryAfterMaxRetry`: replace wall-clock `time.Sleep` + `atomic.Int64` synchronization with context cancellation (`ctx.Done()`), and widen `maxRetryClusterHealth` to 5s so the baseline HTTP round-trip cannot race past the retry interval ([#787](https://github.com/opensearch-project/opensearch-go/pull/787))
-- Skip shard routing integration tests on OpenSearch < 2.2.0 with security plugin due to server-side `OptionalDataException` from non-thread-safe User serialization (opensearch-project/security#1970)
+- Skip opensearchtransport integration tests on OpenSearch < 2.2.0 with security plugin due to server-side `OptionalDataException` from non-thread-safe User serialization (opensearch-project/security#1970)
 - Fix connection lifecycle bug in multiServerPool.OnFailure where connections were scheduled for resurrection before being moved from ready to dead list, causing potential race conditions
 - Fix flaky connection integration test by replacing arbitrary sleep times with proper server readiness polling
 - Fix cluster readiness checks in integration tests to handle HTTPS cold start delays (increase timeout to 15s)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Extract `newMultiServerPoolFromClientWithLock` as single source of truth for Client-to-pool settings propagation ([#786](https://github.com/opensearch-project/opensearch-go/pull/786))
 - Fix discovery pool wipe when all cluster nodes time out during `/_nodes/http` fan-out: parse `_nodes` metadata envelope and return `errDiscoveryEmpty` when `successful == 0`, preserving the existing connection pool for retry ([#821](https://github.com/opensearch-project/opensearch-go/pull/821))
 - Fix flaky `TestDefaultHealthCheck_RetryAfterMaxRetry`: replace wall-clock `time.Sleep` + `atomic.Int64` synchronization with context cancellation (`ctx.Done()`), and widen `maxRetryClusterHealth` to 5s so the baseline HTTP round-trip cannot race past the retry interval ([#787](https://github.com/opensearch-project/opensearch-go/pull/787))
+- Skip shard routing integration tests on OpenSearch < 2.2.0 with security plugin due to server-side `OptionalDataException` from non-thread-safe User serialization (opensearch-project/security#1970)
 - Fix connection lifecycle bug in multiServerPool.OnFailure where connections were scheduled for resurrection before being moved from ready to dead list, causing potential race conditions
 - Fix flaky connection integration test by replacing arbitrary sleep times with proper server readiness polling
 - Fix cluster readiness checks in integration tests to handle HTTPS cold start delays (increase timeout to 15s)

--- a/opensearchtransport/complete_discovery_flow_test.go
+++ b/opensearchtransport/complete_discovery_flow_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi/testutil"
 	"github.com/opensearch-project/opensearch-go/v4/opensearchtransport"
+	tptestutil "github.com/opensearch-project/opensearch-go/v4/opensearchtransport/testutil"
 )
 
 // TestCompleteDiscoveryFlow verifies all 6 requirements:
@@ -34,6 +35,13 @@ func TestCompleteDiscoveryFlow(t *testing.T) {
 
 	// Discovery uses seed URLs including port 9201; skip if only 1 node is available.
 	testutil.SkipIfSingleNode(t, 2)
+
+	// OpenSearch < 2.2.0 with the security plugin has a non-thread-safe User
+	// serialization race (java.io.OptionalDataException) during inter-node
+	// transport. Fixed in 2.2.0 by opensearch-project/security#1970.
+	if testutil.IsSecure(t) {
+		tptestutil.SkipIfVersion(t, "<", "2.2.0", "security plugin OptionalDataException")
+	}
 
 	// Create mux router (includes IfEnabledPolicy for coordinator_only nodes)
 	router := opensearchtransport.NewMuxRouter()

--- a/opensearchtransport/connection_integration_internal_test.go
+++ b/opensearchtransport/connection_integration_internal_test.go
@@ -46,6 +46,13 @@ func TestMultiServerPool(t *testing.T) {
 		// Verify cluster is reachable with the configured scheme
 		testutil.WaitForCluster(t)
 
+		// OpenSearch < 2.2.0 with the security plugin has a non-thread-safe User
+		// serialization race (java.io.OptionalDataException) during inter-node
+		// transport. Fixed in 2.2.0 by opensearch-project/security#1970.
+		if testutil.IsSecure(t) {
+			testutil.SkipIfVersion(t, "<", "2.2.0", "security plugin OptionalDataException")
+		}
+
 		// Test against real OpenSearch cluster
 		u := testutil.GetTestURL(t)
 

--- a/opensearchtransport/discovery_integration_internal_test.go
+++ b/opensearchtransport/discovery_integration_internal_test.go
@@ -43,6 +43,13 @@ func TestDiscoveryIntegration(t *testing.T) {
 	// Verify cluster is reachable with the configured scheme
 	testutil.WaitForCluster(t)
 
+	// OpenSearch < 2.2.0 with the security plugin has a non-thread-safe User
+	// serialization race (java.io.OptionalDataException) during inter-node
+	// transport. Fixed in 2.2.0 by opensearch-project/security#1970.
+	if testutil.IsSecure(t) {
+		testutil.SkipIfVersion(t, "<", "2.2.0", "security plugin OptionalDataException")
+	}
+
 	// Use standardized URL construction and config
 	u := testutil.GetTestURL(t)
 

--- a/opensearchtransport/health_check_integration_internal_test.go
+++ b/opensearchtransport/health_check_integration_internal_test.go
@@ -38,6 +38,13 @@ import (
 )
 
 func TestHealthCheckIntegration(t *testing.T) {
+	// OpenSearch < 2.2.0 with the security plugin has a non-thread-safe User
+	// serialization race (java.io.OptionalDataException) during inter-node
+	// transport. Fixed in 2.2.0 by opensearch-project/security#1970.
+	if testutil.IsSecure(t) {
+		testutil.SkipIfVersion(t, "<", "2.2.0", "security plugin OptionalDataException")
+	}
+
 	u := testutil.GetTestURL(t)
 	cfg := getTestConfig(t, []*url.URL{u})
 

--- a/opensearchtransport/opensearchtransport_integration_multinode_test.go
+++ b/opensearchtransport/opensearchtransport_integration_multinode_test.go
@@ -42,6 +42,13 @@ import (
 var _ = fmt.Print
 
 func TestTransportSelector(t *testing.T) {
+	// OpenSearch < 2.2.0 with the security plugin has a non-thread-safe User
+	// serialization race (java.io.OptionalDataException) during inter-node
+	// transport. Fixed in 2.2.0 by opensearch-project/security#1970.
+	if testutil.IsSecure(t) {
+		testutil.SkipIfVersion(t, "<", "2.2.0", "security plugin OptionalDataException")
+	}
+
 	NodeName := func(t *testing.T, transport opensearchtransport.Interface) string {
 		t.Helper()
 		req, err := http.NewRequest(http.MethodGet, "/", nil)

--- a/opensearchtransport/opensearchtransport_integration_test.go
+++ b/opensearchtransport/opensearchtransport_integration_test.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi/testutil"
 	"github.com/opensearch-project/opensearch-go/v4/opensearchtransport"
+	tptestutil "github.com/opensearch-project/opensearch-go/v4/opensearchtransport/testutil"
 	"github.com/opensearch-project/opensearch-go/v4/opensearchtransport/testutil/mockhttp"
 	"github.com/opensearch-project/opensearch-go/v4/opensearchutil"
 )
@@ -105,6 +106,13 @@ func TestTransportHeaders(t *testing.T) {
 		t.Fatalf("Failed to create client for cluster readiness check: %s", err)
 	}
 
+	// OpenSearch < 2.2.0 with the security plugin has a non-thread-safe User
+	// serialization race (java.io.OptionalDataException) during inter-node
+	// transport. Fixed in 2.2.0 by opensearch-project/security#1970.
+	if testutil.IsSecure(t) {
+		tptestutil.SkipIfVersion(t, "<", "2.2.0", "security plugin OptionalDataException")
+	}
+
 	hdr := http.Header{}
 	hdr.Set("Accept", "application/yaml")
 
@@ -144,6 +152,13 @@ func TestTransportBodyClose(t *testing.T) {
 		t.Fatalf("Failed to create client for cluster readiness check: %s", err)
 	}
 
+	// OpenSearch < 2.2.0 with the security plugin has a non-thread-safe User
+	// serialization race (java.io.OptionalDataException) during inter-node
+	// transport. Fixed in 2.2.0 by opensearch-project/security#1970.
+	if testutil.IsSecure(t) {
+		tptestutil.SkipIfVersion(t, "<", "2.2.0", "security plugin OptionalDataException")
+	}
+
 	// Use standardized URL construction and client config
 	u := mockhttp.GetOpenSearchURL(t)
 	config := testutil.ClientConfig(t)
@@ -180,6 +195,13 @@ func TestTransportCompression(t *testing.T) {
 	_, err := testutil.InitClient(t)
 	if err != nil {
 		t.Fatalf("Failed to create client for cluster readiness check: %s", err)
+	}
+
+	// OpenSearch < 2.2.0 with the security plugin has a non-thread-safe User
+	// serialization race (java.io.OptionalDataException) during inter-node
+	// transport. Fixed in 2.2.0 by opensearch-project/security#1970.
+	if testutil.IsSecure(t) {
+		tptestutil.SkipIfVersion(t, "<", "2.2.0", "security plugin OptionalDataException")
 	}
 
 	var req *http.Request

--- a/opensearchtransport/router_discovery_test.go
+++ b/opensearchtransport/router_discovery_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi/testutil"
 	"github.com/opensearch-project/opensearch-go/v4/opensearchtransport"
+	tptestutil "github.com/opensearch-project/opensearch-go/v4/opensearchtransport/testutil"
 )
 
 // TestRouterWithDiscovery verifies the complete flow:
@@ -32,6 +33,13 @@ func TestRouterWithDiscovery(t *testing.T) {
 
 	// Discovery uses seed URLs including port 9201; skip if only 1 node is available.
 	testutil.SkipIfSingleNode(t, 2)
+
+	// OpenSearch < 2.2.0 with the security plugin has a non-thread-safe User
+	// serialization race (java.io.OptionalDataException) during inter-node
+	// transport. Fixed in 2.2.0 by opensearch-project/security#1970.
+	if testutil.IsSecure(t) {
+		tptestutil.SkipIfVersion(t, "<", "2.2.0", "security plugin OptionalDataException")
+	}
 
 	t.Run("Complete seed URL to router transition", func(t *testing.T) {
 		// Create mux router (which has IfEnabledPolicy for coordinator nodes)

--- a/opensearchtransport/shard_routing_integration_test.go
+++ b/opensearchtransport/shard_routing_integration_test.go
@@ -247,6 +247,15 @@ func TestShardExactRouting_FullPipeline_Integration(t *testing.T) {
 	testutil.WaitForCluster(t)
 	testutil.SkipIfSingleNode(t, 2) // 1 replica requires at least 2 nodes for green health
 
+	// OpenSearch < 2.2.0 with the security plugin returns HTTP 500 on
+	// shard-routed requests due to non-thread-safe User serialization
+	// (java.io.OptionalDataException). Fixed in 2.2.0 by
+	// opensearch-project/security#1970 (50a94b47).
+	if testutil.IsSecure(t) {
+		testutil.SkipIfVersion(t, "<", "2.2.0", "shard-exact pipeline (security plugin OptionalDataException)")
+	}
+
+
 	u := testutil.GetTestURL(t)
 
 	// --- Observer that captures RouteEvent per request ---

--- a/opensearchtransport/shard_routing_integration_test.go
+++ b/opensearchtransport/shard_routing_integration_test.go
@@ -33,6 +33,13 @@ import (
 func TestMurmur3ShardRouting_Integration(t *testing.T) {
 	testutil.WaitForCluster(t)
 
+	// OpenSearch < 2.2.0 with the security plugin has a non-thread-safe User
+	// serialization race (java.io.OptionalDataException) during inter-node
+	// transport. Fixed in 2.2.0 by opensearch-project/security#1970.
+	if testutil.IsSecure(t) {
+		testutil.SkipIfVersion(t, "<", "2.2.0", "security plugin OptionalDataException")
+	}
+
 	u := testutil.GetTestURL(t)
 	cfg := getTestConfig(t, []*url.URL{u})
 	transport, err := New(cfg)

--- a/opensearchtransport/standby_rotation_integration_test.go
+++ b/opensearchtransport/standby_rotation_integration_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi/testutil"
 	"github.com/opensearch-project/opensearch-go/v4/opensearchtransport"
+	tptestutil "github.com/opensearch-project/opensearch-go/v4/opensearchtransport/testutil"
 )
 
 // discoveryPause is the delay between DiscoverNodes calls in retry loops.
@@ -245,6 +246,13 @@ func TestStandbyRotation(t *testing.T) {
 
 	// These tests require a multi-node cluster (3 nodes) for standby rotation.
 	testutil.SkipIfSingleNode(t, 3)
+
+	// OpenSearch < 2.2.0 with the security plugin has a non-thread-safe User
+	// serialization race (java.io.OptionalDataException) during inter-node
+	// transport. Fixed in 2.2.0 by opensearch-project/security#1970.
+	if testutil.IsSecure(t) {
+		tptestutil.SkipIfVersion(t, "<", "2.2.0", "security plugin OptionalDataException")
+	}
 
 	t.Run("Discovery with cap creates standby pool", func(t *testing.T) {
 		cfg := standbyTestConfig(t)

--- a/opensearchtransport/zombie_connection_test.go
+++ b/opensearchtransport/zombie_connection_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi/testutil"
 	"github.com/opensearch-project/opensearch-go/v4/opensearchtransport"
+	tptestutil "github.com/opensearch-project/opensearch-go/v4/opensearchtransport/testutil"
 )
 
 // TestSeedURLsWithDiscovery reproduces the zombie connection issue
@@ -28,6 +29,13 @@ func TestSeedURLsWithDiscovery(t *testing.T) {
 
 	// Discovery uses seed URLs including port 9201; skip if only 1 node is available.
 	testutil.SkipIfSingleNode(t, 2)
+
+	// OpenSearch < 2.2.0 with the security plugin has a non-thread-safe User
+	// serialization race (java.io.OptionalDataException) during inter-node
+	// transport. Fixed in 2.2.0 by opensearch-project/security#1970.
+	if testutil.IsSecure(t) {
+		tptestutil.SkipIfVersion(t, "<", "2.2.0", "security plugin OptionalDataException")
+	}
 
 	t.Run("Seed URLs with role-based router and discovery", func(t *testing.T) {
 		// Create router with data policy (since our test cluster nodes have data role)


### PR DESCRIPTION
OpenSearch < 2.2.0 with the security plugin throws java.io.OptionalDataException on shard-routed requests due to non-thread-safe HashSet/HashMap in User serialization. Fixed in 2.2.0 by opensearch-project/security#1970 (50a94b47).

Widen the existing 2.1.0-only skip to cover all versions below 2.2.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
