### PR TITLE
Add WaitForCompletion to IndicesForcemergeParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
+- Add `WaitForCompletion` field to `IndicesForcemergeParams` to enable non-blocking force-merge via `wait_for_completion=false`, matching the existing pattern on sibling async-capable APIs (Reindex, DeleteByQuery, UpdateByQuery, Snapshot.Create, Indices.Upgrade, Tasks.*) ([#840](https://github.com/opensearch-project/opensearch-go/issues/840))
 - Add `primary_terms_map` and `split_shards_metadata` fields to ClusterState index metadata for OpenSearch >=3.6.0 compatibility
 - Add generic `opensearch.Do[T]()` function for compile-time pointer enforcement on response types, preventing a class of bugs where non-pointer values are silently passed to `Client.Do()` and fail at runtime during JSON unmarshaling. Includes `opensearch.NoBody` marker type for calls that expect no response body, unifying all internal dispatch through a single generic path ([#809](https://github.com/opensearch-project/opensearch-go/pull/809))
 - Add `InsecureSkipVerify` config option to disable TLS certificate verification without constructing a custom `http.Transport`, preserving `DefaultTransport` connection pooling, HTTP/2, and timeout defaults ([#786](https://github.com/opensearch-project/opensearch-go/issues/786))

--- a/opensearchapi/api_indices-forcemerge-params.go
+++ b/opensearchapi/api_indices-forcemerge-params.go
@@ -39,6 +39,7 @@ type IndicesForcemergeParams struct {
 	IgnoreUnavailable  *bool
 	MaxNumSegments     *int
 	OnlyExpungeDeletes *bool
+	WaitForCompletion  *bool
 
 	Pretty     bool
 	Human      bool
@@ -71,6 +72,10 @@ func (r IndicesForcemergeParams) get() map[string]string {
 
 	if r.OnlyExpungeDeletes != nil {
 		params["only_expunge_deletes"] = strconv.FormatBool(*r.OnlyExpungeDeletes)
+	}
+
+	if r.WaitForCompletion != nil {
+		params["wait_for_completion"] = strconv.FormatBool(*r.WaitForCompletion)
 	}
 
 	if r.Pretty {

--- a/opensearchapi/api_indices-forcemerge-params_test.go
+++ b/opensearchapi/api_indices-forcemerge-params_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+//
+//go:build !integration
+
+//nolint:testpackage // to test unexported get() method
+package opensearchapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIndicesForcemergeParams_get(t *testing.T) {
+	type fields struct {
+		AllowNoIndices     *bool
+		ExpandWildcards    string
+		Flush              *bool
+		IgnoreUnavailable  *bool
+		MaxNumSegments     *int
+		OnlyExpungeDeletes *bool
+		WaitForCompletion  *bool
+		Pretty             bool
+		Human              bool
+		ErrorTrace         bool
+		FilterPath         []string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   map[string]string
+	}{
+		{
+			name:   "empty params",
+			fields: fields{},
+			want:   map[string]string{},
+		},
+		{
+			name: "all params set",
+			fields: fields{
+				AllowNoIndices:     ToPointer(true),
+				ExpandWildcards:    "open,closed",
+				Flush:              ToPointer(true),
+				IgnoreUnavailable:  ToPointer(true),
+				MaxNumSegments:     ToPointer(1),
+				OnlyExpungeDeletes: ToPointer(true),
+				WaitForCompletion:  ToPointer(true),
+				Pretty:             true,
+				Human:              true,
+				ErrorTrace:         true,
+				FilterPath:         []string{"_shards.total", "_shards.successful"},
+			},
+			want: map[string]string{
+				"allow_no_indices":     "true",
+				"expand_wildcards":     "open,closed",
+				"flush":                "true",
+				"ignore_unavailable":   "true",
+				"max_num_segments":     "1",
+				"only_expunge_deletes": "true",
+				"wait_for_completion":  "true",
+				"pretty":               "true",
+				"human":                "true",
+				"error_trace":          "true",
+				"filter_path":          "_shards.total,_shards.successful",
+			},
+		},
+		{
+			name: "boolean params false",
+			fields: fields{
+				AllowNoIndices:     ToPointer(false),
+				Flush:              ToPointer(false),
+				IgnoreUnavailable:  ToPointer(false),
+				OnlyExpungeDeletes: ToPointer(false),
+				WaitForCompletion:  ToPointer(false),
+			},
+			want: map[string]string{
+				"allow_no_indices":     "false",
+				"flush":                "false",
+				"ignore_unavailable":   "false",
+				"only_expunge_deletes": "false",
+				"wait_for_completion":  "false",
+			},
+		},
+		{
+			name: "async force-merge (wait_for_completion=false only)",
+			fields: fields{
+				WaitForCompletion: ToPointer(false),
+			},
+			want: map[string]string{
+				"wait_for_completion": "false",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := IndicesForcemergeParams{
+				AllowNoIndices:     tt.fields.AllowNoIndices,
+				ExpandWildcards:    tt.fields.ExpandWildcards,
+				Flush:              tt.fields.Flush,
+				IgnoreUnavailable:  tt.fields.IgnoreUnavailable,
+				MaxNumSegments:     tt.fields.MaxNumSegments,
+				OnlyExpungeDeletes: tt.fields.OnlyExpungeDeletes,
+				WaitForCompletion:  tt.fields.WaitForCompletion,
+				Pretty:             tt.fields.Pretty,
+				Human:              tt.fields.Human,
+				ErrorTrace:         tt.fields.ErrorTrace,
+				FilterPath:         tt.fields.FilterPath,
+			}
+			got := r.get()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Description

The OpenSearch `_forcemerge` HTTP API supports `wait_for_completion` (server-side since OpenSearch 2.7.0), and every other long-running API in this library exposes it on the typed wrapper. `Indices.Forcemerge` is the only async-capable API where the typed wrapper omits it, forcing callers who need non-blocking force-merge to drop down to `client.Transport.Perform` with a manually-built `*http.Request`.

This PR adds the field to `IndicesForcemergeParams` and the corresponding URL parameter encoding, matching the existing pattern used by sibling params (`OnlyExpungeDeletes`, `Flush`, etc).

## Issues Resolved

Closes #840

## Testing

- Added a unit test (`opensearchapi/api_indices-forcemerge-params_test.go`) verifying `WaitForCompletion = &true`/`&false` is encoded into the request URL as `wait_for_completion=true`/`false`, plus an isolated case for the async (`wait_for_completion=false`) call shape. Test mirrors the pattern used by `api_indices-validate-params_test.go`.
- `go build ./...` passes.
- `go test ./opensearchapi/... -count=1` passes (full opensearchapi suite, non-integration).

## Check List

- [x] New functionality includes testing.
- [x] All tests pass.
- [x] New functionality has been documented in code comments where appropriate.
- [x] Commits are signed per the DCO using `--signoff`.
- [x] CHANGELOG updated under `[Unreleased] / Added`.