### PR TITLE
Fix bulk indexer silently creating duplicate documents for IDs with <, >, &

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
+- Fix bulk indexer HTML-escaping `_id` and `routing` values containing `<`, `>`, or `&` characters, causing OpenSearch to store escaped values (e.g., `\u003croot_account\u003e` stored instead of `<root_account>`), leading to duplicate documents, unreachable data on read-by-ID paths, and potential shard routing mismatches. Present since the `json.Marshal` migration in 2021 (commit `3da59092`). Replace `json.Marshal` with `json.NewEncoder` + `SetEscapeHTML(false)` in `opensearchutil.worker.writeMeta` and `opensearchutil.JSONReader`; replace per-worker `aux []byte` with `sync.Pool`-backed `*bytes.Buffer` ([#824](https://github.com/opensearch-project/opensearch-go/pull/824))
 - Fix pool replacement orphaning resurrection goroutines during node discovery, causing connections to become permanently dead with no active health checker ([#786](https://github.com/opensearch-project/opensearch-go/pull/786))
 - Extract `newMultiServerPoolFromClientWithLock` as single source of truth for Client-to-pool settings propagation ([#786](https://github.com/opensearch-project/opensearch-go/pull/786))
 - Fix discovery pool wipe when all cluster nodes time out during `/_nodes/http` fan-out: parse `_nodes` metadata envelope and return `errDiscoveryEmpty` when `successful == 0`, preserving the existing connection pool for retry ([#821](https://github.com/opensearch-project/opensearch-go/pull/821))

--- a/opensearchutil/bulk_indexer.go
+++ b/opensearchutil/bulk_indexer.go
@@ -43,6 +43,9 @@ import (
 
 const defaultFlushInterval = 30 * time.Second
 
+//nolint:mnd // Well-known power-of-two buffer cap.
+const defaultMetaBufferPoolMaxBytes = 32 << 10 // 32 KiB
+
 // BulkIndexer represents a parallel, asynchronous, efficient indexer for OpenSearch.
 type BulkIndexer interface {
 	// Add adds an item to the indexer. It returns an error when the item cannot be added.
@@ -92,6 +95,11 @@ type BulkIndexerConfig struct {
 	SourceIncludes      []string
 	Timeout             time.Duration
 	WaitForActiveShards string
+
+	// MetaBufferPoolMaxBytes is the upper bound for buffers retained in
+	// the metadata serialization pool. Buffers that grow beyond this
+	// cap are discarded instead of returned. Defaults to 32 KiB.
+	MetaBufferPoolMaxBytes int
 }
 
 // BulkIndexerStats represents the indexer statistics.
@@ -153,6 +161,9 @@ type bulkIndexer struct {
 	done    chan bool
 	stats   *bulkIndexerStats
 
+	metaPool         sync.Pool
+	metaPoolMaxBytes int
+
 	config BulkIndexerConfig
 }
 
@@ -194,10 +205,21 @@ func NewBulkIndexer(cfg BulkIndexerConfig) (BulkIndexer, error) {
 		cfg.FlushInterval = defaultFlushInterval
 	}
 
+	if cfg.MetaBufferPoolMaxBytes == 0 {
+		cfg.MetaBufferPoolMaxBytes = defaultMetaBufferPoolMaxBytes
+	}
+
 	bi := bulkIndexer{
-		config: cfg,
-		done:   make(chan bool),
-		stats:  &bulkIndexerStats{},
+		config:           cfg,
+		done:             make(chan bool),
+		stats:            &bulkIndexerStats{},
+		metaPoolMaxBytes: cfg.MetaBufferPoolMaxBytes,
+		metaPool: sync.Pool{
+			New: func() any {
+				//nolint:mnd // 512B matches the original per-worker aux preallocation.
+				return bytes.NewBuffer(make([]byte, 0, 512))
+			},
+		},
 	}
 
 	bi.init(cfg.Context)
@@ -281,8 +303,6 @@ func (bi *bulkIndexer) init(ctx context.Context) {
 			ch:  bi.queue,
 			bi:  bi,
 			buf: bytes.NewBuffer(make([]byte, 0, bi.config.FlushBytes)),
-			//nolint:mnd // Predefine the slice capacity
-			aux: make([]byte, 0, 512),
 		}
 		w.run(ctx)
 		bi.workers = append(bi.workers, &w)
@@ -330,7 +350,6 @@ type worker struct {
 	mu    sync.Mutex
 	bi    *bulkIndexer
 	buf   *bytes.Buffer
-	aux   []byte
 	items []BulkIndexerItem
 }
 
@@ -426,26 +445,31 @@ func (w *worker) writeMeta(item BulkIndexerItem) error {
 		meta.VersionType = nil
 	}
 
-	w.aux, err = json.Marshal(map[string]bulkActionMetadata{
+	buf := w.bi.metaPool.Get().(*bytes.Buffer)
+	buf.Reset()
+
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+
+	err = enc.Encode(map[string]bulkActionMetadata{
 		item.Action: meta,
 	})
 	if err != nil {
+		w.bi.putMetaBuffer(buf)
 		return err
 	}
 
-	_, err = w.buf.Write(w.aux)
-	if err != nil {
-		return err
+	_, err = w.buf.Write(buf.Bytes())
+
+	w.bi.putMetaBuffer(buf)
+
+	return err
+}
+
+func (bi *bulkIndexer) putMetaBuffer(buf *bytes.Buffer) {
+	if buf.Cap() <= bi.metaPoolMaxBytes {
+		bi.metaPool.Put(buf)
 	}
-
-	w.aux = w.aux[:0]
-
-	_, err = w.buf.WriteRune('\n')
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // writeBody writes the item body to the buffer; it must be called under a lock.

--- a/opensearchutil/bulk_indexer_internal_test.go
+++ b/opensearchutil/bulk_indexer_internal_test.go
@@ -792,12 +792,36 @@ func TestBulkIndexer(t *testing.T) {
 				}},
 				fmt.Sprintf(`{"index":{"_index":"%s","_id":"42","version":25,"version_type":"external","retry_on_conflict":5}}`, testIndex) + "\n",
 			},
+			{
+				"_id with angle brackets is not HTML-escaped",
+				args{BulkIndexerItem{
+					Action:     "index",
+					DocumentID: "prefix|<root_account>|suffix",
+					Index:      testIndex,
+				}},
+				fmt.Sprintf(`{"index":{"_index":"%s","_id":"prefix|<root_account>|suffix"}}`, testIndex) + "\n",
+			},
+			{
+				"_id with ampersand is not HTML-escaped",
+				args{BulkIndexerItem{
+					Action:     "index",
+					DocumentID: "foo&bar",
+					Index:      testIndex,
+				}},
+				fmt.Sprintf(`{"index":{"_index":"%s","_id":"foo&bar"}}`, testIndex) + "\n",
+			},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				bi := &bulkIndexer{
+					metaPoolMaxBytes: defaultMetaBufferPoolMaxBytes,
+					metaPool: sync.Pool{
+						New: func() any { return new(bytes.Buffer) },
+					},
+				}
 				w := &worker{
+					bi:  bi,
 					buf: bytes.NewBuffer(make([]byte, 0, 5e+6)),
-					aux: make([]byte, 0, 512),
 				}
 				if err := w.writeMeta(tt.args.item); err != nil {
 					t.Errorf("Unexpected error: %v", err)

--- a/opensearchutil/json_reader.go
+++ b/opensearchutil/json_reader.go
@@ -82,7 +82,9 @@ func (r *JSONReader) encode(w io.Writer) error {
 		return nil
 	}
 
-	return json.NewEncoder(w).Encode(r.val)
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(r.val)
 }
 
 type countingWriter struct {

--- a/opensearchutil/json_reader_internal_test.go
+++ b/opensearchutil/json_reader_internal_test.go
@@ -86,4 +86,44 @@ func TestJSONReader(t *testing.T) {
 			t.Fatalf("Expected error, got: %#v", err)
 		}
 	})
+
+	t.Run("HTML characters are not escaped", func(t *testing.T) {
+		tests := []struct {
+			name string
+			val  any
+			want string
+		}{
+			{
+				"angle brackets",
+				map[string]string{"id": "prefix|<root_account>|suffix"},
+				`{"id":"prefix|<root_account>|suffix"}` + "\n",
+			},
+			{
+				"ampersand",
+				map[string]string{"q": "foo&bar"},
+				`{"q":"foo&bar"}` + "\n",
+			},
+			{
+				"mixed",
+				map[string]string{"v": "a&b<c>d"},
+				`{"v":"a&b<c>d"}` + "\n",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name+"/Read", func(t *testing.T) {
+				out, _ := io.ReadAll(NewJSONReader(tt.val))
+				if string(out) != tt.want {
+					t.Fatalf("got %s, want %s", out, tt.want)
+				}
+			})
+			t.Run(tt.name+"/WriteTo", func(t *testing.T) {
+				var b bytes.Buffer
+				r := JSONReader{val: tt.val}
+				r.WriteTo(&b)
+				if b.String() != tt.want {
+					t.Fatalf("got %s, want %s", b.String(), tt.want)
+				}
+			})
+		}
+	})
 }


### PR DESCRIPTION
Go's json.Marshal HTML-escapes `<`, `>`, and `&` to `\u003c`, `\u003e`, `\u0026` by default. OpenSearch's bulk API stores the raw `_id` value without un-escaping, so a document ID like `prefix|<root_account>|suffix` was persisted as `prefix|\u003croot_account\u003e|suffix`. This causes:

1. Duplicate documents when upserting against pre-existing docs that were indexed with the literal `_id`.
2. Documents unreachable by their expected `_id` on read-by-ID paths.
3. Downstream services receiving escaped `_id` values from search results and aggregations.

Present since commit `3da59092` (`2021-08-25`) across `v1`, `v2`, `v3`, and `v4`.

Replace `json.Marshal` with `json.NewEncoder` + `SetEscapeHTML(false)` in `writeMeta` and `JSONReader`. Replace per-worker `aux []byte` with a `sync.Pool`-backed `*bytes.Buffer` (configurable cap via `MetaBufferPoolMaxBytes`, default `32 KiB`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
