### PR TITLE
Add Sean as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the team set up in https://github.com/orgs/opensearch-project/teams and include any additional contributors
-*   @VijayanB @VachaShah @Jakob3xD
+*   @VijayanB @VachaShah @Jakob3xD @sean-

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,6 +9,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Jakob Hahn              | [Jakob3xD](https://github.com/Jakob3xD)   | Hetzner Online GmbH |
 | Vacha Shah              | [VachaShah](https://github.com/VachaShah) | Amazon              |
 | Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)   | Amazon              |
+| Sean Chittenden         | [sean-](https://github.com/sean-)         | CrowdStrike              |
 
 ## Emeritus
 


### PR DESCRIPTION
### Description
This adds Sean Chittenden (@sean-) as a maintainer of the opensearch-go repository.

Discussion has been had with current active maintainers.

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
