### PR TITLE
Update MAINTAINERS.md and .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the team set up in https://github.com/orgs/opensearch-project/teams and include any additional contributors
-*   @VijayanB @VachaShah @Jakob3xD @sean- @ryanyuan
+*   @VachaShah @Jakob3xD @sean- @ryanyuan

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the team set up in https://github.com/orgs/opensearch-project/teams and include any additional contributors
-*   @VachaShah @Jakob3xD @sean- @ryanyuan
+*   @Jakob3xD @sean- @ryanyuan

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the team set up in https://github.com/orgs/opensearch-project/teams and include any additional contributors
-*   @VijayanB @VachaShah @Jakob3xD @sean-
+*   @VijayanB @VachaShah @Jakob3xD @sean- @ryanyuan

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,12 +4,11 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer      | GitHub ID                                 | Affiliation         |
-| --------------- | ----------------------------------------- | ------------------- |
-| Jakob Hahn      | [Jakob3xD](https://github.com/Jakob3xD)   | Hetzner Online GmbH |
-| Vacha Shah      | [VachaShah](https://github.com/VachaShah) | Amazon              |
-| Sean Chittenden | [sean-](https://github.com/sean-)         | CrowdStrike         |
-| Ryan Yuan       | [ryanyuan](https://github.com/ryanyuan)   | CrowdStrike         |
+| Maintainer      | GitHub ID                               | Affiliation         |
+| --------------- | --------------------------------------- | ------------------- |
+| Jakob Hahn      | [Jakob3xD](https://github.com/Jakob3xD) | Hetzner Online GmbH |
+| Sean Chittenden | [sean-](https://github.com/sean-)       | CrowdStrike         |
+| Ryan Yuan       | [ryanyuan](https://github.com/ryanyuan) | CrowdStrike         |
 
 ## Emeritus
 
@@ -19,5 +18,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Jack Mazanec            | [jmazanec15](https://github.com/jmazanec15) | Amazon      |
 | Rob Cowart              | [robcowart](https://github.com/robcowart)   | ElastiFlow  |
 | Sven Cowart             | [svencowart](https://github.com/svencowart) |             |
+| Vacha Shah              | [VachaShah](https://github.com/VachaShah)   | Amazon      |
 | Vamshi Vijay Nakkirtha  | [vamshin](https://github.com/vamshin)       | Amazon      |
 | Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)     | Amazon      |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,20 +4,20 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer              | GitHub ID                                 | Affiliation         |
-| ----------------------- | ----------------------------------------- | ------------------- |
-| Jakob Hahn              | [Jakob3xD](https://github.com/Jakob3xD)   | Hetzner Online GmbH |
-| Vacha Shah              | [VachaShah](https://github.com/VachaShah) | Amazon              |
-| Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)   | Amazon              |
-| Sean Chittenden         | [sean-](https://github.com/sean-)         | CrowdStrike         |
-| Ryan Yuan               | [ryanyuan](https://github.com/ryanyuan)   | CrowdStrike         |
+| Maintainer      | GitHub ID                                 | Affiliation         |
+| --------------- | ----------------------------------------- | ------------------- |
+| Jakob Hahn      | [Jakob3xD](https://github.com/Jakob3xD)   | Hetzner Online GmbH |
+| Vacha Shah      | [VachaShah](https://github.com/VachaShah) | Amazon              |
+| Sean Chittenden | [sean-](https://github.com/sean-)         | CrowdStrike         |
+| Ryan Yuan       | [ryanyuan](https://github.com/ryanyuan)   | CrowdStrike         |
 
 ## Emeritus
 
-| Maintainer             | GitHub ID                                   | Affiliation |
-| ---------------------- | ------------------------------------------- | ----------- |
-| Daniel Doubrovkine     | [dblock](https://github.com/dblock)         | Independent |
-| Jack Mazanec           | [jmazanec15](https://github.com/jmazanec15) | Amazon      |
-| Rob Cowart             | [robcowart](https://github.com/robcowart)   | ElastiFlow  |
-| Sven Cowart            | [svencowart](https://github.com/svencowart) |             |
-| Vamshi Vijay Nakkirtha | [vamshin](https://github.com/vamshin)       | Amazon      |
+| Maintainer              | GitHub ID                                   | Affiliation |
+| ----------------------- | ------------------------------------------- | ----------- |
+| Daniel Doubrovkine      | [dblock](https://github.com/dblock)         | Independent |
+| Jack Mazanec            | [jmazanec15](https://github.com/jmazanec15) | Amazon      |
+| Rob Cowart              | [robcowart](https://github.com/robcowart)   | ElastiFlow  |
+| Sven Cowart             | [svencowart](https://github.com/svencowart) |             |
+| Vamshi Vijay Nakkirtha  | [vamshin](https://github.com/vamshin)       | Amazon      |
+| Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)     | Amazon      |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,7 +17,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Daniel Doubrovkine      | [dblock](https://github.com/dblock)         | Independent |
 | Jack Mazanec            | [jmazanec15](https://github.com/jmazanec15) | Amazon      |
 | Rob Cowart              | [robcowart](https://github.com/robcowart)   | ElastiFlow  |
-| Sven Cowart             | [svencowart](https://github.com/svencowart) |             |
+| Sven Cowart             | [svencowart](https://github.com/svencowart) | ElastiFlow  |
 | Vacha Shah              | [VachaShah](https://github.com/VachaShah)   | Amazon      |
 | Vamshi Vijay Nakkirtha  | [vamshin](https://github.com/vamshin)       | Amazon      |
 | Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)     | Amazon      |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,6 +10,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Vacha Shah              | [VachaShah](https://github.com/VachaShah) | Amazon              |
 | Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)   | Amazon              |
 | Sean Chittenden         | [sean-](https://github.com/sean-)         | CrowdStrike         |
+| Ryan Yuan               | [ryanyuan](https://github.com/ryanyuan)   | CrowdStrike         |
 
 ## Emeritus
 


### PR DESCRIPTION
Adds Ryan Yuan (@ryanyuan, CrowdStrike) to MAINTAINERS.md and .github/CODEOWNERS

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
