### PR TITLE
ci: Add Docker image pre-pull with retry for resilience

### DIFF
--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -55,6 +55,15 @@ jobs:
           sudo sysctl -w fs.file-max=262144
           sudo sysctl -w vm.max_map_count=262144
 
+      - name: Pre-pull OpenSearch image
+        run: |
+          echo "Pre-pulling opensearchproject/opensearch:${{ matrix.entry.opensearch_version }}..."
+          for attempt in $(seq 30); do
+            docker pull opensearchproject/opensearch:${{ matrix.entry.opensearch_version }} && break
+            echo "Pull attempt ${attempt}/30 failed, retrying in 10s..."
+            sleep 10
+          done
+
       - name: Launch OpenSearch cluster
         run: |
           export OPENSEARCH_VERSION=${{ matrix.entry.opensearch_version }}

--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -55,15 +55,6 @@ jobs:
           sudo sysctl -w fs.file-max=262144
           sudo sysctl -w vm.max_map_count=262144
 
-      - name: Pre-pull OpenSearch image
-        run: |
-          echo "Pre-pulling opensearchproject/opensearch:${{ matrix.entry.opensearch_version }}..."
-          for attempt in $(seq 30); do
-            docker pull opensearchproject/opensearch:${{ matrix.entry.opensearch_version }} && break
-            echo "Pull attempt ${attempt}/30 failed, retrying in 10s..."
-            sleep 10
-          done
-
       - name: Launch OpenSearch cluster
         run: |
           export OPENSEARCH_VERSION=${{ matrix.entry.opensearch_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix cat APIs data type compatibility by changing byte fields from int to string to properly handle values like "0b"
 - Fix floating point precision loss in nodes stats concurrent_avg_slice_count field by changing from float32 to float64
 - Fix ISM RefreshSearchAnalyzers missing leading slash in URL path, causing HTTP/2 request failures ([#686](https://github.com/opensearch-project/opensearch-go/pull/686))
+- Retry transient Docker Hub failures when CI pre-pulls the OpenSearch base image.
 
 ### Security
 

--- a/Makefile
+++ b/Makefile
@@ -336,6 +336,12 @@ cluster.docker-build:
 		fi \
 	))
 	@echo "Building OpenSearch $(OPENSEARCH_VERSION) with role: $(manager_role), secure: $(SECURE_INTEGRATION)"
+	@echo "Pre-pulling base image opensearchproject/opensearch:$(OPENSEARCH_VERSION)..."
+	@for attempt in $$(seq 30); do \
+		docker pull opensearchproject/opensearch:$(OPENSEARCH_VERSION) && break; \
+		echo "Pull attempt $$attempt/30 failed, retrying in 10s..."; \
+		sleep 10; \
+	done
 	OPENSEARCH_MANAGER_ROLE=$(manager_role) OPENSEARCH_MANAGER_SETTING=$(manager_role) \
 		$(DOCKER_COMPOSE) build --pull
 

--- a/Makefile
+++ b/Makefile
@@ -337,9 +337,10 @@ cluster.docker-build:
 	))
 	@echo "Building OpenSearch $(OPENSEARCH_VERSION) with role: $(manager_role), secure: $(SECURE_INTEGRATION)"
 	@echo "Pre-pulling base image opensearchproject/opensearch:$(OPENSEARCH_VERSION)..."
-	@for attempt in $$(seq 30); do \
+	@for attempt in $$(seq $(DOCKER_PULL_RETRIES)); do \
 		docker pull opensearchproject/opensearch:$(OPENSEARCH_VERSION) && break; \
-		echo "Pull attempt $$attempt/30 failed, retrying in 10s..."; \
+		echo "Pull attempt $$attempt/$(DOCKER_PULL_RETRIES) failed, retrying in 10s..."; \
+		[ "$$attempt" -eq $(DOCKER_PULL_RETRIES) ] && { echo "All $(DOCKER_PULL_RETRIES) pull attempts failed, aborting."; exit 1; }; \
 		sleep 10; \
 	done
 	OPENSEARCH_MANAGER_ROLE=$(manager_role) OPENSEARCH_MANAGER_SETTING=$(manager_role) \


### PR DESCRIPTION
## Why

CI may fail when Docker Hub is unstable. Add a setting to retry for up to 5 minutes instead of failing immediately. 
> this is also a problem for other PRs, it is worth proceeding with a quick merge instead of waiting for a large PR.

This was also covered in #804

## What changed

- apply pre-pull
  `opensearchproject/opensearch:<matrix-version>` with a 30-attempt × 10s
  retry loop before `make cluster.build`
