### PR TITLE
Fix flaky health check retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
+- Fix flaky `TestDefaultHealthCheck_RetryAfterMaxRetry`: replace wall-clock `time.Sleep` + `atomic.Int64` synchronization with context cancellation (`ctx.Done()`), and widen `maxRetryClusterHealth` to 5s so the baseline HTTP round-trip cannot race past the retry interval ([#787](https://github.com/opensearch-project/opensearch-go/pull/787))
 - Fix connection lifecycle bug in multiServerPool.OnFailure where connections were scheduled for resurrection before being moved from ready to dead list, causing potential race conditions
 - Fix flaky connection integration test by replacing arbitrary sleep times with proper server readiness polling
 - Fix cluster readiness checks in integration tests to handle HTTPS cold start delays (increase timeout to 15s)

--- a/opensearchtransport/cluster_health.go
+++ b/opensearchtransport/cluster_health.go
@@ -447,7 +447,7 @@ func (c *Client) snapshotClusterHealthConnections() []*Connection {
 	p.mu.RLock()
 	snapshot := make([]*Connection, 0, len(p.mu.ready))
 	for _, conn := range p.mu.ready {
-		if conn.loadClusterHealthState().HasClusterHealth() {
+		if conn.hasClusterHealth() {
 			snapshot = append(snapshot, conn)
 		}
 	}
@@ -461,44 +461,9 @@ func (c *Client) snapshotClusterHealthConnections() []*Connection {
 //
 // Error handling:
 //   - 200: Parse response, store ClusterHealthLocal on connection, update timestamp.
-//   - 401/403: Permission revoked at runtime. Reset clusterHealthState to pending,
+//   - 401/403: Permission revoked at runtime. Reset cluster health lifecycle bits to pending,
 //     zero out clusterHealth. The connection will fall back to baseline GET / health checks.
 //   - Transient errors (network, 5xx): Log and skip. The next poll cycle will retry.
-// ---------------------------------------------------------------------------
-// Cluster health types -- moved from connection.go for cohesion
-// ---------------------------------------------------------------------------
-
-// clusterHealthProbeState represents the capability state of a connection's cluster health check support.
-// It is stored as an atomic.Int64 bitfield on Connection and loaded once per decision point
-// to avoid redundant atomic loads within the same code path.
-type clusterHealthProbeState int64
-
-const (
-	// clusterHealthProbed indicates the node has been probed for cluster health capability.
-	// Bit 0 (value 1).
-	clusterHealthProbed clusterHealthProbeState = 1 << iota
-
-	// clusterHealthAvailable indicates the probe succeeded and /_cluster/health?local=true is usable.
-	// Bit 1 (value 2). Only meaningful when clusterHealthProbed is also set.
-	clusterHealthAvailable
-)
-
-// HasClusterHealth returns true if the connection has been probed and supports /_cluster/health?local=true.
-func (e clusterHealthProbeState) HasClusterHealth() bool {
-	return e&clusterHealthProbed != 0 && e&clusterHealthAvailable != 0
-}
-
-// Pending returns true if cluster health has never been probed on this connection.
-func (e clusterHealthProbeState) Pending() bool {
-	return e == 0
-}
-
-// Unavailable returns true if cluster health was probed and found unavailable.
-// This occurs when the node returned 401 (authentication failure) or 403 (authorization failure,
-// i.e., the authenticated user lacks the cluster:monitor/health privilege).
-func (e clusterHealthProbeState) Unavailable() bool {
-	return e&clusterHealthProbed != 0 && e&clusterHealthAvailable == 0
-}
 
 // ClusterHealthLocal represents the response from GET /_cluster/health?local=true.
 // The local=true parameter causes the request to be served from the connected node's
@@ -545,13 +510,6 @@ type healthCheckInfo struct {
 	} `json:"version"`
 }
 
-// loadClusterHealthState atomically loads the cluster health state bitfield once.
-// Use the returned clusterHealthProbeState value for all subsequent checks within a single code path
-// to avoid redundant atomic loads.
-func (c *Connection) loadClusterHealthState() clusterHealthProbeState {
-	return clusterHealthProbeState(c.clusterHealthState.Load())
-}
-
 // ClusterHealth returns the most recent cluster health snapshot for this connection, or nil
 // if cluster health has not been probed or is unavailable.
 func (c *Connection) ClusterHealth() *ClusterHealthLocal {
@@ -573,7 +531,10 @@ func (c *Client) refreshClusterHealth(conn *Connection) {
 
 	switch {
 	case statusCode == http.StatusOK && health != nil:
+		conn.mu.Lock()
 		storeClusterHealth(conn, health)
+		conn.setLifecycleBit(lcClusterHealthProbed | lcClusterHealthAvailable) //nolint:errcheck // noop is fine
+		conn.mu.Unlock()
 
 	case statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden:
 		resetClusterHealth(conn)

--- a/opensearchtransport/cluster_health_internal_test.go
+++ b/opensearchtransport/cluster_health_internal_test.go
@@ -75,47 +75,43 @@ func newTestClient(transport http.RoundTripper) *Client {
 }
 
 func TestClusterHealthStateFlags(t *testing.T) {
-	t.Run("zero value is pending", func(t *testing.T) {
-		var e clusterHealthProbeState
-		require.True(t, e.Pending())
-		require.False(t, e.HasClusterHealth())
-		require.False(t, e.Unavailable())
-	})
+	tests := []struct {
+		name        string
+		bits        connLifecycle
+		pending     bool
+		has         bool
+		unavailable bool
+	}{
+		{"zero value is pending", 0, true, false, false},
+		{"probed only is unavailable", lcClusterHealthProbed, false, false, true},
+		{"probed and available", lcClusterHealthProbed | lcClusterHealthAvailable, false, true, false},
+		{"available without probed is invalid", lcClusterHealthAvailable, false, false, false},
+	}
 
-	t.Run("checked only is unavailable", func(t *testing.T) {
-		e := clusterHealthProbed
-		require.False(t, e.Pending())
-		require.False(t, e.HasClusterHealth())
-		require.True(t, e.Unavailable())
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := &Connection{URL: &url.URL{}}
+			if tt.bits != 0 {
+				conn.setLifecycleBit(tt.bits)
+			}
+			require.Equal(t, tt.pending, conn.clusterHealthPending(), "pending")
+			require.Equal(t, tt.has, conn.hasClusterHealth(), "hasClusterHealth")
+			require.Equal(t, tt.unavailable, conn.clusterHealthUnavailable(), "unavailable")
+		})
+	}
 
-	t.Run("checked and available is HasClusterHealth", func(t *testing.T) {
-		e := clusterHealthProbed | clusterHealthAvailable
-		require.False(t, e.Pending())
-		require.True(t, e.HasClusterHealth())
-		require.False(t, e.Unavailable())
-	})
-
-	t.Run("available without checked is not HasClusterHealth", func(t *testing.T) {
-		// This is an invalid state but the methods should handle it safely
-		e := clusterHealthAvailable
-		require.False(t, e.Pending())
-		require.False(t, e.HasClusterHealth())
-		require.False(t, e.Unavailable())
-	})
-
-	t.Run("loadClusterHealthState returns correct value", func(t *testing.T) {
+	t.Run("lifecycle round-trip", func(t *testing.T) {
 		conn := &Connection{URL: &url.URL{}}
-		require.True(t, conn.loadClusterHealthState().Pending())
+		require.True(t, conn.clusterHealthPending())
 
-		conn.clusterHealthState.Store(int64(clusterHealthProbed | clusterHealthAvailable))
-		require.True(t, conn.loadClusterHealthState().HasClusterHealth())
+		conn.setLifecycleBit(lcClusterHealthProbed | lcClusterHealthAvailable)
+		require.True(t, conn.hasClusterHealth())
 
-		conn.clusterHealthState.Store(int64(clusterHealthProbed))
-		require.True(t, conn.loadClusterHealthState().Unavailable())
+		conn.clearLifecycleBit(lcClusterHealthAvailable)
+		require.True(t, conn.clusterHealthUnavailable())
 
-		conn.clusterHealthState.Store(0)
-		require.True(t, conn.loadClusterHealthState().Pending())
+		conn.clearLifecycleBit(lcClusterHealthProbed)
+		require.True(t, conn.clusterHealthPending())
 	})
 }
 
@@ -208,14 +204,13 @@ func TestProbeClusterHealth_Success(t *testing.T) {
 	conn := &Connection{URL: serverURL}
 	client := newTestClient(server.Client().Transport)
 
-	require.True(t, conn.loadClusterHealthState().Pending())
+	require.True(t, conn.clusterHealthPending())
 
 	client.probeClusterHealthLocal(t.Context(), conn, serverURL, nil)
 
-	info := conn.loadClusterHealthState()
-	require.True(t, info.HasClusterHealth(), "should be marked as available after successful probe")
-	require.False(t, info.Pending())
-	require.False(t, info.Unavailable())
+	require.True(t, conn.hasClusterHealth(), "should be marked as available after successful probe")
+	require.False(t, conn.clusterHealthPending())
+	require.False(t, conn.clusterHealthUnavailable())
 
 	conn.mu.RLock()
 	health := conn.mu.clusterHealth
@@ -246,14 +241,13 @@ func TestProbeClusterHealth_Forbidden(t *testing.T) {
 	conn := &Connection{URL: serverURL}
 	client := newTestClient(server.Client().Transport)
 
-	require.True(t, conn.loadClusterHealthState().Pending())
+	require.True(t, conn.clusterHealthPending())
 
 	client.probeClusterHealthLocal(t.Context(), conn, serverURL, nil)
 
-	info := conn.loadClusterHealthState()
-	require.True(t, info.Unavailable(), "should be marked as unavailable after 403")
-	require.False(t, info.Pending())
-	require.False(t, info.HasClusterHealth())
+	require.True(t, conn.clusterHealthUnavailable(), "should be marked as unavailable after 403")
+	require.False(t, conn.clusterHealthPending())
+	require.False(t, conn.hasClusterHealth())
 
 	conn.mu.RLock()
 	health := conn.mu.clusterHealth
@@ -277,8 +271,7 @@ func TestProbeClusterHealth_Unauthorized(t *testing.T) {
 
 	client.probeClusterHealthLocal(t.Context(), conn, serverURL, nil)
 
-	info := conn.loadClusterHealthState()
-	require.True(t, info.Unavailable(), "should be marked as unavailable after 401")
+	require.True(t, conn.clusterHealthUnavailable(), "should be marked as unavailable after 401")
 }
 
 func TestProbeClusterHealth_TransientError(t *testing.T) {
@@ -292,13 +285,12 @@ func TestProbeClusterHealth_TransientError(t *testing.T) {
 	conn := &Connection{URL: serverURL}
 	client := newTestClient(server.Client().Transport)
 
-	require.True(t, conn.loadClusterHealthState().Pending())
+	require.True(t, conn.clusterHealthPending())
 
 	client.probeClusterHealthLocal(t.Context(), conn, serverURL, nil)
 
 	// Transient errors should leave state at pending (0) -- retried on next health check
-	info := conn.loadClusterHealthState()
-	require.True(t, info.Pending(), "should remain pending after transient 500 error")
+	require.True(t, conn.clusterHealthPending(), "should remain pending after transient 500 error")
 
 	conn.mu.RLock()
 	checkedAt := conn.mu.clusterHealthCheckedAt
@@ -347,7 +339,7 @@ func TestDefaultHealthCheck_PromotesToClusterHealth(t *testing.T) {
 
 	// Wait for the async probe to complete
 	require.Eventually(t, func() bool {
-		return conn.loadClusterHealthState().HasClusterHealth()
+		return conn.hasClusterHealth()
 	}, 2*time.Second, 10*time.Millisecond, "probe should mark connection as having cluster health")
 
 	require.Equal(t, int64(1), healthCalls.Load(), "probe should call /_cluster/health once")
@@ -399,7 +391,7 @@ func TestDefaultHealthCheck_FallbackOnPermissionRevoked(t *testing.T) {
 	ctx := context.Background()
 
 	// Set up connection as having cluster health available
-	conn.clusterHealthState.Store(int64(clusterHealthProbed | clusterHealthAvailable))
+	conn.setLifecycleBit(lcClusterHealthProbed | lcClusterHealthAvailable)
 	conn.mu.Lock()
 	conn.mu.clusterHealth = &ClusterHealthLocal{
 		ClusterName:   "test-cluster",
@@ -416,7 +408,7 @@ func TestDefaultHealthCheck_FallbackOnPermissionRevoked(t *testing.T) {
 	if resp.Body != nil {
 		resp.Body.Close()
 	}
-	require.True(t, conn.loadClusterHealthState().HasClusterHealth())
+	require.True(t, conn.hasClusterHealth())
 
 	// Revoke permission
 	returnForbidden.Store(true)
@@ -430,8 +422,7 @@ func TestDefaultHealthCheck_FallbackOnPermissionRevoked(t *testing.T) {
 	}
 
 	// Verify state was reset
-	info := conn.loadClusterHealthState()
-	require.True(t, info.Pending(), "cluster health should be reset to pending after 403")
+	require.True(t, conn.clusterHealthPending(), "cluster health should be reset to pending after 403")
 
 	conn.mu.RLock()
 	health := conn.mu.clusterHealth
@@ -477,7 +468,7 @@ func TestDefaultHealthCheck_RetryAfterMaxRetry(t *testing.T) {
 	defer cancel()
 
 	// Mark connection as unavailable with a recent timestamp
-	conn.clusterHealthState.Store(int64(clusterHealthProbed))
+	conn.setLifecycleBit(lcClusterHealthProbed)
 	conn.mu.Lock()
 	conn.mu.clusterHealthCheckedAt = time.Now()
 	conn.mu.Unlock()
@@ -524,7 +515,7 @@ func TestDefaultHealthCheck_RetryAfterMaxRetry(t *testing.T) {
 
 	// The probe will get a 403 again, so it should still be unavailable
 	require.Eventually(t, func() bool {
-		return conn.loadClusterHealthState().Unavailable()
+		return conn.clusterHealthUnavailable()
 	}, 2*time.Second, 10*time.Millisecond, "should remain unavailable after 403 on retry")
 }
 
@@ -581,7 +572,7 @@ func TestDefaultHealthCheck_DisabledClusterHealthProbing(t *testing.T) {
 	// Start with connection already unavailable — the Pending() case always
 	// probes once regardless of maxRetryClusterHealth, so skip it and test
 	// the unavailable retry path directly.
-	conn.clusterHealthState.Store(int64(clusterHealthProbed))
+	conn.setLifecycleBit(lcClusterHealthProbed)
 	conn.mu.Lock()
 	conn.mu.clusterHealthCheckedAt = time.Now().Add(-24 * time.Hour) // Long ago
 	conn.mu.Unlock()
@@ -682,7 +673,7 @@ func TestHealthCheckRequestModifier(t *testing.T) {
 
 	// Wait for cluster health info to be loaded
 	require.Eventually(t, func() bool {
-		return conn.loadClusterHealthState().HasClusterHealth()
+		return conn.hasClusterHealth()
 	}, 2*time.Second, 10*time.Millisecond)
 
 	// Reset: fresh context for the subsequent health check request.
@@ -813,7 +804,7 @@ func TestPollClusterHealth_SingleNodeSkip(t *testing.T) {
 
 	serverURL, _ := url.Parse(server.URL)
 	conn := &Connection{URL: serverURL}
-	conn.clusterHealthState.Store(int64(clusterHealthProbed | clusterHealthAvailable))
+	conn.setLifecycleBit(lcClusterHealthProbed | lcClusterHealthAvailable)
 
 	pool := &singleServerPool{connection: conn}
 	client := newTestClientWithPool(server.Client().Transport, pool)
@@ -835,7 +826,7 @@ func TestPollClusterHealth_EffectiveSingleNodeSkip(t *testing.T) {
 
 	serverURL, _ := url.Parse(server.URL)
 	conn := &Connection{URL: serverURL}
-	conn.clusterHealthState.Store(int64(clusterHealthProbed | clusterHealthAvailable))
+	conn.setLifecycleBit(lcClusterHealthProbed | lcClusterHealthAvailable)
 
 	pool := &multiServerPool{}
 	pool.mu.ready = []*Connection{conn}
@@ -853,16 +844,16 @@ func TestPollClusterHealth_EffectiveSingleNodeSkip(t *testing.T) {
 
 func TestSnapshotClusterHealthConnections(t *testing.T) {
 	connWithInfo := &Connection{URL: &url.URL{Host: "node1:9200"}}
-	connWithInfo.clusterHealthState.Store(int64(clusterHealthProbed | clusterHealthAvailable))
+	connWithInfo.setLifecycleBit(lcClusterHealthProbed | lcClusterHealthAvailable)
 
 	connPending := &Connection{URL: &url.URL{Host: "node2:9200"}}
-	// clusterHealthState defaults to 0 (pending)
+	// cluster health defaults to pending (no lifecycle bits set)
 
 	connUnavailable := &Connection{URL: &url.URL{Host: "node3:9200"}}
-	connUnavailable.clusterHealthState.Store(int64(clusterHealthProbed))
+	connUnavailable.setLifecycleBit(lcClusterHealthProbed)
 
 	connWithInfo2 := &Connection{URL: &url.URL{Host: "node4:9200"}}
-	connWithInfo2.clusterHealthState.Store(int64(clusterHealthProbed | clusterHealthAvailable))
+	connWithInfo2.setLifecycleBit(lcClusterHealthProbed | lcClusterHealthAvailable)
 
 	pool := &multiServerPool{}
 	pool.mu.ready = []*Connection{connWithInfo, connPending, connUnavailable, connWithInfo2}
@@ -918,7 +909,7 @@ func TestRefreshClusterHealth_Success(t *testing.T) {
 
 	serverURL, _ := url.Parse(server.URL)
 	conn := &Connection{URL: serverURL}
-	conn.clusterHealthState.Store(int64(clusterHealthProbed | clusterHealthAvailable))
+	conn.setLifecycleBit(lcClusterHealthProbed | lcClusterHealthAvailable)
 
 	// Pre-populate with old data to verify it gets replaced
 	conn.mu.Lock()
@@ -954,7 +945,7 @@ func TestRefreshClusterHealth_Success(t *testing.T) {
 	require.WithinDuration(t, time.Now(), checkedAt, 2*time.Second)
 
 	// Cluster health state should remain available
-	require.True(t, conn.loadClusterHealthState().HasClusterHealth())
+	require.True(t, conn.hasClusterHealth())
 }
 
 func TestRefreshClusterHealth_PermissionRevoked(t *testing.T) {
@@ -966,7 +957,7 @@ func TestRefreshClusterHealth_PermissionRevoked(t *testing.T) {
 
 	serverURL, _ := url.Parse(server.URL)
 	conn := &Connection{URL: serverURL}
-	conn.clusterHealthState.Store(int64(clusterHealthProbed | clusterHealthAvailable))
+	conn.setLifecycleBit(lcClusterHealthProbed | lcClusterHealthAvailable)
 
 	conn.mu.Lock()
 	conn.mu.clusterHealth = &ClusterHealthLocal{Status: "green", NumberOfNodes: 3}
@@ -984,7 +975,7 @@ func TestRefreshClusterHealth_PermissionRevoked(t *testing.T) {
 	client.refreshClusterHealth(conn)
 
 	// Cluster health should be reset to pending
-	require.True(t, conn.loadClusterHealthState().Pending(),
+	require.True(t, conn.clusterHealthPending(),
 		"should reset to pending after 403")
 
 	// Cluster health should be zeroed out
@@ -1006,7 +997,7 @@ func TestRefreshClusterHealth_TransientError(t *testing.T) {
 
 	serverURL, _ := url.Parse(server.URL)
 	conn := &Connection{URL: serverURL}
-	conn.clusterHealthState.Store(int64(clusterHealthProbed | clusterHealthAvailable))
+	conn.setLifecycleBit(lcClusterHealthProbed | lcClusterHealthAvailable)
 
 	originalHealth := &ClusterHealthLocal{Status: "green", NumberOfNodes: 3}
 	originalCheckedAt := time.Now().Add(-5 * time.Minute)
@@ -1027,7 +1018,7 @@ func TestRefreshClusterHealth_TransientError(t *testing.T) {
 	client.refreshClusterHealth(conn)
 
 	// Cluster health state should remain available (transient errors don't change state)
-	require.True(t, conn.loadClusterHealthState().HasClusterHealth(),
+	require.True(t, conn.hasClusterHealth(),
 		"state should remain available after transient 503")
 
 	// Cluster health should be preserved (not zeroed)
@@ -1068,7 +1059,7 @@ func TestClusterHealthCheck_TransientFallback(t *testing.T) {
 	client := newTestClient(server.Client().Transport)
 
 	// Pre-set as having cluster health
-	conn.clusterHealthState.Store(int64(clusterHealthProbed | clusterHealthAvailable))
+	conn.setLifecycleBit(lcClusterHealthProbed | lcClusterHealthAvailable)
 	conn.mu.Lock()
 	conn.mu.clusterHealth = &ClusterHealthLocal{Status: "green", NumberOfNodes: 3}
 	conn.mu.Unlock()
@@ -1087,8 +1078,7 @@ func TestClusterHealthCheck_TransientFallback(t *testing.T) {
 	require.Equal(t, int64(1), rootCalls.Load(), "should have fallen back to GET /")
 
 	// Cluster health state should NOT be changed on transient errors
-	info := conn.loadClusterHealthState()
-	require.True(t, info.HasClusterHealth(), "state should remain available after transient error")
+	require.True(t, conn.hasClusterHealth(), "state should remain available after transient error")
 
 	conn.mu.RLock()
 	health := conn.mu.clusterHealth
@@ -1462,13 +1452,12 @@ func TestPollClusterHealthMultiNode(t *testing.T) {
 
 		serverURL, _ := url.Parse(server.URL)
 		conn1 := &Connection{URL: serverURL}
-		conn1.state.Store(int64(newConnState(lcActive)))
-		conn1.clusterHealthState.Store(int64(clusterHealthProbed | clusterHealthAvailable))
 		conn2 := &Connection{URL: serverURL}
-		conn2.state.Store(int64(newConnState(lcActive)))
-		conn2.clusterHealthState.Store(int64(clusterHealthProbed | clusterHealthAvailable))
 
+		// newStandbyPool sets lcActive, so set health bits after pool creation.
 		pool := newStandbyPool([]*Connection{conn1, conn2}, nil)
+		conn1.setLifecycleBit(lcClusterHealthProbed | lcClusterHealthAvailable)
+		conn2.setLifecycleBit(lcClusterHealthProbed | lcClusterHealthAvailable)
 		client := newTestClientWithPool(server.Client().Transport, pool)
 
 		client.pollClusterHealth()

--- a/opensearchtransport/cluster_health_internal_test.go
+++ b/opensearchtransport/cluster_health_internal_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -442,7 +443,11 @@ func TestDefaultHealthCheck_FallbackOnPermissionRevoked(t *testing.T) {
 }
 
 func TestDefaultHealthCheck_RetryAfterMaxRetry(t *testing.T) {
-	var healthCalls atomic.Int64
+	// probeCtx / probeCancel: canceled by the /_cluster/health handler to
+	// signal that an async probe was received. Tests wait on probeCtx.Done()
+	// instead of wall-clock sleeps or channel reads.
+	probeCtx, probeCancel := context.WithCancel(t.Context())
+	defer probeCancel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -451,10 +456,10 @@ func TestDefaultHealthCheck_RetryAfterMaxRetry(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(validOpenSearchRootResponse()))
 		case "/_cluster/health":
-			healthCalls.Add(1)
 			// Always return 403 for this test
 			w.WriteHeader(http.StatusForbidden)
 			w.Write([]byte(`{"error":"no permissions"}`))
+			probeCancel() // signal that the probe arrived
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -464,8 +469,12 @@ func TestDefaultHealthCheck_RetryAfterMaxRetry(t *testing.T) {
 	serverURL, _ := url.Parse(server.URL)
 	conn := &Connection{URL: serverURL}
 	client := newTestClient(server.Client().Transport)
+	// Use a large retry interval so the baseline HTTP round-trip
+	// (which runs before the elapsed check) can't race past it.
+	client.maxRetryClusterHealth = 5 * time.Second
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
 
 	// Mark connection as unavailable with a recent timestamp
 	conn.clusterHealthState.Store(int64(clusterHealthProbed))
@@ -480,13 +489,22 @@ func TestDefaultHealthCheck_RetryAfterMaxRetry(t *testing.T) {
 		resp.Body.Close()
 	}
 
-	// Give async goroutines time to run (if any were launched erroneously)
-	time.Sleep(50 * time.Millisecond)
-	require.Equal(t, int64(0), healthCalls.Load(), "should NOT re-probe when interval hasn't elapsed")
+	// Verify no probe was launched. If a probe goroutine were spawned it would
+	// hit /_cluster/health and cancel probeCtx. A short deadline is sufficient:
+	// we only need to outlast goroutine scheduling, not real I/O.
+	noProbeCtx, noProbeCancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer noProbeCancel()
 
-	// Now set the timestamp far enough in the past
+	select {
+	case <-probeCtx.Done():
+		t.Fatal("should NOT re-probe when retry interval hasn't elapsed")
+	case <-noProbeCtx.Done():
+		// Good — no probe was launched within the window
+	}
+
+	// Now set the timestamp far enough in the past to exceed the retry interval
 	conn.mu.Lock()
-	conn.mu.clusterHealthCheckedAt = time.Now().Add(-100 * time.Millisecond)
+	conn.mu.clusterHealthCheckedAt = time.Now().Add(-10 * time.Second)
 	conn.mu.Unlock()
 
 	// Call DefaultHealthCheck -- retry interval has elapsed, should re-probe
@@ -496,10 +514,13 @@ func TestDefaultHealthCheck_RetryAfterMaxRetry(t *testing.T) {
 		resp.Body.Close()
 	}
 
-	// Wait for async probe to run
-	require.Eventually(t, func() bool {
-		return healthCalls.Load() > 0
-	}, 2*time.Second, 10*time.Millisecond, "should re-probe after interval elapses")
+	// Wait for the async probe to hit /_cluster/health (cancels probeCtx)
+	select {
+	case <-probeCtx.Done():
+		// Good — probe was launched
+	case <-time.After(2 * time.Second):
+		t.Fatal("should re-probe after retry interval elapses")
+	}
 
 	// The probe will get a 403 again, so it should still be unavailable
 	require.Eventually(t, func() bool {
@@ -530,7 +551,8 @@ func TestDefaultHealthCheck_NilConnection(t *testing.T) {
 }
 
 func TestDefaultHealthCheck_DisabledClusterHealthProbing(t *testing.T) {
-	var healthCalls atomic.Int64
+	probeCtx, probeCancel := context.WithCancel(t.Context())
+	defer probeCancel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -539,10 +561,10 @@ func TestDefaultHealthCheck_DisabledClusterHealthProbing(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(validOpenSearchRootResponse()))
 		case "/_cluster/health":
-			healthCalls.Add(1)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(validClusterHealthResponse()))
+			probeCancel()
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -556,67 +578,63 @@ func TestDefaultHealthCheck_DisabledClusterHealthProbing(t *testing.T) {
 	// (disable probing entirely means the resolved value is 0)
 	client.maxRetryClusterHealth = 0
 
-	ctx := context.Background()
-
-	// Even though conn is pending, probing is disabled -- should not launch probe
-	resp, err := client.DefaultHealthCheck(ctx, conn, serverURL)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	if resp.Body != nil {
-		resp.Body.Close()
-	}
-
-	// Give async goroutines time to run (if any were launched erroneously)
-	time.Sleep(100 * time.Millisecond)
-
-	// With maxRetryClusterHealth=0, the Pending() case still launches a probe.
-	// The "disable probing entirely" behavior is controlled by Config value <0 -> resolved to 0,
-	// but the Pending() case always probes once. Verify the unavailable retry case is blocked.
+	// Start with connection already unavailable — the Pending() case always
+	// probes once regardless of maxRetryClusterHealth, so skip it and test
+	// the unavailable retry path directly.
 	conn.clusterHealthState.Store(int64(clusterHealthProbed))
 	conn.mu.Lock()
 	conn.mu.clusterHealthCheckedAt = time.Now().Add(-24 * time.Hour) // Long ago
 	conn.mu.Unlock()
 
-	healthCalls.Store(0) // Reset counter
-
-	resp, err = client.DefaultHealthCheck(ctx, conn, serverURL)
+	resp, err := client.DefaultHealthCheck(context.Background(), conn, serverURL)
 	require.NoError(t, err)
 	if resp != nil && resp.Body != nil {
 		resp.Body.Close()
 	}
 
-	time.Sleep(100 * time.Millisecond)
-	require.Equal(t, int64(0), healthCalls.Load(),
-		"should NOT retry probe when maxRetryClusterHealth is 0 (disabled)")
+	// Verify no retry probe was launched.
+	noProbeCtx, noProbeCancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer noProbeCancel()
+
+	select {
+	case <-probeCtx.Done():
+		t.Fatal("should NOT retry probe when maxRetryClusterHealth is 0 (disabled)")
+	case <-noProbeCtx.Done():
+		// Good — no retry probe was launched
+	}
 }
 
 func TestHealthCheckRequestModifier(t *testing.T) {
-	// Channels to signal when specific requests arrive
-	rootRequestCh := make(chan http.Header, 1)
-	healthRequestCh := make(chan http.Header, 1)
+	// Contexts canceled by handlers to signal request arrival.
+	rootCtx, rootCancel := context.WithCancel(t.Context())
+	defer rootCancel()
+	healthCtx, healthCancel := context.WithCancel(t.Context())
+	defer healthCancel()
+
+	// Mutex-protected header snapshots captured by the handler.
+	var mu sync.Mutex
+	var rootHeader, healthHeader http.Header
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		header := r.Header.Clone()
 
 		switch r.URL.Path {
 		case "/":
-			select {
-			case rootRequestCh <- header:
-			default:
-				// Already sent one, ignore duplicates
-			}
+			mu.Lock()
+			rootHeader = header
+			mu.Unlock()
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(validOpenSearchRootResponse()))
+			rootCancel()
 		case "/_cluster/health":
-			select {
-			case healthRequestCh <- header:
-			default:
-				// Already sent one, ignore duplicates
-			}
+			mu.Lock()
+			healthHeader = header
+			mu.Unlock()
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(validClusterHealthResponse()))
+			healthCancel()
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -640,20 +658,24 @@ func TestHealthCheckRequestModifier(t *testing.T) {
 		resp.Body.Close()
 	}
 
-	// Verify the root request had the custom header
+	// Wait for the root request
 	select {
-	case header := <-rootRequestCh:
-		require.Equal(t, "bearer-token-123", header.Get("X-Custom-Auth"),
+	case <-rootCtx.Done():
+		mu.Lock()
+		require.Equal(t, "bearer-token-123", rootHeader.Get("X-Custom-Auth"),
 			"modifier should apply custom header to baseline health check")
-	case <-time.After(1 * time.Second):
+		mu.Unlock()
+	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for root request")
 	}
 
 	// Wait for async probe to complete and verify its header
 	select {
-	case header := <-healthRequestCh:
-		require.Equal(t, "bearer-token-123", header.Get("X-Custom-Auth"),
+	case <-healthCtx.Done():
+		mu.Lock()
+		require.Equal(t, "bearer-token-123", healthHeader.Get("X-Custom-Auth"),
 			"modifier should apply to /_cluster/health probe requests")
+		mu.Unlock()
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for async probe request")
 	}
@@ -663,15 +685,9 @@ func TestHealthCheckRequestModifier(t *testing.T) {
 		return conn.loadClusterHealthState().HasClusterHealth()
 	}, 2*time.Second, 10*time.Millisecond)
 
-	// Reset channels for next test
-	select {
-	case <-rootRequestCh:
-	default:
-	}
-	select {
-	case <-healthRequestCh:
-	default:
-	}
+	// Reset: fresh context for the subsequent health check request.
+	healthCtx, healthCancel = context.WithCancel(t.Context())
+	defer healthCancel()
 
 	// Now test that subsequent health checks also use the modifier
 	resp, err = client.DefaultHealthCheck(ctx, conn, serverURL)
@@ -683,10 +699,12 @@ func TestHealthCheckRequestModifier(t *testing.T) {
 
 	// Should hit the health endpoint since cluster health is now available
 	select {
-	case header := <-healthRequestCh:
-		require.Equal(t, "bearer-token-123", header.Get("X-Custom-Auth"),
+	case <-healthCtx.Done():
+		mu.Lock()
+		require.Equal(t, "bearer-token-123", healthHeader.Get("X-Custom-Auth"),
 			"modifier should apply to cluster health check requests")
-	case <-time.After(1 * time.Second):
+		mu.Unlock()
+	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for cluster health check request")
 	}
 }

--- a/opensearchtransport/connection.go
+++ b/opensearchtransport/connection.go
@@ -180,9 +180,8 @@ type Connection struct {
 	// ratio: (inFlight + 1) / cwnd.
 	pools poolRegistry
 
-	failures           atomic.Int64
-	clusterHealthState atomic.Int64 // Bitfield: clusterHealthProbed | clusterHealthAvailable
-	state              atomic.Int64 // Packed connState: connLifecycle (12b) + 2*warmupManager (26b each)
+	failures atomic.Int64
+	state    atomic.Int64 // Packed connState: connLifecycle (12b) + 2*warmupManager (26b each)
 
 	// drainingQuiescingRemaining counts the number of successful health checks remaining
 	// before this connection can be resurrected. Set to defaultDrainingQuiescingChecks when
@@ -199,7 +198,7 @@ type Connection struct {
 		sync.RWMutex
 		deadSince              time.Time
 		checkStartedAt         time.Time
-		clusterHealth          *ClusterHealthLocal // Populated when clusterHealthAvailable is set
+		clusterHealth          *ClusterHealthLocal // Populated when lcClusterHealthAvailable is set
 		clusterHealthCheckedAt time.Time           // When cluster health was last probed (for retry timing)
 		overloadedAt           time.Time           // When overloaded state was last set (lcOverloaded metadata bit)
 		lastBreakerTripped     map[string]int64    // Previous tripped counts for delta detection

--- a/opensearchtransport/connection_lifecycle.go
+++ b/opensearchtransport/connection_lifecycle.go
@@ -176,6 +176,27 @@ func (c *Connection) needsCatUpdate() bool {
 	return c.loadConnState().lifecycle().has(lcNeedsCatUpdate)
 }
 
+// hasClusterHealth reports whether this connection has been probed and supports
+// /_cluster/health?local=true.
+func (c *Connection) hasClusterHealth() bool {
+	lc := c.loadConnState().lifecycle()
+	return lc.has(lcClusterHealthProbed) && lc.has(lcClusterHealthAvailable)
+}
+
+// clusterHealthPending reports whether cluster health has never been probed on
+// this connection (neither probed nor available bits set).
+func (c *Connection) clusterHealthPending() bool {
+	lc := c.loadConnState().lifecycle()
+	return !lc.has(lcClusterHealthProbed) && !lc.has(lcClusterHealthAvailable)
+}
+
+// clusterHealthUnavailable reports whether cluster health was probed and found
+// unavailable (probed is set, available is not).
+func (c *Connection) clusterHealthUnavailable() bool {
+	lc := c.loadConnState().lifecycle()
+	return lc.has(lcClusterHealthProbed) && !lc.has(lcClusterHealthAvailable)
+}
+
 // ---------------------------------------------------------------------------
 // connLifecycle -- 12-bit packed lifecycle bitfield
 // ---------------------------------------------------------------------------
@@ -209,9 +230,10 @@ func (c *Connection) needsCatUpdate() bool {
 //
 // Extended metadata (bits 8-11) -- independent flags, freely combinable:
 //
-//	lcNeedsHardware  (0x100) -- needs hardware info (/_nodes/_local/http,os)
-//	lcNeedsCatUpdate (0x200) -- shard placement stale; excluded from shard-aware routing until /_cat/shards refresh
-//	bits 10-11: reserved for future use
+//	lcNeedsHardware          (0x100) -- needs hardware info (/_nodes/_local/http,os)
+//	lcNeedsCatUpdate         (0x200) -- shard placement stale; excluded from shard-aware routing until /_cat/shards refresh
+//	lcClusterHealthProbed    (0x400) -- node has been probed for /_cluster/health capability
+//	lcClusterHealthAvailable (0x800) -- probe succeeded; /_cluster/health?local=true is usable
 //
 // Metadata bits are observability signals for metrics and monitoring.
 // They do NOT serve as concurrency guards -- mutexes and actual field
@@ -236,12 +258,14 @@ const (
 
 // Metadata flags (independent -- freely combinable with readiness and position).
 const (
-	lcNeedsWarmup    connLifecycle = 0x10  // needs warmup before full traffic
-	lcOverloaded     connLifecycle = 0x20  // node resource overload; parked in standby
-	lcHealthChecking connLifecycle = 0x40  // health check goroutine running
-	lcDraining       connLifecycle = 0x80  // HTTP/2 GOAWAY; no new requests
-	lcNeedsHardware  connLifecycle = 0x100 // needs hardware info (/_nodes/_local/http,os)
-	lcNeedsCatUpdate connLifecycle = 0x200 // shard placement stale; excluded from shard-aware routing until /_cat/shards refresh
+	lcNeedsWarmup            connLifecycle = 0x10  // needs warmup before full traffic
+	lcOverloaded             connLifecycle = 0x20  // node resource overload; parked in standby
+	lcHealthChecking         connLifecycle = 0x40  // health check goroutine running
+	lcDraining               connLifecycle = 0x80  // HTTP/2 GOAWAY; no new requests
+	lcNeedsHardware          connLifecycle = 0x100 // needs hardware info (/_nodes/_local/http,os)
+	lcNeedsCatUpdate         connLifecycle = 0x200 // shard placement stale; excluded from shard-aware routing until /_cat/shards refresh
+	lcClusterHealthProbed    connLifecycle = 0x400 // node has been probed for /_cluster/health capability
+	lcClusterHealthAvailable connLifecycle = 0x800 // probe succeeded; /_cluster/health?local=true is usable
 )
 
 // Compound aliases for common lifecycle combinations.
@@ -263,7 +287,7 @@ func (lc connLifecycle) hasAny(flags connLifecycle) bool {
 }
 
 // connLifecycleBits maps each bit to its human-readable name.
-var connLifecycleBits = [10]struct { //nolint:gochecknoglobals // lookup table, not mutable state
+var connLifecycleBits = [12]struct { //nolint:gochecknoglobals // lookup table, not mutable state
 	bit  connLifecycle
 	name string
 }{
@@ -277,6 +301,8 @@ var connLifecycleBits = [10]struct { //nolint:gochecknoglobals // lookup table, 
 	{lcDraining, "draining"},
 	{lcNeedsHardware, "needsHardware"},
 	{lcNeedsCatUpdate, "needsCatUpdate"},
+	{lcClusterHealthProbed, "clusterHealthProbed"},
+	{lcClusterHealthAvailable, "clusterHealthAvailable"},
 }
 
 // String returns a human-readable name for the lifecycle.
@@ -390,7 +416,7 @@ func (wm warmupManager) withSkipCount(skipCount int) warmupManager {
 // readiness (bits 0-1):  lcReady=0x01, lcUnknown=0x02 (mutually exclusive)
 // position  (bits 2-3):  lcActive=0x04, lcStandby=0x08 (at most one; 0=dead)
 // metadata  (bits 4-7):  lcNeedsWarmup, lcOverloaded, lcHealthChecking, lcDraining
-// extended  (bits 8-11): lcNeedsHardware=0x100, lcNeedsCatUpdate=0x200, 2 reserved
+// extended  (bits 8-11): lcNeedsHardware=0x100, lcNeedsCatUpdate=0x200, lcClusterHealthProbed=0x400, lcClusterHealthAvailable=0x800
 //
 // Each 26-bit warmupManager field uses the lower 16 bits:
 //

--- a/opensearchtransport/opensearchtransport.go
+++ b/opensearchtransport/opensearchtransport.go
@@ -1688,11 +1688,8 @@ func (c *Client) DefaultHealthCheck(ctx context.Context, conn *Connection, u *ur
 		return c.hardwareInfoHealthCheck(ctx, conn, u, applyModifier)
 	}
 
-	// Load the cluster health state once for all checks in this code path
-	info := conn.loadClusterHealthState()
-
 	// Fast path: if cluster health is available, use the richer endpoint
-	if info.HasClusterHealth() {
+	if conn.hasClusterHealth() {
 		return c.clusterHealthCheck(ctx, conn, u, applyModifier)
 	}
 
@@ -1709,11 +1706,11 @@ func (c *Client) DefaultHealthCheck(ctx context.Context, conn *Connection, u *ur
 	}
 
 	switch {
-	case info.Pending():
+	case conn.clusterHealthPending():
 		// Never probed -- launch async probe
 		go c.probeClusterHealthLocal(ctx, conn, u, applyModifier)
 
-	case info.Unavailable() && c.maxRetryClusterHealth > 0:
+	case conn.clusterHealthUnavailable() && c.maxRetryClusterHealth > 0:
 		// Previously unavailable (401/403 from cluster:monitor/health permission check) --
 		// check if jittered retry interval has elapsed before re-probing.
 		conn.mu.RLock()
@@ -2004,22 +2001,22 @@ func (c *Client) fetchClusterHealth(ctx context.Context, u *url.URL, applyModifi
 }
 
 // storeClusterHealth updates the connection's cluster health data under lock.
+// storeClusterHealth stores the health data and timestamp on the connection.
+// CALLER RESPONSIBILITIES: Caller must hold conn.mu.Lock().
 func storeClusterHealth(conn *Connection, health *ClusterHealthLocal) {
-	conn.mu.Lock()
 	conn.mu.clusterHealth = health
 	conn.mu.clusterHealthCheckedAt = time.Now()
-	conn.mu.Unlock()
 }
 
 // resetClusterHealth resets a connection's cluster health state to pending and
 // zeros out stale cluster health data. Called when the /_cluster/health endpoint
 // returns 401/403 (permission revoked at runtime).
 func resetClusterHealth(conn *Connection) {
-	conn.clusterHealthState.Store(0)
-
 	conn.mu.Lock()
 	conn.mu.clusterHealth = nil
 	conn.mu.clusterHealthCheckedAt = time.Time{}
+	conn.clearLifecycleBit(lcClusterHealthProbed)    //nolint:errcheck // noop is fine
+	conn.clearLifecycleBit(lcClusterHealthAvailable) //nolint:errcheck // noop is fine
 	conn.mu.Unlock()
 }
 
@@ -2041,7 +2038,10 @@ func (c *Client) clusterHealthCheck(
 
 	switch {
 	case statusCode == http.StatusOK && health != nil:
+		conn.mu.Lock()
 		storeClusterHealth(conn, health)
+		conn.setLifecycleBit(lcClusterHealthProbed | lcClusterHealthAvailable) //nolint:errcheck // noop is fine
+		conn.mu.Unlock()
 
 		// Readiness gate: reject nodes that are still recovering (initializing shards).
 		// This prevents slamming a node with traffic while it is still absorbing shard data.
@@ -2083,13 +2083,13 @@ func (c *Client) clusterHealthCheck(
 // required by the OpenSearch Security plugin. The result determines which endpoint subsequent
 // health checks use:
 //
-//   - 200: Probe succeeded. Sets clusterHealthProbed|clusterHealthAvailable, populates
+//   - 200: Probe succeeded. Sets lcClusterHealthProbed|lcClusterHealthAvailable, populates
 //     [Connection.mu.clusterHealth], and records the probe timestamp. Subsequent health
 //     checks will use /_cluster/health?local=true for richer data.
-//   - 401/403: The cluster:monitor/health privilege is not available. Sets clusterHealthProbed
+//   - 401/403: The cluster:monitor/health privilege is not available. Sets lcClusterHealthProbed
 //     only (marking unavailable) and records the timestamp. The client continues using GET /
 //     and will retry the probe after MaxRetryClusterHealth elapses (default 4h).
-//   - Transient errors (5xx, network, timeout): Leaves state at 0 (pending) and does NOT
+//   - Transient errors (5xx, network, timeout): Leaves state at pending and does NOT
 //     record a timestamp, so the probe is retried on the very next health check cycle.
 func (c *Client) probeClusterHealthLocal(ctx context.Context, conn *Connection, u *url.URL, applyModifier func(*http.Request)) {
 	health, statusCode, err := c.fetchClusterHealth(ctx, u, applyModifier)
@@ -2100,17 +2100,19 @@ func (c *Client) probeClusterHealthLocal(ctx context.Context, conn *Connection, 
 
 	switch {
 	case statusCode == http.StatusOK && health != nil:
-		// Probe succeeded -- store data and flip the atomic flag
+		// Probe succeeded -- store data and mark available (under conn.mu)
+		conn.mu.Lock()
 		storeClusterHealth(conn, health)
-		conn.clusterHealthState.Store(int64(clusterHealthProbed | clusterHealthAvailable))
+		conn.setLifecycleBit(lcClusterHealthProbed | lcClusterHealthAvailable) //nolint:errcheck // noop is fine
+		conn.mu.Unlock()
 
 	case statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden:
 		// Definitively unavailable -- record timestamp for retry timing
 		conn.mu.Lock()
 		conn.mu.clusterHealthCheckedAt = time.Now()
+		conn.setLifecycleBit(lcClusterHealthProbed)      //nolint:errcheck // noop is fine
+		conn.clearLifecycleBit(lcClusterHealthAvailable) //nolint:errcheck // noop is fine
 		conn.mu.Unlock()
-
-		conn.clusterHealthState.Store(int64(clusterHealthProbed))
 
 	default:
 		// Transient error (5xx, etc.) -- leave at pending (0), do NOT set timestamp

--- a/opensearchtransport/policy.go
+++ b/opensearchtransport/policy.go
@@ -36,7 +36,7 @@ import (
 
 // HealthCheckFunc defines the signature for health check functions.
 // The conn parameter provides the Connection being health-checked, allowing the function
-// to read connection state (e.g., clusterHealthState) to choose the appropriate endpoint.
+// to read connection state (e.g., cluster health lifecycle bits) to choose the appropriate endpoint.
 type HealthCheckFunc func(ctx context.Context, conn *Connection, url *url.URL) (*http.Response, error)
 
 // policyConfig holds shared configuration for policy-owned connection pools.


### PR DESCRIPTION
## Summary

- **Fix flaky `TestDefaultHealthCheck_RetryAfterMaxRetry`**: Replace channel-based synchronization and wall-clock `maxRetryClusterHealth=50ms` with `ctx.Done()` signaling, eliminating races where httptest round-trip latency exceeds the retry interval. Apply the same fix to `TestDefaultHealthCheck_DisabledClusterHealthProbing` and `TestHealthCheckRequestModifier`. Introduced in #787.

- **Migrate `clusterHealthState` into `connLifecycle` bits**: Replace the separate `atomic.Int64` field on `Connection` with two lifecycle bits (`lcClusterHealthProbed`, `lcClusterHealthAvailable`) in the existing `connState` packed word. Delete `clusterHealthProbeState` type; add `hasClusterHealth()`, `clusterHealthPending()`, `clusterHealthUnavailable()` methods on `Connection`. Widen `conn.mu` critical sections to cover both data writes and lifecycle transitions atomically.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
