### PR TITLE
chore: Updated Go version to 1.25.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,9 +179,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `github.com/aws/aws-sdk-go-v2` from 1.36.4 to 1.41.0 ([#710](https://github.com/opensearch-project/opensearch-go/pull/710), [#720](https://github.com/opensearch-project/opensearch-go/pull/720), [#759](https://github.com/opensearch-project/opensearch-go/pull/759))
 - Bump `github.com/stretchr/testify` from 1.10.0 to 1.11.1 ([#728](https://github.com/opensearch-project/opensearch-go/pull/728))
 - Bump `github.com/aws/aws-sdk-go` from 1.55.7 to 1.55.8 ([#716](https://github.com/opensearch-project/opensearch-go/pull/716))
-
-### Dependencies
-
 - Bump go version from 1.24.0 to 1.25.9 in order to resolve certain CVEs. Details in the Pull Request ([#825](https://github.com/opensearch-project/opensearch-go/pull/825))
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,10 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `github.com/stretchr/testify` from 1.10.0 to 1.11.1 ([#728](https://github.com/opensearch-project/opensearch-go/pull/728))
 - Bump `github.com/aws/aws-sdk-go` from 1.55.7 to 1.55.8 ([#716](https://github.com/opensearch-project/opensearch-go/pull/716))
 
+### Dependencies
+
+- Bump go version from 1.24.0 to 1.25.9 in order to resolve certain CVEs. Details in the Pull Request ([#825](https://github.com/opensearch-project/opensearch-go/pull/825))
+
 ### Added
 
 - Adds new fields for Opensearch 3.0 ([#702](https://github.com/opensearch-project/opensearch-go/pull/702))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opensearch-project/opensearch-go/v4
 
-go 1.24.0
+go 1.25.9
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1


### PR DESCRIPTION
### Description
Updates Go to a known new version. 

### Issues Resolved
Known CVEs have been resolved by updating the version of Go.  

I ran a tool named `osv-scanner` which allows a repo to be scanned for known CVEs. When I ran this on the current repo, it identified 33 known vulnerabilities which could be fixed by updating the version of Go. Details:
```
Total 1 package affected by 33 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 33 Unknown) from 1 ecosystem.
33 vulnerabilities can be fixed.

╭──────────────────────────────┬──────┬───────────┬─────────┬─────────┬───────────────┬──────────────────────╮
│ OSV URL                      │ CVSS │ ECOSYSTEM │ PACKAGE │ VERSION │ FIXED VERSION │ SOURCE               │
├──────────────────────────────┼──────┼───────────┼─────────┼─────────┼───────────────┼──────────────────────┤
│ https://osv.dev/GO-2025-3503 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.1        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2025-3563 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.2        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2025-3749 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.4        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2025-3750 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.4        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2025-3751 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.4        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2025-3849 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.6        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2025-3956 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.6        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2025-4006 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.8        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2025-4007 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.9        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2025-4008 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.8        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2025-4009 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.8        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2025-4010 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.8        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2025-4011 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.8        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2025-4012 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.8        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2025-4013 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.8        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2025-4014 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.8        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2025-4015 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.8        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2025-4155 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.11       │ opensearch-go/go.mod │
│ https://osv.dev/GO-2025-4175 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.11       │ opensearch-go/go.mod │
│ https://osv.dev/GO-2026-4337 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.13       │ opensearch-go/go.mod │
│ https://osv.dev/GO-2026-4340 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.12       │ opensearch-go/go.mod │
│ https://osv.dev/GO-2026-4341 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.12       │ opensearch-go/go.mod │
│ https://osv.dev/GO-2026-4342 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.12       │ opensearch-go/go.mod │
│ https://osv.dev/GO-2026-4403 │      │ Go        │ stdlib  │ 1.24.0  │ 1.24.3        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2026-4601 │      │ Go        │ stdlib  │ 1.24.0  │ 1.25.8        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2026-4602 │      │ Go        │ stdlib  │ 1.24.0  │ 1.25.8        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2026-4603 │      │ Go        │ stdlib  │ 1.24.0  │ 1.25.8        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2026-4864 │      │ Go        │ stdlib  │ 1.24.0  │ 1.25.9        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2026-4865 │      │ Go        │ stdlib  │ 1.24.0  │ 1.25.9        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2026-4869 │      │ Go        │ stdlib  │ 1.24.0  │ 1.25.9        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2026-4870 │      │ Go        │ stdlib  │ 1.24.0  │ 1.25.9        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2026-4946 │      │ Go        │ stdlib  │ 1.24.0  │ 1.25.9        │ opensearch-go/go.mod │
│ https://osv.dev/GO-2026-4947 │      │ Go        │ stdlib  │ 1.24.0  │ 1.25.9        │ opensearch-go/go.mod │
╰──────────────────────────────┴──────┴───────────┴─────────┴─────────┴───────────────┴──────────────────────╯
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
