### PR TITLE
Include _nodes.failures in discovery error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 
+- Include `_nodes.failures` detail in discovery error messages for diagnosing intermittent CI failures on older OpenSearch versions ([#823](https://github.com/opensearch-project/opensearch-go/pull/823))
 - Test against Opensearch 3.6.0 ([#817](https://github.com/opensearch-project/opensearch-go/pull/817))
 - Consolidate test utilities into two canonical packages: opensearchtransport/testutil (env helpers, polling, version comparison) and opensearchapi/testutil (client-dependent helpers, test suite, JSON comparison)
 - Rename `singleConnectionPool` to `singleServerPool` and `statusConnectionPool` to `multiServerPool` for clarity ([#786](https://github.com/opensearch-project/opensearch-go/pull/786))

--- a/opensearchtransport/discovery.go
+++ b/opensearchtransport/discovery.go
@@ -239,6 +239,19 @@ type _NodesMeta struct {
 	Failures   []json.RawMessage `json:"failures,omitempty"`
 }
 
+// formatFailures returns a compact JSON representation of the _nodes failures
+// array for inclusion in error messages. Returns "[]" when no failures are present.
+func (m *_NodesMeta) formatFailures() string {
+	if len(m.Failures) == 0 {
+		return "[]"
+	}
+	b, err := json.Marshal(m.Failures)
+	if err != nil {
+		return fmt.Sprintf("[<%d failures, marshal error: %v>]", len(m.Failures), err)
+	}
+	return string(b)
+}
+
 // DiscoverNodes reloads the client connections by fetching information from the cluster.
 func (c *Client) DiscoverNodes(ctx context.Context) error {
 	// Bail out early if the context is already cancelled (e.g. client shutting down).
@@ -1062,12 +1075,13 @@ func (c *Client) getNodesInfo(ctx context.Context) ([]nodeInfo, error) {
 	}
 
 	if hasNodesMeta && nodesMeta.Successful == 0 {
+		failuresJSON := nodesMeta.formatFailures()
 		if debugLogger != nil {
 			debugLogger.Logf("Discovery: _nodes reports total=%d successful=%d failed=%d failures=%s; retaining current pool\n",
-				nodesMeta.Total, nodesMeta.Successful, nodesMeta.Failed, nodesMeta.Failures)
+				nodesMeta.Total, nodesMeta.Successful, nodesMeta.Failed, failuresJSON)
 		}
-		return nil, fmt.Errorf("discovery: total=%d successful=%d failed=%d: %w",
-			nodesMeta.Total, nodesMeta.Successful, nodesMeta.Failed, errDiscoveryEmpty)
+		return nil, fmt.Errorf("discovery: total=%d successful=%d failed=%d failures=%s: %w",
+			nodesMeta.Total, nodesMeta.Successful, nodesMeta.Failed, failuresJSON, errDiscoveryEmpty)
 	}
 
 	var nodes map[string]nodeInfo
@@ -1086,7 +1100,7 @@ func (c *Client) getNodesInfo(ctx context.Context) ([]nodeInfo, error) {
 
 	if hasNodesMeta && nodesMeta.Failed > 0 && debugLogger != nil {
 		debugLogger.Logf("Discovery: partial failure — _nodes reports total=%d successful=%d failed=%d failures=%s\n",
-			nodesMeta.Total, nodesMeta.Successful, nodesMeta.Failed, nodesMeta.Failures)
+			nodesMeta.Total, nodesMeta.Successful, nodesMeta.Failed, nodesMeta.formatFailures())
 	}
 
 	out := make([]nodeInfo, len(nodes))

--- a/opensearchtransport/discovery_internal_test.go
+++ b/opensearchtransport/discovery_internal_test.go
@@ -2120,6 +2120,54 @@ func TestUpdateConnectionPool(t *testing.T) {
 	})
 }
 
+func TestNodesMeta_formatFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		failures []json.RawMessage
+		want     string
+	}{
+		{
+			name:     "nil failures",
+			failures: nil,
+			want:     "[]",
+		},
+		{
+			name:     "empty failures",
+			failures: []json.RawMessage{},
+			want:     "[]",
+		},
+		{
+			name:     "single failure",
+			failures: []json.RawMessage{json.RawMessage(`{"node_id":"n1","reason":"timeout"}`)},
+			want:     `[{"node_id":"n1","reason":"timeout"}]`,
+		},
+		{
+			name: "multiple failures",
+			failures: []json.RawMessage{
+				json.RawMessage(`{"node_id":"n1","reason":"timeout"}`),
+				json.RawMessage(`{"node_id":"n2","reason":"OptionalDataException"}`),
+			},
+			want: `[{"node_id":"n1","reason":"timeout"},{"node_id":"n2","reason":"OptionalDataException"}]`,
+		},
+		{
+			name:     "malformed raw JSON triggers marshal error",
+			failures: []json.RawMessage{json.RawMessage("\xff")},
+			want:     "[<1 failures, marshal error: json: error calling MarshalJSON for type json.RawMessage: invalid character 'ÿ' looking for beginning of value>]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := &_NodesMeta{Failures: tt.failures}
+			got := m.formatFailures()
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 // TestGetNodesInfoNodesMeta tests the _nodes metadata guard in getNodesInfo.
 func TestGetNodesInfoNodesMeta(t *testing.T) {
 	tests := []struct {
@@ -2139,7 +2187,7 @@ func TestGetNodesInfoNodesMeta(t *testing.T) {
 			}`,
 			enableDebug:     true,
 			wantErrIs:       errDiscoveryEmpty,
-			wantErrContains: "successful=0",
+			wantErrContains: `failures=[{"node_id":"n1","reason":"timeout"}]`,
 		},
 		{
 			name: "no _nodes metadata and empty nodes",


### PR DESCRIPTION
The discovery guard added in b8ba2e29 rejects `/_nodes/http` responses where `successful=0`, but the error message only reported the counts (`total`, `successful`, `failed`) without the server's failure reasons.

CI intermittently fails on OpenSearch 2.0.1 (secure) with all three nodes reported as failed during the `/_nodes` internal transport fan-out. We suspect this is the `OptionalDataException` race in the security plugin's User serialization (opensearch-project/security#1970, fixed in 2.2.0), but cannot confirm without seeing the actual failure details.

Surface the `_nodes.failures` JSON array in both the returned error and the debug log so the next CI failure reveals the root cause.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
