### PR TITLE
Bump golangci-lint from v2.11.2 to v2.11.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.11.2
+          version: v2.11.4
           args: --fix --build-tags "integration core plugins plugin_security plugin_index_management multinode"
 
   prettify:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Dependencies
 
+- Bump golangci-lint from v2.11.2 to v2.11.4
 - Bump `github.com/aws/aws-sdk-go-v2/config` from 1.32.6 to 1.32.7 ([#767](https://github.com/opensearch-project/opensearch-go/pull/767))
 
 ## [4.6.0]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 # Tool versions
-GOLANGCI_LINT_VERSION := v2.11.2
+GOLANGCI_LINT_VERSION := v2.11.4
 
 GOLANGCI_LINT_BUILD_TAGS := "integration core plugins plugin_security plugin_index_management multinode"
 


### PR DESCRIPTION
Update `golangci-lint` version from `v2.11.2` to `v2.11.4` in `Makefile` and CI workflow

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
