### PR TITLE
chore: modernize internal tests to use WaitGroup.Go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - **BREAKING**: Replace `[]json.RawMessage` with typed `[]BulkByScrollFailure` for `Failures` field in `DocumentDeleteByQueryResp`, `UpdateByQueryResp`, and `ReindexResp` ([#797](https://github.com/opensearch-project/opensearch-go/issues/797)). This is a compile-time change only — callers that were not accessing `.Failures` are unaffected, and callers that were manually unmarshaling `json.RawMessage` can now access typed fields directly.
 - Replace inline `_shards` struct with `ResponseShards` in `IndexResp`, `DocumentCreateResp`, `DocumentDeleteResp`, `UpdateResp`, `IndicesRefreshResp`, and `IndicesCountResp` to expose shard `Failures` and `Skipped` fields ([#797](https://github.com/opensearch-project/opensearch-go/issues/797)). Code accessing `resp.Shards.Total`, `resp.Shards.Successful`, or `resp.Shards.Failed` compiles unchanged.
 - Add `omitempty` to all deprecated `_type` JSON tags so empty values are omitted during marshaling
-- Modernize internal tests to use Go 1.25's `WaitGroup.Go()` ([#834](https://github.com/opensearch-project/opensearch-go/pull/834))
+- Modernize tests to use Go 1.25's `WaitGroup.Go()` ([#834](https://github.com/opensearch-project/opensearch-go/pull/834))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - **BREAKING**: Replace `[]json.RawMessage` with typed `[]BulkByScrollFailure` for `Failures` field in `DocumentDeleteByQueryResp`, `UpdateByQueryResp`, and `ReindexResp` ([#797](https://github.com/opensearch-project/opensearch-go/issues/797)). This is a compile-time change only — callers that were not accessing `.Failures` are unaffected, and callers that were manually unmarshaling `json.RawMessage` can now access typed fields directly.
 - Replace inline `_shards` struct with `ResponseShards` in `IndexResp`, `DocumentCreateResp`, `DocumentDeleteResp`, `UpdateResp`, `IndicesRefreshResp`, and `IndicesCountResp` to expose shard `Failures` and `Skipped` fields ([#797](https://github.com/opensearch-project/opensearch-go/issues/797)). Code accessing `resp.Shards.Total`, `resp.Shards.Successful`, or `resp.Shards.Failed` compiles unchanged.
 - Add `omitempty` to all deprecated `_type` JSON tags so empty values are omitted during marshaling
-- Modernize two internal tests to use Go 1.25's `WaitGroup.Go()`.
+- Modernize internal tests to use Go 1.25's `WaitGroup.Go()` ([#834](https://github.com/opensearch-project/opensearch-go/pull/834))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - **BREAKING**: Replace `[]json.RawMessage` with typed `[]BulkByScrollFailure` for `Failures` field in `DocumentDeleteByQueryResp`, `UpdateByQueryResp`, and `ReindexResp` ([#797](https://github.com/opensearch-project/opensearch-go/issues/797)). This is a compile-time change only — callers that were not accessing `.Failures` are unaffected, and callers that were manually unmarshaling `json.RawMessage` can now access typed fields directly.
 - Replace inline `_shards` struct with `ResponseShards` in `IndexResp`, `DocumentCreateResp`, `DocumentDeleteResp`, `UpdateResp`, `IndicesRefreshResp`, and `IndicesCountResp` to expose shard `Failures` and `Skipped` fields ([#797](https://github.com/opensearch-project/opensearch-go/issues/797)). Code accessing `resp.Shards.Total`, `resp.Shards.Successful`, or `resp.Shards.Failed` compiles unchanged.
 - Add `omitempty` to all deprecated `_type` JSON tags so empty values are omitted during marshaling
+- Modernize two internal tests to use Go 1.25's `WaitGroup.Go()`.
 
 ### Deprecated
 

--- a/opensearch_integration_test.go
+++ b/opensearch_integration_test.go
@@ -97,15 +97,13 @@ func TestClientTransport(t *testing.T) {
 		client, err := testutil.InitClient(t)
 		require.NoError(t, err)
 
-		for i := range 101 {
-			wg.Add(1)
+		for range 101 {
 			time.Sleep(10 * time.Millisecond)
 
-			go func(_ int) {
-				defer wg.Done()
+			wg.Go(func() {
 				_, err := client.Info(t.Context(), nil)
 				require.NoError(t, err)
-			}(i)
+			})
 		}
 		wg.Wait()
 	})

--- a/opensearchtransport/connection_warmup_internal_test.go
+++ b/opensearchtransport/connection_warmup_internal_test.go
@@ -695,9 +695,7 @@ func TestWarmupConcurrentSkip(t *testing.T) {
 
 			const goroutines = 16
 			for range goroutines {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 					for {
 						switch conn.tryWarmupSkip() {
 						case warmupSkipped:
@@ -708,7 +706,7 @@ func TestWarmupConcurrentSkip(t *testing.T) {
 							return
 						}
 					}
-				}()
+				})
 			}
 
 			wg.Wait()

--- a/opensearchtransport/logger_internal_test.go
+++ b/opensearchtransport/logger_internal_test.go
@@ -73,10 +73,7 @@ func TestTransportLogger(t *testing.T) {
 		})
 
 		for range 100 {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-
+			wg.Go(func() {
 				req, _ := http.NewRequest(http.MethodGet, "/abc", nil)
 				resp, err := tp.Perform(req)
 				if err != nil {
@@ -84,7 +81,7 @@ func TestTransportLogger(t *testing.T) {
 					return
 				}
 				defer resp.Body.Close()
-			}()
+			})
 		}
 		wg.Wait()
 	})

--- a/opensearchtransport/selector_round_robin_internal_test.go
+++ b/opensearchtransport/selector_round_robin_internal_test.go
@@ -123,9 +123,7 @@ func TestRoundRobinSelectorConcurrency(t *testing.T) {
 
 	// Start multiple goroutines selecting connections
 	for range numGoroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range selectionsPerGoroutine {
 				selected, err := selector.Select(connections)
 				if err != nil {
@@ -134,7 +132,7 @@ func TestRoundRobinSelectorConcurrency(t *testing.T) {
 				}
 				results <- selected
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/opensearchutil/bulk_indexer_internal_test.go
+++ b/opensearchutil/bulk_indexer_internal_test.go
@@ -303,9 +303,7 @@ func TestBulkIndexerLifecycle(t *testing.T) {
 				bi, _ := NewBulkIndexer(cfg)
 
 				for i := 1; i <= 6; i++ {
-					wg.Add(1)
-					go func(i int) {
-						defer wg.Done()
+					wg.Go(func() {
 						err := bi.Add(context.Background(), BulkIndexerItem{
 							Action:     "foo",
 							DocumentID: strconv.Itoa(i),
@@ -314,7 +312,7 @@ func TestBulkIndexerLifecycle(t *testing.T) {
 						if err != nil {
 							t.Errorf("Unexpected error: %s", err)
 						}
-					}(i)
+					})
 				}
 				wg.Wait()
 
@@ -437,9 +435,7 @@ func TestBulkIndexerLifecycle(t *testing.T) {
 				bi, _ := NewBulkIndexer(biCfg)
 
 				for i := 1; i <= 2; i++ {
-					wg.Add(1)
-					go func() {
-						defer wg.Done()
+					wg.Go(func() {
 						err := bi.Add(context.Background(), BulkIndexerItem{
 							Action: "foo",
 							Body:   strings.NewReader(`{"title":"foo"}`),
@@ -447,7 +443,7 @@ func TestBulkIndexerLifecycle(t *testing.T) {
 						if err != nil {
 							t.Errorf("Unexpected error: %s", err)
 						}
-					}()
+					})
 				}
 				wg.Wait()
 
@@ -475,8 +471,8 @@ func TestBulkIndexerLifecycle(t *testing.T) {
 
 func TestBulkIndexerContext(t *testing.T) {
 	tests := []struct {
-		name  string
-		run   func(t *testing.T)
+		name string
+		run  func(t *testing.T)
 	}{
 		{
 			name: "Add returns error on expired context",
@@ -533,8 +529,8 @@ func TestBulkIndexerContext(t *testing.T) {
 
 func TestBulkIndexerCallbacks(t *testing.T) {
 	tests := []struct {
-		name  string
-		run   func(t *testing.T)
+		name string
+		run  func(t *testing.T)
 	}{
 		{
 			name: "OnError called on transport failure",
@@ -758,8 +754,7 @@ func TestBulkIndexerCallbacks(t *testing.T) {
 							},
 						},
 					},
-					})
-
+				})
 
 				bi, _ := NewBulkIndexer(BulkIndexerConfig{
 					NumWorkers: 1,


### PR DESCRIPTION
`golangci-lint`'s `modernize` linter flags the classic `go func() { defer wg.Done(); ... }()` pattern in internal tests — a pattern Go 1.25 collapsed into a single `WaitGroup.Go` call. CI runs the linter with `--fix`, so the suggestions silently auto-apply in CI and never surface as a review item, but contributors running the linter locally without `--fix` see the same findings on every run. Landing the change once clears the noise.

The Go bump that made `WaitGroup.Go` available landed in #825.

## Verification

`golangci-lint run --build-tags "integration core plugins plugin_security plugin_index_management multinode" --timeout=5m ./...` → 0 issues after, 2 `modernize` findings before.

`make test-integ race=true` passes locally.