### PR TITLE
test(opensearchtransport): bump shard-routing poll budget 4->32 (temp)

### DIFF
--- a/opensearchtransport/shard_routing_integration_test.go
+++ b/opensearchtransport/shard_routing_integration_test.go
@@ -416,7 +416,7 @@ func TestShardExactRouting_FullPipeline_Integration(t *testing.T) {
 			// routes consistently. The cluster-state-independent invariants
 			// (client murmur3 vs observer TargetShard, RoutingValue capture)
 			// are hard-asserted after convergence.
-			const maxAttempts = 4
+			const maxAttempts = 32
 			var (
 				lastEvent   *RouteEvent
 				gt          groundTruth


### PR DESCRIPTION
### Description
The first routing subtest in TestShardExactRouting_FullPipeline_Integration exhausts its poll budget on "shard map not fully populated" when a freshly created index's routing_num_shards has not yet propagated from /_cluster/state/metadata, made worse by CI CPU starvation. Bump the budget from 4 to 32 attempts as a temporary measure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
