### PR TITLE
feat(transport): remove Perform, promote Stream to Interface (closes #872)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Removed
 
+- Remove deprecated `(*opensearch.Client).Perform` and `(*opensearchtransport.Transport).Perform`; `Stream(*http.Request) (*http.Response, error)` is now the sole method on `opensearchtransport.Interface`. Custom transport implementations must implement `Stream` instead of `Perform`. The `opensearch.Streamer` opt-in interface and `opensearch.ErrTransportMissingMethodStream` sentinel are removed. ([#872](https://github.com/opensearch-project/opensearch-go/issues/872))
 - Remove backport.yml and dependabot_pr.yml as we are not using backport app anymore
 - Stop emitting `opensearchapi.Client` sub-client fields that have no operations routed to them. `cmd/osgen` now emits a sub-client only when at least one operation targets it, dropping the previously-empty `Script`, `ComponentTemplate`, `IndexTemplate`, `Template`, and `DataStream` fields. Index-template and data-stream operations are reached through `client.Indices.*` (e.g. `client.Indices.PutIndexTemplate`, `client.Indices.CreateDataStream`); stored-script operations remain top-level on `Client`
 

--- a/UPGRADING_V5.md
+++ b/UPGRADING_V5.md
@@ -155,6 +155,33 @@ type Route interface {
 
 External code that implements `Route` (custom routing policies) must add an `OpID() OperationID` method returning the [`OperationID`](https://pkg.go.dev/github.com/opensearch-project/opensearch-go/v5/opensearchtransport#OperationID) for the route -- typically the `Op*` constant matching the route's HTTP method+path. Built-in routes built via `NewRouteMux` are populated automatically; only hand-written `Route` implementations are affected.
 
+## `Perform` removed; `Stream` is now the transport interface method
+
+`opensearchtransport.Interface` previously required `Perform(*http.Request) (*http.Response, error)`, which buffered the entire response body before returning. It now requires `Stream(*http.Request) (*http.Response, error)`, which returns the raw, unbuffered body. The caller owns the body and must close it.
+
+**Custom transport implementations** must rename `Perform` to `Stream` and stop pre-buffering the body:
+
+```go
+// Before
+func (t *MyTransport) Perform(req *http.Request) (*http.Response, error) {
+    resp, err := t.inner.RoundTrip(req)
+    // ... any buffering logic ...
+    return resp, err
+}
+
+// After
+func (t *MyTransport) Stream(req *http.Request) (*http.Response, error) {
+    return t.inner.RoundTrip(req)
+}
+```
+
+**Callers of `(*opensearch.Client).Perform`** should switch to the appropriate alternative:
+
+- Use `client.Stream(req)` for raw byte forwarding (proxy/streaming use cases). You are responsible for closing `resp.Body`.
+- Use `opensearch.Do[T](ctx, client, method, req, &result)` for typed, decoded responses.
+
+The `opensearch.Streamer` interface and `opensearch.ErrTransportMissingMethodStream` sentinel are removed; `Stream` is now guaranteed on every `opensearchtransport.Interface` implementation.
+
 ## `Response.RawBody()` for buffered response bytes
 
 `Response.Body` remains a public `io.ReadCloser` field; reading it is unchanged:

--- a/_samples/transport-discovery_demo.go
+++ b/_samples/transport-discovery_demo.go
@@ -131,7 +131,7 @@ func makeRequest(ctx context.Context, transport *opensearchtransport.Transport, 
 		return fmt.Errorf("create request: %w", err)
 	}
 
-	res, err := transport.Perform(req)
+	res, err := transport.Stream(req)
 	if err != nil {
 		return fmt.Errorf("perform request: %w", err)
 	}

--- a/_samples/usage-json.go
+++ b/_samples/usage-json.go
@@ -48,12 +48,12 @@ func example() error {
 		return err
 	}
 
-	infoResponse, err := client.Client.Perform(infoRequest)
+	infoResponse, err := client.Client.Stream(infoRequest)
 	if err != nil {
 		return err
 	}
-
 	resBody, err := io.ReadAll(infoResponse.Body)
+	infoResponse.Body.Close()
 	if err != nil {
 		return err
 	}
@@ -85,11 +85,12 @@ func example() error {
 		return err
 	}
 	createIndexRequest.Header["Content-Type"] = []string{"application/json"}
-	createIndexResp, err := client.Client.Perform(createIndexRequest)
+	createIndexResp, err := client.Client.Stream(createIndexRequest)
 	if err != nil {
 		return err
 	}
 	createIndexRespBody, err := io.ReadAll(createIndexResp.Body)
+	createIndexResp.Body.Close()
 	if err != nil {
 		return err
 	}
@@ -111,11 +112,12 @@ func example() error {
 		return err
 	}
 	searchRequest.Header["Content-Type"] = []string{"application/json"}
-	searchResp, err := client.Client.Perform(searchRequest)
+	searchResp, err := client.Client.Stream(searchRequest)
 	if err != nil {
 		return err
 	}
 	searchRespBody, err := io.ReadAll(searchResp.Body)
+	searchResp.Body.Close()
 	if err != nil {
 		return err
 	}
@@ -127,11 +129,12 @@ func example() error {
 	if err != nil {
 		return err
 	}
-	deleteIndexResp, err := client.Client.Perform(deleteIndexRequest)
+	deleteIndexResp, err := client.Client.Stream(deleteIndexRequest)
 	if err != nil {
 		return err
 	}
 	deleteIndexRespBody, err := io.ReadAll(deleteIndexResp.Body)
+	deleteIndexResp.Body.Close()
 	if err != nil {
 		return err
 	}

--- a/cmd/osgen/emit/frag_plugin.go
+++ b/cmd/osgen/emit/frag_plugin.go
@@ -147,7 +147,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/internal/build/request.go
+++ b/internal/build/request.go
@@ -70,7 +70,7 @@ type requestBuf struct {
 // supply Content-Type in headers and the caller's value wins.
 //
 // Header is intentionally left nil when body is nil and no custom headers are
-// passed. The transport layer ([opensearch.Client.Perform]) lazily allocates
+// passed. The transport layer ([opensearch.Client.Stream]) lazily allocates
 // the Header map before setting User-Agent and other transport headers. This
 // keeps the fast path (GET with no body) down to 2 heap allocations: the
 // coalesced requestBuf and the path string from the path builder.

--- a/opensearch.go
+++ b/opensearch.go
@@ -83,7 +83,6 @@ var (
 	ErrPathRequired                        = path.ErrRequired
 	ErrTransportMissingMethodMetrics       = errors.New("transport is missing method Metrics()")
 	ErrTransportMissingMethodDiscoverNodes = errors.New("transport is missing method DiscoverNodes()")
-	ErrTransportMissingMethodStream        = errors.New("transport is missing method Stream()")
 )
 
 // Config represents the client configuration.
@@ -453,47 +452,11 @@ func ParseVersion(version string) (int64, int64, int64, error) {
 	return major, minor, patch, nil
 }
 
-// Perform delegates to Transport to execute a request and return a response.
-//
-// Deprecated: Perform follows the legacy buffered-response contract and will
-// be removed before the first stable release, alongside
-// [opensearchtransport.Transport.Perform]. Use [Client.Stream] when you need raw
-// byte forwarding (the caller owns the body) or the typed [Do] helpers when
-// you want a decoded Go value.
-func (c *Client) Perform(req *http.Request) (*http.Response, error) {
-	if req.Header == nil {
-		// Pre-allocate for the headers the transport layer sets on every
-		// outgoing request (User-Agent, Authorization, Content-Type,
-		// Content-Encoding, etc.) so the map does not have to resize on
-		// the hot path.
-		const defaultHeaderCount = 8
-		req.Header = make(http.Header, defaultHeaderCount)
-	}
-	return c.Transport.Perform(req)
-}
-
-// Streamer is implemented by transports that expose an unbuffered Stream
-// path: [opensearchtransport.Transport] satisfies it. Custom [opensearchtransport.Interface]
-// implementations may opt in by adding a Stream method with the same
-// signature; [Client.Stream] reports [ErrTransportMissingMethodStream] when
-// the underlying transport does not.
-type Streamer interface {
-	Stream(*http.Request) (*http.Response, error)
-}
-
-// Stream delegates to Transport.Stream when available, returning the raw
-// [http.Response] from the underlying [http.RoundTripper]. The caller owns
-// the response body and must close it. Use Stream for proxy and streaming
-// use cases where bytes are forwarded incrementally; use [Do] when you want
-// a decoded Go value.
-//
-// Stream returns [ErrTransportMissingMethodStream] when the configured
-// transport does not implement [Streamer].
+// Stream delegates to Transport.Stream, returning the raw [http.Response] from
+// the underlying [http.RoundTripper]. The caller owns the response body and
+// must close it. Use Stream for proxy and streaming use cases where bytes are
+// forwarded incrementally; use [Do] when you want a decoded Go value.
 func (c *Client) Stream(req *http.Request) (*http.Response, error) {
-	st, ok := c.Transport.(Streamer)
-	if !ok {
-		return nil, ErrTransportMissingMethodStream
-	}
 	if req.Header == nil {
 		// Pre-allocate for the headers the transport layer sets on every
 		// outgoing request (User-Agent, Authorization, Content-Type,
@@ -502,7 +465,7 @@ func (c *Client) Stream(req *http.Request) (*http.Response, error) {
 		const defaultHeaderCount = 8
 		req.Header = make(http.Header, defaultHeaderCount)
 	}
-	return st.Stream(req)
+	return c.Transport.Stream(req)
 }
 
 // Do gets and performs the request. It also tries to parse the response into the dataPointer.
@@ -529,10 +492,20 @@ func (c *Client) Do(ctx context.Context, method string, req Request, dataPointer
 		httpReq = httpReq.WithContext(ctx)
 	}
 
-	//nolint:bodyclose // body got already closed by Perform, this is a nopcloser
-	resp, err := c.Perform(httpReq)
+	resp, err := c.Stream(httpReq)
 	if resp == nil {
 		return nil, err
+	}
+
+	// Buffer and close the raw body so the TCP connection returns to the pool.
+	// Stream returns the body unbuffered; Do owns it from here.
+	if resp.Body != nil {
+		body, rerr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		if rerr != nil && err == nil {
+			err = fmt.Errorf("%w: %w", opensearchtransport.ErrResponseBodyRead, rerr)
+		}
 	}
 
 	response := &Response{
@@ -543,13 +516,10 @@ func (c *Client) Do(ctx context.Context, method string, req Request, dataPointer
 	}
 
 	if err != nil {
-		// Perform returns (resp != nil, err != nil) in two distinct cases:
-		// a genuine body-read failure during response buffering, and an
-		// unrelated transport error returned alongside a response (e.g. the
-		// context being cancelled during retry backoff after a retryable
-		// status). Only label the former as ErrReadBody; otherwise surface
-		// the underlying error so its identity (such as context.Canceled)
-		// is preserved without a misleading "failed to read body" prefix.
+		// Stream may return (resp != nil, err != nil) in two cases: a body-read
+		// failure (ErrResponseBodyRead) or an unrelated transport error alongside
+		// a response (e.g. context cancellation during retry backoff). Only label
+		// the former as ErrReadBody so callers can distinguish the two.
 		if errors.Is(err, opensearchtransport.ErrResponseBodyRead) {
 			return response, fmt.Errorf("%w, status: %d, err: %w", ErrReadBody, resp.StatusCode, err)
 		}
@@ -557,14 +527,9 @@ func (c *Client) Do(ctx context.Context, method string, req Request, dataPointer
 	}
 
 	if resp.Body != nil {
-		// Buffer the response payload into rawBody for every Do response --
-		// success, error, and no-decode (nil dataPointer) alike -- so the
-		// value-receiver String renders via the rawBody fast-path and never
-		// drains Body, and a subsequent ParseError still reads an intact Body.
-		// Without this, a String call (e.g. log.Printf("%s", resp)) would
-		// consume the single-use Body. In the default buffered mode Perform
-		// already returned an in-memory NopCloser, so this just copies bytes
-		// already resident in memory.
+		// Buffer the response payload into rawBody so the value-receiver String
+		// renders via the rawBody fast-path and never drains Body, and a
+		// subsequent ParseError still reads an intact Body.
 		data, rerr := io.ReadAll(resp.Body)
 		if rerr != nil {
 			return response, fmt.Errorf("%w, status: %d, err: %w", ErrReadBody, resp.StatusCode, rerr)

--- a/opensearch_integration_test.go
+++ b/opensearch_integration_test.go
@@ -248,7 +248,7 @@ type TestTransport struct {
 	t       *testing.T
 }
 
-func (tr *TestTransport) Perform(req *http.Request) (*http.Response, error) {
+func (tr *TestTransport) Stream(req *http.Request) (*http.Response, error) {
 	// Use centralized URL construction
 	u := mockhttp.GetOpenSearchURL(tr.t)
 	req.URL.Scheme = u.Scheme
@@ -363,7 +363,7 @@ func TestClientGetConfigIntegration(t *testing.T) {
 		req, err := build.Request(http.MethodGet, "/", nil, nil, nil)
 		require.NoError(t, err)
 
-		resp, err := newClient.Perform(req)
+		resp, err := newClient.Stream(req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		defer resp.Body.Close()
@@ -403,7 +403,7 @@ func TestNewFromClientIntegration(t *testing.T) {
 		req, err := build.Request(http.MethodGet, "/", nil, nil, nil)
 		require.NoError(t, err)
 
-		resp1, err := osClient.Perform(req)
+		resp1, err := osClient.Stream(req)
 		require.NoError(t, err)
 		require.NotNil(t, resp1)
 		defer resp1.Body.Close()

--- a/opensearch_internal_test.go
+++ b/opensearch_internal_test.go
@@ -193,13 +193,13 @@ func TestClientConfiguration(t *testing.T) {
 }
 
 func TestClientInterfe(t *testing.T) {
-	t.Run("Perform()", func(t *testing.T) {
+	t.Run("Stream()", func(t *testing.T) {
 		c, err := NewClient(Config{Transport: mockhttp.NewRoundTripFunc(t, defaultRoundTripFunc)})
 		require.NoError(t, err)
 
 		call := called
 
-		res, err := c.Perform(&http.Request{URL: &url.URL{Path: "/test"}, Header: make(http.Header)})
+		res, err := c.Stream(&http.Request{URL: &url.URL{Path: "/test"}, Header: make(http.Header)})
 		if err == nil && res != nil && res.Body != nil {
 			res.Body.Close()
 		}
@@ -369,41 +369,41 @@ func TestResponseString_ErrorBodyNotDrained(t *testing.T) {
 
 // fakeTransport is an opensearchtransport.Interface that returns a fixed
 // (response, error) pair, used to exercise Client.Do's handling of the
-// (resp != nil, err != nil) contract that Perform may now return.
+// (resp != nil, err != nil) contract that Stream may return.
 type fakeTransport struct {
 	resp *http.Response
 	err  error
 }
 
-func (f fakeTransport) Perform(*http.Request) (*http.Response, error) {
+func (f fakeTransport) Stream(*http.Request) (*http.Response, error) {
 	return f.resp, f.err
 }
 
-// TestDoPerformErrorClassification verifies that Client.Do only labels a
+// TestDoStreamErrorClassification verifies that Client.Do only labels a
 // returned error as ErrReadBody when it is a genuine body-read failure
 // (signaled by opensearchtransport.ErrResponseBodyRead). An unrelated transport
 // error returned alongside a response -- e.g. context cancellation during retry
 // backoff -- must surface with its identity intact and without the misleading
 // "failed to read body" prefix.
-func TestDoPerformErrorClassification(t *testing.T) {
+func TestDoStreamErrorClassification(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name        string
-		performErr  error
+		streamErr   error
 		wantReadErr bool   // expect errors.Is(err, ErrReadBody)
 		wantIs      error  // an error the result must still wrap (nil to skip)
 		wantNotMsg  string // substring that must NOT appear in the message (empty to skip)
 	}{
 		{
 			name:        "genuine body-read failure is labeled ErrReadBody",
-			performErr:  fmt.Errorf("%w: %w", opensearchtransport.ErrResponseBodyRead, io.ErrUnexpectedEOF),
+			streamErr:   fmt.Errorf("%w: %w", opensearchtransport.ErrResponseBodyRead, io.ErrUnexpectedEOF),
 			wantReadErr: true,
 			wantIs:      io.ErrUnexpectedEOF,
 		},
 		{
 			name:        "context cancellation during backoff is not ErrReadBody",
-			performErr:  context.Canceled,
+			streamErr:   context.Canceled,
 			wantReadErr: false,
 			wantIs:      context.Canceled,
 			wantNotMsg:  "failed to read body",
@@ -433,7 +433,7 @@ func TestDoPerformErrorClassification(t *testing.T) {
 					Header:     http.Header{},
 					Body:       io.NopCloser(strings.NewReader("")),
 				},
-				err: tt.performErr,
+				err: tt.streamErr,
 			}
 
 			resp, err := c.Do(context.TODO(), http.MethodGet, testReq{Path: "/test"}, nil)
@@ -453,6 +453,50 @@ func TestDoPerformErrorClassification(t *testing.T) {
 			}
 		})
 	}
+}
+
+// headerCapturingTransport records the request header it is handed so a test
+// can assert Client.Do never dispatches a request with a nil Header map.
+type headerCapturingTransport struct {
+	gotHeader http.Header
+	called    bool
+}
+
+func (h *headerCapturingTransport) Stream(req *http.Request) (*http.Response, error) {
+	h.called = true
+	h.gotHeader = req.Header
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader("{}")),
+	}, nil
+}
+
+// TestDoInitializesNilRequestHeader guards the contract that Client.Do routes
+// through Client.Stream, which allocates req.Header when a Request builds one
+// with a nil Header. A custom transport that touches req.Header (e.g. calls
+// req.SetBasicAuth) would otherwise panic with "assignment to entry in nil
+// map". Regression test for the Perform -> Stream transition.
+func TestDoInitializesNilRequestHeader(t *testing.T) {
+	t.Parallel()
+
+	noDiscovery := false
+	c, err := NewClient(Config{
+		Transport:            mockhttp.NewRoundTripFunc(t, defaultRoundTripFunc),
+		DiscoverNodesOnStart: &noDiscovery,
+	})
+	require.NoError(t, err)
+
+	tr := &headerCapturingTransport{}
+	c.Transport = tr
+
+	// testReq with no Headers builds an *http.Request whose Header is nil.
+	resp, err := c.Do(context.TODO(), http.MethodGet, testReq{Path: "/test"}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	require.True(t, tr.called, "transport must be invoked")
+	require.NotNil(t, tr.gotHeader, "Do must hand the transport a non-nil request Header")
 }
 
 func TestAddrsToURLs(t *testing.T) {

--- a/opensearchapi/api.go
+++ b/opensearchapi/api.go
@@ -230,7 +230,7 @@ func (c *Client) Clone() *Client {
 
 // do calls [opensearch.Do] and checks the response for OpenSearch API errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/opensearchapi/api_do_internal_test.go
+++ b/opensearchapi/api_do_internal_test.go
@@ -28,14 +28,13 @@ func (doTestReq) GetRequest(method string) (*http.Request, error) {
 }
 
 // doTestTransport is an opensearchtransport.Interface that returns a fixed
-// response, mimicking what Perform yields in the default buffered mode: the
-// body is an in-memory NopCloser that has already been read once from the wire.
+// response with an in-memory NopCloser body.
 type doTestTransport struct {
 	statusCode int
 	body       string
 }
 
-func (tr doTestTransport) Perform(*http.Request) (*http.Response, error) {
+func (tr doTestTransport) Stream(*http.Request) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: tr.statusCode,
 		Status:     http.StatusText(tr.statusCode),

--- a/opensearchtransport/cluster_health.go
+++ b/opensearchtransport/cluster_health.go
@@ -227,7 +227,7 @@ func (c *Transport) fetchAndEvaluateNodeStats(conn *Connection, pool *multiServe
 	}
 	if res.Body != nil {
 		// Drain on close so http.Transport can reuse the connection. This is a
-		// raw RoundTrip path with no Perform buffering safety net, so closing a
+		// raw RoundTrip path via Stream; body is caller-owned, so closing a
 		// partially-read body (e.g. on the non-200 early return below) would
 		// otherwise defeat keep-alive. On the success path io.ReadAll has
 		// already reached EOF, so the drain is a cheap no-op.

--- a/opensearchtransport/complete_discovery_flow_test.go
+++ b/opensearchtransport/complete_discovery_flow_test.go
@@ -62,7 +62,7 @@ func TestCompleteDiscoveryFlow(t *testing.T) {
 	req1, err := http.NewRequest(http.MethodGet, "/", nil)
 	require.NoError(t, err)
 
-	res1, err := transport.Perform(req1)
+	res1, err := transport.Stream(req1)
 	require.NoError(t, err)
 	res1.Body.Close()
 
@@ -84,13 +84,13 @@ func TestCompleteDiscoveryFlow(t *testing.T) {
 	bulkReq, err := http.NewRequest(http.MethodPost, "/_bulk", strings.NewReader(bulkBody))
 	require.NoError(t, err)
 	bulkReq.Header.Set("Content-Type", "application/x-ndjson")
-	bulkRes, err := transport.Perform(bulkReq)
+	bulkRes, err := transport.Stream(bulkReq)
 	require.NoError(t, err)
 	bulkRes.Body.Close()
 
 	t.Cleanup(func() {
 		delReq, _ := http.NewRequest(http.MethodDelete, "/test-discovery-flow", nil)
-		if res, err := transport.Perform(delReq); err == nil {
+		if res, err := transport.Stream(delReq); err == nil {
 			res.Body.Close()
 		}
 	})
@@ -98,14 +98,14 @@ func TestCompleteDiscoveryFlow(t *testing.T) {
 	// Test search operation - should route to data/search nodes
 	searchReq, err := http.NewRequest(http.MethodGet, "/_search", nil)
 	require.NoError(t, err)
-	searchRes, err := transport.Perform(searchReq)
+	searchRes, err := transport.Stream(searchReq)
 	require.NoError(t, err)
 	searchRes.Body.Close()
 
 	// Test general operation - should use round-robin fallback
 	infoReq, err := http.NewRequest(http.MethodGet, "/", nil)
 	require.NoError(t, err)
-	infoRes, err := transport.Perform(infoReq)
+	infoRes, err := transport.Stream(infoReq)
 	require.NoError(t, err)
 	infoRes.Body.Close()
 }

--- a/opensearchtransport/connection_integration_internal_test.go
+++ b/opensearchtransport/connection_integration_internal_test.go
@@ -72,7 +72,7 @@ func TestMultiServerPool(t *testing.T) {
 		// Test basic request functionality
 		for i := 1; i <= 5; i++ {
 			req, _ := http.NewRequest(http.MethodGet, "/", nil)
-			res, err := transport.Perform(req)
+			res, err := transport.Stream(req)
 			if err != nil {
 				t.Errorf("Unexpected error: %v", err)
 				continue
@@ -150,7 +150,7 @@ func TestMultiServerPool(t *testing.T) {
 			req, err := http.NewRequest(http.MethodGet, "/", nil)
 			require.NoError(t, err, "Failed to create request %d", i)
 
-			res, err := transport.Perform(req)
+			res, err := transport.Stream(req)
 			require.NoError(t, err, "Request %d failed", i)
 			require.NotNil(t, res, "Request %d returned nil response", i)
 

--- a/opensearchtransport/discovery.go
+++ b/opensearchtransport/discovery.go
@@ -1866,7 +1866,7 @@ func (c *Transport) getShardPlacement(ctx context.Context) (map[string]*indexSha
 	if res == nil {
 		return nil, fmt.Errorf("nil response from /_cat/shards")
 	}
-	// Drain on close: this raw RoundTrip path has no Perform buffering, and
+	// Drain on close: this raw RoundTrip path (Stream); body is caller-owned, and
 	// json.Decode below stops at the end of the JSON value without consuming any
 	// trailing bytes, so a plain Close would defeat keep-alive on both the
 	// non-200 return and the healthy path.

--- a/opensearchtransport/integration_test_helpers_test.go
+++ b/opensearchtransport/integration_test_helpers_test.go
@@ -75,7 +75,7 @@ func selectorRouteObserved(transport *Transport, ctx context.Context, obs routeO
 		}
 		obs.reset()
 		probeReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
-		resp, err := transport.Perform(probeReq)
+		resp, err := transport.Stream(probeReq)
 		if err != nil {
 			return false
 		}
@@ -350,7 +350,7 @@ func selectorIndexGreen(transport *Transport, ctx context.Context, indexName str
 		if err != nil {
 			return false
 		}
-		resp, err := transport.Perform(req)
+		resp, err := transport.Stream(req)
 		if err != nil {
 			return false
 		}
@@ -373,7 +373,7 @@ func clusterNodeCount(t *testing.T, transport *Transport, ctx context.Context) i
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/_nodes", nil)
 	require.NoError(t, err)
 
-	resp, err := transport.Perform(req)
+	resp, err := transport.Stream(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 

--- a/opensearchtransport/logger_benchmark_test.go
+++ b/opensearchtransport/logger_benchmark_test.go
@@ -62,7 +62,7 @@ func BenchmarkTransportLogger(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			req, _ := http.NewRequest(http.MethodGet, "/abc", nil)
-			res, err := tp.Perform(req)
+			res, err := tp.Stream(req)
 			if err != nil {
 				b.Fatalf("Unexpected error: %q", err)
 			}

--- a/opensearchtransport/logger_internal_test.go
+++ b/opensearchtransport/logger_internal_test.go
@@ -76,7 +76,7 @@ func TestTransportLogger(t *testing.T) {
 		for range 100 {
 			wg.Go(func() {
 				req, _ := http.NewRequest(http.MethodGet, "/abc", nil)
-				resp, err := tp.Perform(req)
+				resp, err := tp.Stream(req)
 				if err != nil {
 					t.Errorf("Unexpected error: %s", err)
 					return
@@ -96,7 +96,7 @@ func TestTransportLogger(t *testing.T) {
 		})
 
 		req, _ := http.NewRequest(http.MethodGet, "/abc", nil)
-		resp, err := tp.Perform(req)
+		resp, err := tp.Stream(req)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -114,7 +114,7 @@ func TestTransportLogger(t *testing.T) {
 		})
 
 		req, _ := http.NewRequest(http.MethodGet, "/abc", nil)
-		resp, err := tp.Perform(req)
+		resp, err := tp.Stream(req)
 		if err == nil {
 			defer resp.Body.Close()
 			t.Errorf("Expected error: %v", err)
@@ -137,7 +137,7 @@ func TestTransportLogger(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "/abc?q=a,b", nil)
 		req.Body = io.NopCloser(strings.NewReader(`{"query":"42"}`))
 
-		res, err := tp.Perform(req)
+		res, err := tp.Stream(req)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -170,7 +170,7 @@ func TestTransportLogger(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "/abc?q=a,b", nil)
 		req.Body = io.NopCloser(strings.NewReader(`{"query":"42"}`))
 
-		res, err := tp.Perform(req)
+		res, err := tp.Stream(req)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -217,7 +217,7 @@ func TestTransportLogger(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "/abc?q=a,b", nil)
 		req.Body = io.NopCloser(strings.NewReader(`{"query":"42"}`))
 
-		res, err := tp.Perform(req)
+		res, err := tp.Stream(req)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -273,7 +273,7 @@ func TestTransportLogger(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "/abc?q=a,b", nil)
 		req.Body = io.NopCloser(strings.NewReader(`{"query":"42"}`))
 
-		res, err := tp.Perform(req)
+		res, err := tp.Stream(req)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -310,7 +310,7 @@ func TestTransportLogger(t *testing.T) {
 
 		req, _ := http.NewRequest(http.MethodGet, "/abc?q=a,b", nil)
 		req.Body = io.NopCloser(strings.NewReader(`{"query":"42"}`))
-		resp, err := tp.Perform(req)
+		resp, err := tp.Stream(req)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -350,7 +350,7 @@ func TestTransportLogger(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "/abc?q=a,b", nil)
 		req.Body = io.NopCloser(strings.NewReader(`{"query":"42"}`))
 
-		res, err := tp.Perform(req)
+		res, err := tp.Stream(req)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -395,7 +395,7 @@ func TestTransportLogger(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "/abc?q=a,b", nil)
 		req.Body = io.NopCloser(strings.NewReader(`{"query":"42"}`))
 
-		res, err := tp.Perform(req)
+		res, err := tp.Stream(req)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}

--- a/opensearchtransport/metrics_internal_test.go
+++ b/opensearchtransport/metrics_internal_test.go
@@ -153,7 +153,7 @@ func TestMetrics(t *testing.T) {
 		tp.metrics.zombieConnections.Store(5)
 
 		req, _ := http.NewRequest(http.MethodHead, "/", nil)
-		resp, err := tp.Perform(req)
+		resp, err := tp.Stream(req)
 		if err == nil {
 			defer resp.Body.Close()
 		}
@@ -219,7 +219,7 @@ func TestMetrics(t *testing.T) {
 		})
 
 		req, _ := http.NewRequest(http.MethodHead, "/", nil)
-		if resp, err := tp.Perform(req); err == nil {
+		if resp, err := tp.Stream(req); err == nil {
 			resp.Body.Close()
 		}
 

--- a/opensearchtransport/opensearchtransport.go
+++ b/opensearchtransport/opensearchtransport.go
@@ -69,12 +69,12 @@ var (
 	reGoVersion          = regexp.MustCompile(`go(\d+\.\d+\..+)`)
 	errHealthCheckFailed = errors.New("connection health check error")
 
-	// ErrResponseBodyRead identifies an error that occurred while buffering the
-	// response body inside [Transport.Perform]. Callers that receive a non-nil
-	// response together with a non-nil error can use [errors.Is] against this
-	// sentinel to distinguish a genuine body-read failure from an unrelated
-	// transport error returned alongside a response (for example, context
-	// cancellation during retry backoff after a retryable status was received).
+	// ErrResponseBodyRead identifies an error that occurred while reading the
+	// response body. Callers that receive a non-nil response together with a
+	// non-nil error can use [errors.Is] against this sentinel to distinguish a
+	// genuine body-read failure from an unrelated transport error returned
+	// alongside a response (for example, context cancellation during retry
+	// backoff after a retryable status was received).
 	ErrResponseBodyRead = errors.New("error reading response body")
 )
 
@@ -97,16 +97,12 @@ func getConnectionFromPool(c *Transport, req *http.Request) (*Connection, error)
 // Interface is the HTTP client contract used by the OpenSearch API layer.
 //
 // Implementations may return a non-nil *http.Response together with a non-nil
-// error (for example, when the response was received but buffering its body
-// failed). Callers must treat a nil response, not a non-nil error, as the
-// signal for a hard transport failure. See [Transport.Perform] for details.
-//
-// TODO(v5): add Stream(*http.Request) (*http.Response, error) to this
-// interface and remove the deprecated Perform. Stream is currently exposed
-// only as a concrete [*Transport] method to avoid a v4 interface change; v5
-// will swap the surfaces.
+// error (for example, when the response was received but body reading failed,
+// or when context cancellation races a retry). Callers must treat a nil
+// response, not a non-nil error, as the signal for a hard transport failure.
+// The caller owns the response body and must close it.
 type Interface interface {
-	Perform(*http.Request) (*http.Response, error)
+	Stream(*http.Request) (*http.Response, error)
 }
 
 // OpenSearchInfo represents the root endpoint response structure for health checks.
@@ -1238,51 +1234,6 @@ func (c *Transport) Close() error {
 	return nil
 }
 
-// Perform executes the request and returns a buffered response.
-//
-// The response body is fully read into memory and replaced with an
-// [io.NopCloser] over a [bytes.Reader] before returning, so the underlying
-// TCP connection is drained and returned to the connection pool even if the
-// caller never reads the body. This is the right behavior for the typed
-// [github.com/opensearch-project/opensearch-go/v5.Do] helpers, which decode
-// the buffered body into a Go value.
-//
-// Perform may return a non-nil *http.Response together with a non-nil error.
-// This happens when the request reached a server and a response was received,
-// but a subsequent step failed -- most notably when buffering the response
-// body fails (see [ErrResponseBodyRead]), or when the request context is
-// cancelled during retry backoff after a retryable status was received. In
-// those cases the returned response is still usable (its body, if any, holds
-// whatever bytes were read before the failure).
-//
-// Callers must therefore treat resp == nil, not err != nil, as the signal for
-// a hard transport failure where no response is available. The same contract
-// applies to any custom [Interface] implementation.
-//
-// Deprecated: Perform follows the legacy buffered-response contract and will
-// be removed before the first stable release. Use [Transport.Stream] when you
-// need raw byte forwarding (the caller owns the body), or the typed
-// [github.com/opensearch-project/opensearch-go/v5.Do] helpers when you want
-// a decoded Go value (the SDK owns the body).
-func (c *Transport) Perform(req *http.Request) (*http.Response, error) {
-	res, err := c.Stream(req)
-
-	// Read, close and replace the http response body to close the connection.
-	// Callers that want to stream raw bytes should call [Transport.Stream]
-	// directly; Perform exists for the typed Do helpers and for backward
-	// compatibility with v4 callers that relied on a buffered body.
-	if res != nil && res.Body != nil {
-		body, rerr := io.ReadAll(res.Body)
-		res.Body.Close()
-		res.Body = io.NopCloser(bytes.NewReader(body))
-		if rerr != nil && err == nil {
-			err = fmt.Errorf("%w: %w", ErrResponseBodyRead, rerr)
-		}
-	}
-
-	return res, err
-}
-
 // Stream executes the request and returns the raw [http.Response] from the
 // underlying [http.RoundTripper]. The caller owns the response body: Stream
 // does not read or close res.Body. Use Stream when you want to forward or
@@ -1297,8 +1248,7 @@ func (c *Transport) Perform(req *http.Request) (*http.Response, error) {
 // Stream mutates req.URL to point at the selected backend (Scheme/Host) so
 // that signing, retry, and routing all see the resolved address. It performs
 // retry, signing, header injection, request-body compression, metrics, and
-// the seed URL fallback identically to [Transport.Perform]; the only difference
-// is that Stream returns the raw RoundTrip body instead of buffering it.
+// the seed URL fallback before returning the raw RoundTrip body.
 //
 // Pairs with [github.com/opensearch-project/opensearch-go/v5.Do]: use Do[T]
 // for typed, decoded results (the SDK owns the body), use Stream for raw
@@ -2242,7 +2192,7 @@ func (c *Transport) fetchClusterHealth(
 	}
 	defer func() {
 		if res.Body != nil {
-			// Drain on close: raw RoundTrip path with no Perform buffering
+			// Drain on close: Stream returns the raw RoundTrip body unbuffered
 			// safety net. Closing a partially-read body (the non-200 early
 			// return below, or the io.ReadAll error path) would otherwise
 			// defeat keep-alive. On the success path io.ReadAll has already

--- a/opensearchtransport/opensearchtransport_benchmark_test.go
+++ b/opensearchtransport/opensearchtransport_benchmark_test.go
@@ -79,7 +79,7 @@ func BenchmarkTransport(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			req, _ := http.NewRequest(http.MethodGet, "/abc", nil)
-			res, err := tp.Perform(req)
+			res, err := tp.Stream(req)
 			if err != nil {
 				b.Fatalf("Unexpected error: %q", err)
 			}
@@ -105,7 +105,7 @@ func BenchmarkTransport(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			req, _ := http.NewRequest(http.MethodGet, "/abc", nil)
-			res, err := tp.Perform(req)
+			res, err := tp.Stream(req)
 			if err != nil {
 				b.Fatalf("Unexpected error: %q", err)
 			}

--- a/opensearchtransport/opensearchtransport_integration_multinode_test.go
+++ b/opensearchtransport/opensearchtransport_integration_multinode_test.go
@@ -56,7 +56,7 @@ func TestTransportSelector(t *testing.T) {
 			t.Fatalf("Unexpected error: %s", err)
 		}
 
-		res, err := transport.Perform(req)
+		res, err := transport.Stream(req)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}

--- a/opensearchtransport/opensearchtransport_integration_test.go
+++ b/opensearchtransport/opensearchtransport_integration_test.go
@@ -78,7 +78,7 @@ func TestTransportRetries(t *testing.T) {
 				t.Fatalf("Unexpected error: %s", err)
 			}
 
-			res, err := transport.Perform(req)
+			res, err := transport.Stream(req)
 			if err != nil {
 				t.Fatalf("Unexpected error: %s", err)
 			}
@@ -129,7 +129,7 @@ func TestTransportHeaders(t *testing.T) {
 	})
 
 	req, _ := http.NewRequest(http.MethodGet, "/", nil)
-	res, err := tp.Perform(req)
+	res, err := tp.Stream(req)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -171,22 +171,26 @@ func TestTransportBodyClose(t *testing.T) {
 	})
 
 	req, _ := http.NewRequest(http.MethodGet, "/", nil)
-	res, err := tp.Perform(req)
+	res, err := tp.Stream(req)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
-	if closeResp := res.Body.Close(); closeResp != nil {
-		t.Fatalf("Unexpected return on res.Body.Close(): %s", closeResp)
-	}
-	if closeResp := res.Body.Close(); closeResp != nil {
-		t.Fatalf("Unexpected return on res.Body.Close(): %s", closeResp)
-	}
+
+	// Stream returns the raw, unbuffered body: the caller owns it and must
+	// read before closing. Read first, then verify Close is idempotent.
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		t.Fatalf("Failed to read the response body: %s", err)
 	}
 	if len(body) == 0 {
 		t.Fatalf("Unexpected response body:\n%s", body)
+	}
+
+	if closeResp := res.Body.Close(); closeResp != nil {
+		t.Fatalf("Unexpected return on res.Body.Close(): %s", closeResp)
+	}
+	if closeResp := res.Body.Close(); closeResp != nil {
+		t.Fatalf("Unexpected return on second res.Body.Close(): %s", closeResp)
 	}
 }
 
@@ -223,7 +227,7 @@ func TestTransportCompression(t *testing.T) {
 	indexName := testutil.MustUniqueString(t, "/transport-compression-test")
 
 	req, _ = http.NewRequest(http.MethodPut, indexName, nil)
-	res, err = transport.Perform(req)
+	res, err = transport.Stream(req)
 	if err != nil {
 		t.Fatalf("Unexpected error, cannot create index: %v", err)
 	}
@@ -232,7 +236,7 @@ func TestTransportCompression(t *testing.T) {
 	}
 
 	req, _ = http.NewRequest(http.MethodGet, indexName, nil)
-	res, err = transport.Perform(req)
+	res, err = transport.Stream(req)
 	if err != nil {
 		t.Fatalf("Unexpected error, cannot find index: %v", err)
 	}
@@ -246,7 +250,7 @@ func TestTransportCompression(t *testing.T) {
 		strings.NewReader(`{"solidPayload": 1}`),
 	)
 	req.Header.Set("Content-Type", "application/json")
-	res, err = transport.Perform(req)
+	res, err = transport.Stream(req)
 	if err != nil {
 		t.Fatalf("Unexpected error, cannot POST payload: %v", err)
 	}
@@ -259,7 +263,7 @@ func TestTransportCompression(t *testing.T) {
 	}
 
 	req, _ = http.NewRequest(http.MethodDelete, indexName, nil)
-	res, err = transport.Perform(req)
+	res, err = transport.Stream(req)
 	if err != nil {
 		t.Fatalf("Unexpected error, cannot DELETE %s: %v", indexName, err)
 	}

--- a/opensearchtransport/opensearchtransport_internal_test.go
+++ b/opensearchtransport/opensearchtransport_internal_test.go
@@ -335,7 +335,7 @@ func TestTransportCustomConnectionPool(t *testing.T) {
 	})
 }
 
-func TestTransportPerform(t *testing.T) {
+func TestTransportStream(t *testing.T) {
 	t.Run("Executes", func(t *testing.T) {
 		u, _ := url.Parse("https://foo.com/bar")
 		tp, _ := New(
@@ -351,7 +351,7 @@ func TestTransportPerform(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "/abc", nil)
 
 		//nolint:bodyclose // Mock response does not have a body to close
-		res, err := tp.Perform(req)
+		res, err := tp.Stream(req)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -480,14 +480,14 @@ func TestTransportPerform(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "/abc", nil)
 
 		//nolint:bodyclose // Mock response does not have a body to close
-		_, err := tp.Perform(req)
+		_, err := tp.Stream(req)
 		if err.Error() != `cannot get connection: no connections available` {
 			t.Fatalf("Expected error `cannot get connection: no connections available`: but got error %q", err)
 		}
 	})
 }
 
-func TestTransportPerformRetries(t *testing.T) {
+func TestTransportStreamRetries(t *testing.T) {
 	t.Run("Retry request on network error and return the response", func(t *testing.T) {
 		var (
 			i       int
@@ -517,7 +517,7 @@ func TestTransportPerformRetries(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "/abc", nil)
 
 		//nolint:bodyclose // Mock response does not have a body to close
-		res, err := tp.Perform(req)
+		res, err := tp.Stream(req)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -560,7 +560,7 @@ func TestTransportPerformRetries(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "/abc", nil)
 
 		//nolint:bodyclose // Mock response does not have a body to close
-		res, err := tp.Perform(req)
+		res, err := tp.Stream(req)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -603,7 +603,7 @@ func TestTransportPerformRetries(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "/abc", nil)
 
 		//nolint:bodyclose // Mock response does not have a body to close
-		res, err := tp.Perform(req)
+		res, err := tp.Stream(req)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -641,7 +641,7 @@ func TestTransportPerformRetries(t *testing.T) {
 
 		req, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-		res, err := tp.Perform(req)
+		res, err := tp.Stream(req)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -688,7 +688,7 @@ func TestTransportPerformRetries(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "/abc", nil)
 
 		//nolint:bodyclose // Mock response does not have a body to close
-		res, err := tp.Perform(req)
+		res, err := tp.Stream(req)
 		if err == nil {
 			t.Fatalf("Expected error, got: %v", err)
 		}
@@ -724,7 +724,7 @@ func TestTransportPerformRetries(t *testing.T) {
 
 		req, _ := http.NewRequest(http.MethodPost, "/abc", strings.NewReader("FOOBAR"))
 		//nolint:bodyclose // Mock response does not have a body to close
-		res, err := tp.Perform(req)
+		res, err := tp.Stream(req)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -765,7 +765,7 @@ func TestTransportPerformRetries(t *testing.T) {
 
 		req, _ := http.NewRequest(http.MethodPost, "/abc", strings.NewReader(foobar))
 		//nolint:bodyclose // Mock response does not have a body to close
-		res, err := tp.Perform(req)
+		res, err := tp.Stream(req)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -812,7 +812,7 @@ func TestTransportPerformRetries(t *testing.T) {
 
 		req, _ := http.NewRequest(http.MethodPost, "/abc", strings.NewReader(expectedBody))
 		//nolint:bodyclose // Mock response does not have a body to close
-		_, err := tp.Perform(req)
+		_, err := tp.Stream(req)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -843,7 +843,7 @@ func TestTransportPerformRetries(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "/abc", nil)
 
 		//nolint:bodyclose // Mock response does not have a body to close
-		res, err := tp.Perform(req)
+		res, err := tp.Stream(req)
 		if err == nil {
 			t.Fatalf("Expected error, got: %v", err)
 		}
@@ -879,7 +879,7 @@ func TestTransportPerformRetries(t *testing.T) {
 
 		req, _ := http.NewRequest(http.MethodGet, "/abc", nil)
 		//nolint:bodyclose // Mock response does not have a body to close
-		tp.Perform(req)
+		tp.Stream(req)
 
 		if count := i.Load(); count != 1 {
 			t.Errorf("Unexpected number of requests, want=%d, got=%d", 1, count)
@@ -923,7 +923,7 @@ func TestTransportPerformRetries(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "/abc", nil)
 
 		//nolint:bodyclose // Mock response does not have a body to close
-		res, err := tp.Perform(req)
+		res, err := tp.Stream(req)
 		end := time.Since(start)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
@@ -964,7 +964,7 @@ func TestTransportPerformRetries(t *testing.T) {
 		req = req.WithContext(ctx)
 
 		//nolint:bodyclose // Mock response does not have a body to close
-		_, err := tp.Perform(req)
+		_, err := tp.Stream(req)
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("expected context.DeadlineExceeded, got %s", err)
 		}
@@ -1007,7 +1007,7 @@ func TestTransportPerformRetries(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "/abc", nil)
 
 		//nolint:bodyclose // Mock response does not have a body to close
-		_, err := tp.Perform(req)
+		_, err := tp.Stream(req)
 		if err == nil {
 			t.Fatalf("Expected error, got: %v", err)
 		}
@@ -1115,7 +1115,7 @@ func TestMaxRetries(t *testing.T) {
 			})
 
 			//nolint:bodyclose // Mock response does not have a body to close
-			c.Perform(&http.Request{URL: &url.URL{}, Header: make(http.Header)}) // errcheck ignore
+			c.Stream(&http.Request{URL: &url.URL{}, Header: make(http.Header)}) // errcheck ignore
 
 			if test.expectedCallCount != callCount {
 				t.Errorf("Bad retry call count, got : %d, want : %d", callCount, test.expectedCallCount)
@@ -1181,7 +1181,7 @@ func TestRequestCompression(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodPost, "/abc", bytes.NewBufferString(test.inputBody))
 
 			//nolint:bodyclose // Mock response does not have a body to close
-			res, err := tp.Perform(req)
+			res, err := tp.Stream(req)
 			if err != nil {
 				t.Fatalf("Unexpected error: %s", err)
 			}
@@ -1193,132 +1193,84 @@ func TestRequestCompression(t *testing.T) {
 	}
 }
 
-// TestPerformStreamBuffering covers the v4 split between Perform (buffered)
-// and Stream (raw, caller-owned body): the same handler must produce a
-// re-readable in-memory body when called via Perform and a live, un-drained,
-// caller-closeable body when called via Stream. Both entry points must
-// rewrite req.URL.Host to the selected backend address; that side effect is
-// load-bearing for downstream signing and routing.
-func TestPerformStreamBuffering(t *testing.T) {
+// TestStreamBuffering verifies that Stream returns the body unbuffered: the
+// underlying body must not be read or closed before the caller drains it, and
+// req.URL.Host must be rewritten to the selected backend (load-bearing for
+// downstream signing and routing).
+func TestStreamBuffering(t *testing.T) {
 	const largeBody = "ABCDEFGHIJ"
 
-	tests := []struct {
-		name           string
-		viaStream      bool // true => call tp.Stream, false => call tp.Perform
-		wantBodyRead   bool // body Read() must have been called before the helper returned
-		wantBodyClosed bool // body Close() must have been called before the helper returned
-	}{
-		{name: "Perform buffers", viaStream: false, wantBodyRead: true, wantBodyClosed: true},
-		{name: "Stream leaves body untouched", viaStream: true, wantBodyRead: false, wantBodyClosed: false},
-	}
+	var (
+		bodyRead   atomic.Bool
+		bodyClosed atomic.Bool
+	)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var (
-				bodyRead   atomic.Bool
-				bodyClosed atomic.Bool
-			)
+	u, err := url.Parse("http://backend.example:9200")
+	require.NoError(t, err)
+	tp, err := New(Config{
+		URLs:              []*url.URL{u},
+		NodeStatsInterval: -1, // Disable stats poller to avoid background requests through mock transport
+		Transport: mockhttp.NewRoundTripFunc(t, func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"X-Test": []string{"yes"}},
+				Body: &trackingReadCloser{
+					Reader:  strings.NewReader(largeBody),
+					onRead:  func() { bodyRead.Store(true) },
+					onClose: func() { bodyClosed.Store(true) },
+				},
+			}, nil
+		}),
+	})
+	require.NoError(t, err)
 
-			u, err := url.Parse("http://backend.example:9200")
-			require.NoError(t, err)
-			tp, err := New(Config{
-				URLs:              []*url.URL{u},
-				NodeStatsInterval: -1, // Disable stats poller to avoid background requests through mock transport
-				Transport: mockhttp.NewRoundTripFunc(t, func(req *http.Request) (*http.Response, error) {
-					return &http.Response{
-						StatusCode: http.StatusOK,
-						Header:     http.Header{"X-Test": []string{"yes"}},
-						Body: &trackingReadCloser{
-							Reader:  strings.NewReader(largeBody),
-							onRead:  func() { bodyRead.Store(true) },
-							onClose: func() { bodyClosed.Store(true) },
-						},
-					}, nil
-				}),
-			})
-			require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodGet, "/test", nil)
+	require.NoError(t, err)
 
-			req, err := http.NewRequest(http.MethodGet, "/test", nil)
-			require.NoError(t, err)
+	res, err := tp.Stream(req)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, "yes", res.Header.Get("X-Test"))
 
-			var res *http.Response
-			if tt.viaStream {
-				res, err = tp.Stream(req)
-			} else {
-				res, err = tp.Perform(req)
-			}
-			require.NoError(t, err)
-			require.NotNil(t, res)
-			require.Equal(t, http.StatusOK, res.StatusCode)
-			require.Equal(t, "yes", res.Header.Get("X-Test"))
+	// Stream routes the request through the configured backend, so req.URL.Host
+	// must reflect the selected connection.
+	require.Equal(t, "backend.example:9200", req.URL.Host,
+		"req.URL.Host must be rewritten to the selected backend")
 
-			// Both paths route the request through the configured backend,
-			// so req.URL.Host must reflect the selected connection.
-			require.Equal(t, "backend.example:9200", req.URL.Host,
-				"req.URL.Host must be rewritten to the selected backend")
+	// Body must not be touched until the caller drains it.
+	require.False(t, bodyRead.Load(), "Stream must not read body before caller")
+	require.False(t, bodyClosed.Load(), "Stream must not close body before caller")
 
-			require.Equal(t, tt.wantBodyRead, bodyRead.Load(),
-				"unexpected bodyRead state before caller drains the body")
-			require.Equal(t, tt.wantBodyClosed, bodyClosed.Load(),
-				"unexpected bodyClosed state before caller drains the body")
+	got, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+	require.Equal(t, largeBody, string(got))
 
-			// Body content is identical regardless of entry point.
-			got, err := io.ReadAll(res.Body)
-			require.NoError(t, err)
-			require.NoError(t, res.Body.Close())
-			require.Equal(t, largeBody, string(got))
-
-			if tt.viaStream {
-				// After the caller drains and closes, the underlying
-				// trackingReadCloser must finally be observed as both
-				// read and closed.
-				require.True(t, bodyRead.Load(), "Stream caller must end up reading the body")
-				require.True(t, bodyClosed.Load(), "Stream caller must end up closing the body")
-			}
-		})
-	}
+	require.True(t, bodyRead.Load(), "Stream caller must end up reading the body")
+	require.True(t, bodyClosed.Load(), "Stream caller must end up closing the body")
 }
 
-// TestStreamNilBody verifies Stream tolerates a response with no body, and
-// confirms that Perform's wrapper does the same (Perform is a thin Stream
-// caller, but the nil-body branch in the wrapper is worth pinning).
+// TestStreamNilBody verifies Stream tolerates a response with no body.
 func TestStreamNilBody(t *testing.T) {
-	tests := []struct {
-		name      string
-		viaStream bool
-	}{
-		{name: "Stream nil body", viaStream: true},
-		{name: "Perform nil body", viaStream: false},
-	}
+	u, err := url.Parse("http://backend.example:9200")
+	require.NoError(t, err)
+	tp, err := New(Config{
+		URLs:              []*url.URL{u},
+		NodeStatsInterval: -1, // Disable stats poller to avoid background requests through mock transport
+		Transport: mockhttp.NewRoundTripFunc(t, func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusNoContent}, nil
+		}),
+	})
+	require.NoError(t, err)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			u, err := url.Parse("http://backend.example:9200")
-			require.NoError(t, err)
-			tp, err := New(Config{
-				URLs:              []*url.URL{u},
-				NodeStatsInterval: -1, // Disable stats poller to avoid background requests through mock transport
-				Transport: mockhttp.NewRoundTripFunc(t, func(*http.Request) (*http.Response, error) {
-					return &http.Response{StatusCode: http.StatusNoContent}, nil
-				}),
-			})
-			require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodHead, "/test", nil)
+	require.NoError(t, err)
 
-			req, err := http.NewRequest(http.MethodHead, "/test", nil)
-			require.NoError(t, err)
-
-			var res *http.Response
-			if tt.viaStream {
-				//nolint:bodyclose // Response has no body
-				res, err = tp.Stream(req)
-			} else {
-				//nolint:bodyclose // Response has no body
-				res, err = tp.Perform(req)
-			}
-			require.NoError(t, err)
-			require.Equal(t, http.StatusNoContent, res.StatusCode)
-		})
-	}
+	//nolint:bodyclose // Response has no body
+	res, err := tp.Stream(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, res.StatusCode)
 }
 
 // trackingReadCloser wraps a Reader and records whether Read and Close were called.
@@ -1359,7 +1311,7 @@ func TestRequestSigning(t *testing.T) {
 		)
 		req, _ := http.NewRequest(http.MethodGet, "/", nil)
 		//nolint:bodyclose // Mock response does not have a body to close
-		_, err := tp.Perform(req)
+		_, err := tp.Stream(req)
 		if err == nil {
 			t.Fatal("Expected error, but, no error found")
 		}

--- a/opensearchtransport/policy.go
+++ b/opensearchtransport/policy.go
@@ -111,7 +111,7 @@ type NextHop struct {
 
 	// MaxConcurrentShardRequests is the adaptive shard fan-out limit derived
 	// from the selected connection's search pool congestion window. When > 0,
-	// Perform() injects it as the max_concurrent_shard_requests query parameter
+	// Stream() injects it as the max_concurrent_shard_requests query parameter
 	// on search requests routed through a coordinator node. Zero means "not set"
 	// (shard-exact routing, non-search request, or feature disabled).
 	MaxConcurrentShardRequests int

--- a/opensearchtransport/policy_chain.go
+++ b/opensearchtransport/policy_chain.go
@@ -118,7 +118,7 @@ func (r *PolicyChain) OnSuccess(conn *Connection) {
 // (e.g., connection refused, EOF, TLS error, timeout).
 //
 // This does not handle HTTP-level errors like 429 or 503 --those are
-// successful transports with error status codes, handled in Perform.
+// successful transports with error status codes, handled in Stream.
 // Thread pool congestion is managed separately by the stats poller.
 //
 // Marks the connection as dead atomically. Each pool lazily evicts the

--- a/opensearchtransport/policy_index_router.go
+++ b/opensearchtransport/policy_index_router.go
@@ -595,7 +595,7 @@ func extractIndexFromPath(path string) string {
 //   - cfg: adaptive concurrency config (min/max overrides)
 //   - features: routing feature flags (checked for adaptiveConcurrencyEnabled)
 //
-// Returns 0 when the feature is disabled, meaning Perform() should not inject
+// Returns 0 when the feature is disabled, meaning Stream() should not inject
 // the query parameter.
 func computeAdaptiveConcurrency(cwnd int32, cfg adaptiveConcurrencyConfig, features routingFeatures) int {
 	if !features.adaptiveConcurrencyEnabled() {

--- a/opensearchtransport/pool_congestion.go
+++ b/opensearchtransport/pool_congestion.go
@@ -27,7 +27,7 @@ const (
 // poolCongestion tracks AIMD congestion state for a single thread pool
 // on a single node.
 //
-// Hot-path reads (calcConnScore, Perform) use atomic loads for lock-free
+// Hot-path reads (calcConnScore, Stream) use atomic loads for lock-free
 // access. The stats poller is the sole writer for AIMD state, protected
 // by mu. The 429 handler may also write under TryLock to mark overload.
 type poolCongestion struct {

--- a/opensearchtransport/router_discovery_test.go
+++ b/opensearchtransport/router_discovery_test.go
@@ -62,7 +62,7 @@ func TestRouterWithDiscovery(t *testing.T) {
 		req1, err := http.NewRequest(http.MethodGet, "/", nil)
 		require.NoError(t, err)
 
-		res1, err := transport.Perform(req1)
+		res1, err := transport.Stream(req1)
 		require.NoError(t, err)
 		res1.Body.Close()
 
@@ -78,7 +78,7 @@ func TestRouterWithDiscovery(t *testing.T) {
 			req, err := http.NewRequest(http.MethodGet, "/", nil)
 			require.NoError(t, err, "request %d", i+1)
 
-			res, err := transport.Perform(req)
+			res, err := transport.Stream(req)
 			require.NoError(t, err, "request %d", i+1)
 			res.Body.Close()
 		}
@@ -102,7 +102,7 @@ func TestRouterWithDiscovery(t *testing.T) {
 		// Initial request using seed URL.
 		req1, err := http.NewRequest(http.MethodGet, "/", nil)
 		require.NoError(t, err)
-		res1, err := transport.Perform(req1)
+		res1, err := transport.Stream(req1)
 		require.NoError(t, err)
 		res1.Body.Close()
 
@@ -119,13 +119,13 @@ func TestRouterWithDiscovery(t *testing.T) {
 		bulkReq, err := http.NewRequest(http.MethodPost, "/_bulk", strings.NewReader(bulkBody))
 		require.NoError(t, err)
 		bulkReq.Header.Set("Content-Type", "application/x-ndjson")
-		bulkRes, err := transport.Perform(bulkReq)
+		bulkRes, err := transport.Stream(bulkReq)
 		require.NoError(t, err)
 		bulkRes.Body.Close()
 
 		t.Cleanup(func() {
 			delReq, _ := http.NewRequest(http.MethodDelete, "/test-router", nil)
-			if res, err := transport.Perform(delReq); err == nil {
+			if res, err := transport.Stream(delReq); err == nil {
 				res.Body.Close()
 			}
 		})
@@ -133,7 +133,7 @@ func TestRouterWithDiscovery(t *testing.T) {
 		// Test with a search operation that should route to data/search nodes.
 		searchReq, err := http.NewRequest(http.MethodGet, "/_search", nil)
 		require.NoError(t, err)
-		searchRes, err := transport.Perform(searchReq)
+		searchRes, err := transport.Stream(searchReq)
 		require.NoError(t, err)
 		searchRes.Body.Close()
 	})

--- a/opensearchtransport/seed_fallback_internal_test.go
+++ b/opensearchtransport/seed_fallback_internal_test.go
@@ -50,7 +50,7 @@ func TestSeedFallback(t *testing.T) {
 		tp.mu.Unlock()
 
 		req, _ := http.NewRequest(http.MethodGet, "/test", nil)
-		res, err := tp.Perform(req)
+		res, err := tp.Stream(req)
 		require.NoError(t, err)
 		require.NotNil(t, res)
 		require.Equal(t, http.StatusOK, res.StatusCode)
@@ -79,7 +79,7 @@ func TestSeedFallback(t *testing.T) {
 		require.NotNil(t, tp.seedFallbackPool)
 
 		req, _ := http.NewRequest(http.MethodGet, "/test", nil)
-		res, err := tp.Perform(req)
+		res, err := tp.Stream(req)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, res.StatusCode)
 		if res.Body != nil {
@@ -107,7 +107,7 @@ func TestSeedFallback(t *testing.T) {
 		require.Nil(t, tp.seedFallbackPool)
 
 		req, _ := http.NewRequest(http.MethodGet, "/test", nil)
-		res, err := tp.Perform(req) //nolint:bodyclose // error path: res is nil
+		res, err := tp.Stream(req) //nolint:bodyclose // error path: res is nil
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrNoConnections)
 		require.Nil(t, res)
@@ -131,7 +131,7 @@ func TestSeedFallback(t *testing.T) {
 		require.NotNil(t, tp.seedFallbackPool)
 
 		req, _ := http.NewRequest(http.MethodGet, "/test", nil)
-		res, err := tp.Perform(req) //nolint:bodyclose // error path: res is nil
+		res, err := tp.Stream(req) //nolint:bodyclose // error path: res is nil
 		require.Error(t, err)
 		require.Nil(t, res)
 		require.Contains(t, err.Error(), "seed fallback request failed")
@@ -195,7 +195,7 @@ func TestSeedFallback(t *testing.T) {
 		tp.seedFallbackPool.mu.RUnlock()
 
 		req, _ := http.NewRequest(http.MethodGet, "/test", nil)
-		res, err := tp.Perform(req)
+		res, err := tp.Stream(req)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, res.StatusCode)
 		if res.Body != nil {

--- a/opensearchtransport/shard_routing_integration_test.go
+++ b/opensearchtransport/shard_routing_integration_test.go
@@ -76,7 +76,7 @@ func TestMurmur3ShardRouting_Integration(t *testing.T) {
 			return false
 		}
 		createReq.Header.Set("Content-Type", "application/json")
-		resp, perfErr := transport.Perform(createReq)
+		resp, perfErr := transport.Stream(createReq)
 		if perfErr != nil {
 			return false
 		}
@@ -95,7 +95,7 @@ func TestMurmur3ShardRouting_Integration(t *testing.T) {
 		delPath, _ := ospath.IndicesDeletePath{Indices: []string{index}}.Build()
 		delReq, _ := http.NewRequestWithContext(context.Background(), http.MethodDelete,
 			delPath, nil)
-		resp, _ := transport.Perform(delReq)
+		resp, _ := transport.Stream(delReq)
 		if resp != nil {
 			resp.Body.Close()
 		}
@@ -174,7 +174,7 @@ func querySearchShardsForRouting(t *testing.T, transport *Transport, ctx context
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.String(), nil)
 	require.NoError(t, err)
 
-	resp, err := transport.Perform(req)
+	resp, err := transport.Stream(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -218,7 +218,7 @@ func indexDoc(t *testing.T, transport *Transport, ctx context.Context, index, do
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := transport.Perform(req)
+	resp, err := transport.Stream(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -315,7 +315,7 @@ func TestShardExactRouting_FullPipeline_Integration(t *testing.T) {
 			return false
 		}
 		createReq.Header.Set("Content-Type", "application/json")
-		resp, perfErr := transport.Perform(createReq)
+		resp, perfErr := transport.Stream(createReq)
 		if perfErr != nil {
 			return false
 		}
@@ -334,7 +334,7 @@ func TestShardExactRouting_FullPipeline_Integration(t *testing.T) {
 		delPath, _ := ospath.IndicesDeletePath{Indices: []string{index}}.Build()
 		delReq, _ := http.NewRequestWithContext(context.Background(), http.MethodDelete,
 			delPath, nil)
-		resp, _ := transport.Perform(delReq)
+		resp, _ := transport.Stream(delReq)
 		if resp != nil {
 			resp.Body.Close()
 		}
@@ -359,7 +359,7 @@ func TestShardExactRouting_FullPipeline_Integration(t *testing.T) {
 		bytes.NewReader([]byte(`{"query":{"match_all":{}},"size":0}`)))
 	require.NoError(t, err)
 	warmReq.Header.Set("Content-Type", "application/json")
-	warmResp, err := transport.Perform(warmReq)
+	warmResp, err := transport.Stream(warmReq)
 	require.NoError(t, err)
 	warmResp.Body.Close()
 
@@ -451,7 +451,7 @@ func TestShardExactRouting_FullPipeline_Integration(t *testing.T) {
 					}
 					searchReq.Header.Set("Content-Type", "application/json")
 
-					resp, perfErr := transport.Perform(searchReq)
+					resp, perfErr := transport.Stream(searchReq)
 					if perfErr != nil {
 						lastFailure = fmt.Sprintf("Perform error: %v", perfErr)
 						_ = transport.DiscoverNodes(ctx)
@@ -549,7 +549,7 @@ func querySearchShardsWithNodes( //nolint:nonamedreturns // named returns docume
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.String(), nil)
 	require.NoError(t, err)
 
-	resp, err := transport.Perform(req)
+	resp, err := transport.Stream(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -612,7 +612,7 @@ func fetchRoutingNumShardsForTest(t *testing.T, transport *Transport, observer *
 			return false
 		}
 
-		resp, err := transport.Perform(req)
+		resp, err := transport.Stream(req)
 		if err != nil {
 			return false
 		}

--- a/opensearchtransport/standby_rotation_integration_test.go
+++ b/opensearchtransport/standby_rotation_integration_test.go
@@ -159,7 +159,7 @@ func drainWarmup(transport *opensearchtransport.Transport) {
 		if err != nil {
 			break
 		}
-		resp, err := transport.Perform(req)
+		resp, err := transport.Stream(req)
 		if err != nil {
 			continue
 		}
@@ -298,7 +298,7 @@ func TestStandbyRotation(t *testing.T) {
 			req, err := http.NewRequest(http.MethodGet, "/", nil)
 			require.NoError(t, err)
 
-			res, err := transport.Perform(req)
+			res, err := transport.Stream(req)
 			require.NoError(t, err)
 
 			var info struct {
@@ -333,7 +333,7 @@ func TestStandbyRotation(t *testing.T) {
 		// Record which node is currently active
 		req, err := http.NewRequest(http.MethodGet, "/", nil)
 		require.NoError(t, err)
-		res, err := transport.Perform(req)
+		res, err := transport.Stream(req)
 		require.NoError(t, err)
 		var info0 struct {
 			Name string `json:"name"`
@@ -439,7 +439,7 @@ func TestStandbyRotation(t *testing.T) {
 				if reqErr != nil {
 					return false
 				}
-				res, perfErr := transport.Perform(req)
+				res, perfErr := transport.Stream(req)
 				if perfErr != nil {
 					return false
 				}
@@ -452,7 +452,7 @@ func TestStandbyRotation(t *testing.T) {
 		for range 5 {
 			req, err := http.NewRequest(http.MethodGet, "/", nil)
 			require.NoError(t, err)
-			res, err := transport.Perform(req)
+			res, err := transport.Stream(req)
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, res.StatusCode, "active node should serve healthy responses")
 			res.Body.Close()

--- a/opensearchtransport/transport_correctness_internal_test.go
+++ b/opensearchtransport/transport_correctness_internal_test.go
@@ -106,11 +106,10 @@ func TestSetReqGlobalHeaderOverride(t *testing.T) {
 	}
 }
 
-// TestPerformSurfacesBodyReadError verifies the := shadowing fix: when buffering
-// the response body fails, Perform returns the response (so the caller can still
-// inspect status) together with an error wrapping ErrResponseBodyRead, rather
-// than silently swallowing the read failure and returning err == nil.
-func TestPerformSurfacesBodyReadError(t *testing.T) {
+// TestStreamReturnsBodyUnbuffered verifies that Stream returns the raw response
+// body without reading or closing it: a failing body reader must not be
+// triggered by Stream itself — the caller owns the body lifecycle.
+func TestStreamReturnsBodyUnbuffered(t *testing.T) {
 	t.Parallel()
 
 	body := &errReadCloser{err: errors.New("truncated body")}
@@ -129,11 +128,10 @@ func TestPerformSurfacesBodyReadError(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, "/test", nil)
 	require.NoError(t, err)
 
-	//nolint:bodyclose // body is a NopCloser over the buffered (empty) bytes
-	res, err := tp.Perform(req)
-	require.Error(t, err)
-	require.ErrorIs(t, err, ErrResponseBodyRead)
-	require.NotNil(t, res, "response must be returned alongside the read error")
+	res, err := tp.Stream(req)
+	require.NoError(t, err, "Stream must not read the body, so the read error must not surface here")
+	require.NotNil(t, res)
 	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.True(t, body.closed, "original body must be closed after the failed read")
+	require.False(t, body.closed, "Stream must not close the body before the caller does")
+	res.Body.Close()
 }

--- a/opensearchtransport/transport_coverage_internal_test.go
+++ b/opensearchtransport/transport_coverage_internal_test.go
@@ -428,7 +428,7 @@ func TestPerform_GzipCompression(t *testing.T) {
 
 	body := bytes.NewReader([]byte(`{"query":{"match_all":{}}}`))
 	req, _ := http.NewRequest(http.MethodPost, "/_search", io.NopCloser(body))
-	res, err := tp.Perform(req)
+	res, err := tp.Stream(req)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	if res.Body != nil {
@@ -453,7 +453,7 @@ func TestPerform_MetricsEnabled(t *testing.T) {
 	require.NoError(t, err)
 
 	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
-	res, err := tp.Perform(req)
+	res, err := tp.Stream(req)
 	require.NoError(t, err)
 	if res != nil && res.Body != nil {
 		res.Body.Close()
@@ -479,7 +479,7 @@ func TestPerform_SignError(t *testing.T) {
 	require.NoError(t, err)
 
 	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
-	res, err := tp.Perform(req) //nolint:bodyclose // error path
+	res, err := tp.Stream(req) //nolint:bodyclose // error path
 	require.Error(t, err)
 	require.Nil(t, res)
 	require.Contains(t, err.Error(), "failed to sign request")
@@ -503,7 +503,7 @@ func TestPerform_TransportError(t *testing.T) {
 	tp.seedFallbackPool = nil
 
 	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
-	res, err := tp.Perform(req) //nolint:bodyclose // error path
+	res, err := tp.Stream(req) //nolint:bodyclose // error path
 	require.Error(t, err)
 	require.Nil(t, res)
 }
@@ -529,7 +529,7 @@ func TestPerform_NetworkErrorRetry(t *testing.T) {
 	require.NoError(t, err)
 
 	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
-	res, err := tp.Perform(req)
+	res, err := tp.Stream(req)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	if res.Body != nil {

--- a/opensearchtransport/zombie_connection_test.go
+++ b/opensearchtransport/zombie_connection_test.go
@@ -65,7 +65,7 @@ func TestSeedURLsWithDiscovery(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "/", nil)
 		require.NoError(t, err)
 
-		res, err := transport.Perform(req)
+		res, err := transport.Stream(req)
 		require.NoError(t, err)
 		res.Body.Close()
 
@@ -80,7 +80,7 @@ func TestSeedURLsWithDiscovery(t *testing.T) {
 			req, err := http.NewRequest(http.MethodGet, "/", nil)
 			require.NoError(t, err, "request %d", i+1)
 
-			res, err := transport.Perform(req)
+			res, err := transport.Stream(req)
 			require.NoError(t, err, "request %d", i+1)
 			res.Body.Close()
 		}

--- a/plugins/asynchronous_search/client_gen.go
+++ b/plugins/asynchronous_search/client_gen.go
@@ -28,7 +28,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/flow_framework/client_gen.go
+++ b/plugins/flow_framework/client_gen.go
@@ -28,7 +28,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/geospatial/client_gen.go
+++ b/plugins/geospatial/client_gen.go
@@ -31,7 +31,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/ingestion/client_gen.go
+++ b/plugins/ingestion/client_gen.go
@@ -28,7 +28,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/insights/client_gen.go
+++ b/plugins/insights/client_gen.go
@@ -28,7 +28,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/ism/client_gen.go
+++ b/plugins/ism/client_gen.go
@@ -31,7 +31,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/knn/client_gen.go
+++ b/plugins/knn/client_gen.go
@@ -31,7 +31,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/list/client_gen.go
+++ b/plugins/list/client_gen.go
@@ -28,7 +28,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/ltr/client_gen.go
+++ b/plugins/ltr/client_gen.go
@@ -39,7 +39,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/ml/client_gen.go
+++ b/plugins/ml/client_gen.go
@@ -53,7 +53,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/neural/client_gen.go
+++ b/plugins/neural/client_gen.go
@@ -28,7 +28,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/notifications/client_gen.go
+++ b/plugins/notifications/client_gen.go
@@ -31,7 +31,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/observability/client_gen.go
+++ b/plugins/observability/client_gen.go
@@ -31,7 +31,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/ppl/client_gen.go
+++ b/plugins/ppl/client_gen.go
@@ -31,7 +31,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/query/client_gen.go
+++ b/plugins/query/client_gen.go
@@ -28,7 +28,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/replication/client_gen.go
+++ b/plugins/replication/client_gen.go
@@ -31,7 +31,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/rollups/client_gen.go
+++ b/plugins/rollups/client_gen.go
@@ -28,7 +28,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/search_relevance/client_gen.go
+++ b/plugins/search_relevance/client_gen.go
@@ -39,7 +39,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/security/client_gen.go
+++ b/plugins/security/client_gen.go
@@ -55,7 +55,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/security_analytics/client_gen.go
+++ b/plugins/security_analytics/client_gen.go
@@ -28,7 +28,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/sm/client_gen.go
+++ b/plugins/sm/client_gen.go
@@ -31,7 +31,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/sql/client_gen.go
+++ b/plugins/sql/client_gen.go
@@ -31,7 +31,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/transforms/client_gen.go
+++ b/plugins/transforms/client_gen.go
@@ -28,7 +28,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/ubi/client_gen.go
+++ b/plugins/ubi/client_gen.go
@@ -28,7 +28,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.

--- a/plugins/wlm/client_gen.go
+++ b/plugins/wlm/client_gen.go
@@ -31,7 +31,7 @@ func NewClient(client *opensearch.Client) *Client {
 
 // do calls [opensearch.Do] and checks the response for errors.
 //
-// [opensearch.Do] routes through the buffered [opensearchtransport.Transport.Perform],
+// [opensearch.Do] routes through [opensearchtransport.Transport.Stream] and buffers the response body,
 // so resp.Body here is already an [io.NopCloser] over a [bytes.Reader] -- the
 // connection has been drained and returned to the pool. The helper only needs
 // to translate IsError into a typed error.


### PR DESCRIPTION
## Summary

Closes #872.

- `opensearchtransport.Interface` now requires `Stream(*http.Request) (*http.Response, error)` instead of the deprecated `Perform`. The caller owns the response body and must close it.
- Remove `(*opensearchtransport.Transport).Perform` and `(*opensearch.Client).Perform`.
- Remove the `opensearch.Streamer` opt-in interface and `opensearch.ErrTransportMissingMethodStream`; `Stream` is now guaranteed on every `Interface` implementation so the type-assertion shim is unnecessary.
- `(*opensearch.Client).Stream` delegates directly to `c.Transport.Stream` (no more type assertion).
- `(*opensearch.Client).Do` inlines the body-buffering that `Perform` used to do: single `ReadAll`, explicit `Close`, same `ErrResponseBodyRead` contract preserved for callers.
- `_samples/json.go`: add explicit `Body.Close()` after each `ReadAll` (callers now own the body).
- `TestPerformSurfacesBodyReadError` → `TestStreamReturnsBodyUnbuffered` (pins that `Stream` must not read or close the body).
- `TestPerformStreamBuffering` → `TestStreamBuffering` (collapsed to a single Stream-only path).
- CHANGELOG and UPGRADING.md entries for the breaking change.

## Checklist

- [x] All acceptance criteria from #872 satisfied
- [x] `opensearchtransport.Interface` swapped from `Perform` to `Stream`
- [x] `(*opensearchtransport.Transport).Perform` removed
- [x] `(*opensearch.Client).Perform` removed
- [x] `Streamer` shim and `ErrTransportMissingMethodStream` removed
- [x] All internal callers updated (tests, benchmarks, samples)
- [x] `CHANGELOG.md` entry under **Removed**
- [x] `UPGRADING.md` migration note with before/after examples
- [x] Full unit test suite passes (`go test ./... -short`)

## Test plan

- `go test ./... -short` — all packages pass
- Integration tests require a live OpenSearch cluster (not run in this PR; covered by CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)