### PR TITLE
feat(github/workflows): pin remaining actions to SHA

### DIFF
--- a/.github/workflows/check-gen.yml
+++ b/.github/workflows/check-gen.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with: { go-version-file: 'go.mod' }
       - name: Fetch OpenAPI spec
         run: make fetch-opensearch-spec

--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -51,9 +51,9 @@ jobs:
           - { opensearch_version: 3.6.0, node_count: 3 }
           - { opensearch_version: latest, node_count: 3 }
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with: { go-version-file: 'go.mod' }
 
       - run: go version


### PR DESCRIPTION
### Description
Pin actions to SHA as it is required by the org

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
