### PR TITLE
Guard against empty discovery responses by parsing _nodes metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
+- Fix discovery pool wipe when all cluster nodes time out during `/_nodes/http` fan-out: parse `_nodes` metadata envelope and return `errDiscoveryEmpty` when `successful == 0`, preserving the existing connection pool for retry ([#821](https://github.com/opensearch-project/opensearch-go/pull/821))
 - Fix flaky `TestDefaultHealthCheck_RetryAfterMaxRetry`: replace wall-clock `time.Sleep` + `atomic.Int64` synchronization with context cancellation (`ctx.Done()`), and widen `maxRetryClusterHealth` to 5s so the baseline HTTP round-trip cannot race past the retry interval ([#787](https://github.com/opensearch-project/opensearch-go/pull/787))
 - Fix connection lifecycle bug in multiServerPool.OnFailure where connections were scheduled for resurrection before being moved from ready to dead list, causing potential race conditions
 - Fix flaky connection integration test by replacing arbitrary sleep times with proper server readiness polling

--- a/opensearchtransport/discovery.go
+++ b/opensearchtransport/discovery.go
@@ -43,6 +43,11 @@ import (
 	"time"
 )
 
+// errDiscoveryEmpty is returned by getNodesInfo when the /_nodes response
+// reports zero successful nodes. Callers should retry; the existing
+// connection pool is left untouched.
+var errDiscoveryEmpty = errors.New("discovery returned zero successful nodes")
+
 // Node role constants matching upstream OpenSearch server definitions.
 const (
 	// RoleData nodes store and retrieve data, perform indexing, searching, and
@@ -217,6 +222,21 @@ type nodeInfo struct {
 
 	// Internal fields (not part of JSON)
 	roleSet roleSet
+}
+
+// _NodesMeta is the "_nodes" metadata envelope returned by all
+// /_nodes/* endpoints. It reports how many nodes were contacted
+// (Total), how many responded successfully (Successful), and how
+// many timed out or errored (Failed).
+//
+// Example:
+//
+//	"_nodes": { "total": 3, "successful": 1, "failed": 2 }
+type _NodesMeta struct {
+	Total      int               `json:"total"`
+	Successful int               `json:"successful"`
+	Failed     int               `json:"failed"`
+	Failures   []json.RawMessage `json:"failures,omitempty"`
 }
 
 // DiscoverNodes reloads the client connections by fetching information from the cluster.
@@ -1046,9 +1066,49 @@ func (c *Client) getNodesInfo(ctx context.Context) ([]nodeInfo, error) {
 		return nil, err
 	}
 
+	// Parse the "_nodes" metadata header. Every /_nodes/* response includes
+	// this envelope with total/successful/failed counts from the internal
+	// transport fan-out. When nodes time out or error during the fan-out,
+	// they appear in "failed" and their entries are absent from "nodes".
+	//
+	// The metadata is present in all OpenSearch versions (forked from ES 7.10)
+	// and Elasticsearch >= 2.0. If absent (pre-2.0 ES or a stripping proxy),
+	// skip the check and fall through to the nodes map.
+	var nodesMeta _NodesMeta
+	var hasNodesMeta bool
+	if raw, ok := env["_nodes"]; ok {
+		if err := json.Unmarshal(raw, &nodesMeta); err != nil {
+			return nil, fmt.Errorf("discovery: parse _nodes metadata: %w", err)
+		}
+		hasNodesMeta = true
+	}
+
+	if hasNodesMeta && nodesMeta.Successful == 0 {
+		if debugLogger != nil {
+			debugLogger.Logf("Discovery: _nodes reports total=%d successful=%d failed=%d failures=%s; retaining current pool\n",
+				nodesMeta.Total, nodesMeta.Successful, nodesMeta.Failed, nodesMeta.Failures)
+		}
+		return nil, fmt.Errorf("discovery: total=%d successful=%d failed=%d: %w",
+			nodesMeta.Total, nodesMeta.Successful, nodesMeta.Failed, errDiscoveryEmpty)
+	}
+
 	var nodes map[string]nodeInfo
 	if err := json.Unmarshal(env["nodes"], &nodes); err != nil {
 		return nil, err
+	}
+
+	// Fallback for servers that don't return _nodes metadata (ElasticSearch or OpenSearch < 2.0):
+	// use the nodes map length as a last-resort empty-response guard.
+	if !hasNodesMeta && len(nodes) == 0 {
+		if debugLogger != nil {
+			debugLogger.Logf("Discovery: no _nodes metadata and zero nodes returned; retaining current pool\n")
+		}
+		return nil, fmt.Errorf("discovery: %w", errDiscoveryEmpty)
+	}
+
+	if hasNodesMeta && nodesMeta.Failed > 0 && debugLogger != nil {
+		debugLogger.Logf("Discovery: partial failure — _nodes reports total=%d successful=%d failed=%d failures=%s\n",
+			nodesMeta.Total, nodesMeta.Successful, nodesMeta.Failed, nodesMeta.Failures)
 	}
 
 	out := make([]nodeInfo, len(nodes))

--- a/opensearchtransport/discovery_internal_test.go
+++ b/opensearchtransport/discovery_internal_test.go
@@ -41,6 +41,7 @@ import (
 	"reflect"
 	"slices"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -1034,24 +1035,33 @@ func TestDiscoverNodesWithNewRoleValidation(t *testing.T) {
 
 			// Nodes info endpoint
 			mux.HandleFunc("/_nodes/http", func(w http.ResponseWriter, r *http.Request) {
-				nodes := make(map[string]map[string]nodeInfo)
-				nodes["nodes"] = make(map[string]nodeInfo)
+				response := map[string]any{
+					"_nodes": map[string]any{
+						"total":      len(tt.nodes),
+						"successful": len(tt.nodes),
+						"failed":     0,
+					},
+					"cluster_name": "test-cluster",
+					"nodes":        make(map[string]any),
+				}
 
+				nodes := response["nodes"].(map[string]any)
 				port := 9200
 				for name, roles := range tt.nodes {
-					nodes["nodes"][name] = nodeInfo{
-						ID:    name + "-id",
-						Name:  name,
-						Roles: roles,
-						HTTP: nodeInfoHTTP{
-							PublishAddress: net.JoinHostPort("localhost", strconv.Itoa(port)),
+					nodes[name] = map[string]any{
+						"name":  name,
+						"host":  "127.0.0.1",
+						"ip":    "127.0.0.1",
+						"roles": roles,
+						"http": map[string]any{
+							"publish_address": net.JoinHostPort("localhost", strconv.Itoa(port)),
 						},
 					}
 					port++
 				}
 
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(nodes)
+				json.NewEncoder(w).Encode(response)
 			})
 
 			// Catch-all 404 handler
@@ -2108,4 +2118,95 @@ func TestUpdateConnectionPool(t *testing.T) {
 			t.Fatalf("unexpected pool type: %T", pool)
 		}
 	})
+}
+
+// TestGetNodesInfoNodesMeta tests the _nodes metadata guard in getNodesInfo.
+func TestGetNodesInfoNodesMeta(t *testing.T) {
+	tests := []struct {
+		name            string
+		body            string
+		enableDebug     bool
+		wantErrIs       error
+		wantErrContains string
+		wantNodes       int
+	}{
+		{
+			name: "all nodes failed",
+			body: `{
+				"_nodes": {"total": 3, "successful": 0, "failed": 3, "failures": [{"node_id": "n1", "reason": "timeout"}]},
+				"cluster_name": "test",
+				"nodes": {}
+			}`,
+			enableDebug:     true,
+			wantErrIs:       errDiscoveryEmpty,
+			wantErrContains: "successful=0",
+		},
+		{
+			name: "no _nodes metadata and empty nodes",
+			body: `{
+				"cluster_name": "test",
+				"nodes": {}
+			}`,
+			enableDebug: true,
+			wantErrIs:   errDiscoveryEmpty,
+		},
+		{
+			name: "partial failure with successful nodes",
+			body: `{
+				"_nodes": {"total": 3, "successful": 2, "failed": 1, "failures": [{"node_id": "n3", "reason": "timeout"}]},
+				"cluster_name": "test",
+				"nodes": {
+					"n1": {"name": "node1", "host": "127.0.0.1", "ip": "127.0.0.1", "roles": ["data"], "http": {"publish_address": "127.0.0.1:9200"}},
+					"n2": {"name": "node2", "host": "127.0.0.1", "ip": "127.0.0.1", "roles": ["data"], "http": {"publish_address": "127.0.0.1:9201"}}
+				}
+			}`,
+			enableDebug: true,
+			wantNodes:   2,
+		},
+		{
+			name: "malformed _nodes metadata",
+			body: `{
+				"_nodes": "not-an-object",
+				"cluster_name": "test",
+				"nodes": {}
+			}`,
+			wantErrContains: "parse _nodes metadata",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := mockhttp.NewRoundTripFunc(t, func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": {"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(tt.body)),
+				}, nil
+			})
+
+			u, _ := url.Parse("http://localhost:9200")
+			tp, err := New(Config{
+				URLs:              []*url.URL{u},
+				Transport:         rt,
+				EnableDebugLogger: tt.enableDebug,
+			})
+			require.NoError(t, err)
+
+			nodes, err := tp.getNodesInfo(t.Context())
+
+			if tt.wantErrIs != nil {
+				require.ErrorIs(t, err, tt.wantErrIs)
+				require.Nil(t, nodes)
+			}
+			if tt.wantErrContains != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErrContains)
+				require.Nil(t, nodes)
+			}
+			if tt.wantErrIs == nil && tt.wantErrContains == "" {
+				require.NoError(t, err)
+				require.Len(t, nodes, tt.wantNodes)
+			}
+		})
+	}
 }


### PR DESCRIPTION
When all cluster nodes time out during the /_nodes/http internal fan-out, OpenSearch returns `{"_nodes": {"successful": 0, "failed": N}, "nodes": {}}`. Previously the client parsed only the `nodes` map, got zero entries, and wiped the connection pool, causing a hang in any slow cluster (particularly `TestStandbyRotation` in CI).

Parse the `_nodes` metadata (present in OpenSearch >= 2.0) and return `errDiscoveryEmpty` when `successful == 0`, leaving the existing pool intact for retry. A fallback guard on `len(nodes) == 0` covers pre-2.0 and ElasticSearch servers that lack this metadata.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
