### PR TITLE
docs: update release process

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,13 +33,13 @@ Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v
 
 The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [MAINTAINERS](MAINTAINERS.md).
 
-1. Ensure that the version in [version.go](internal/version/version.go) is correct for the next release. The example here releases version 4.3.0.
-2. For major version releases, ensure that all references are up-to-date, e.g. `github.com/opensearch-project/opensearch-go/v5`, see [opensearch-go#444](https://github.com/opensearch-project/opensearch-go/pull/444).
+1. Ensure that the version in [version.go](internal/version/version.go) is correct for the next release.
+2. For major version releases, ensure that all references are up-to-date, e.g. `github.com/opensearch-project/opensearch-go/v3`, see [opensearch-go#444](https://github.com/opensearch-project/opensearch-go/pull/444).
 3. Edit the [CHANGELOG](CHANGELOG.md) and replace the `Unreleased` section with the version about to be released.
-4. Add a comparison link to the new version at the bottom of the [CHANGELOG](CHANGELOG.md).
+4. Add a comparison link to the new version at the bottom of the [CHANGELOG](CHANGELOG.md#dependencies).
 5. Create a pull request with the changes into `main`, e.g. [opensearch-go#443](https://github.com/opensearch-project/opensearch-go/pull/443).
-6. Create a tag, e.g. `v5.0.0`, and push it to the GitHub repo. This [makes the new version available](https://go.dev/doc/modules/publishing) on [pkg.go.dev](https://pkg.go.dev/github.com/opensearch-project/opensearch-go/v5).
-7. Draft and publish a [new GitHub release](https://github.com/opensearch-project/opensearch-go/releases/new) from the newly created tag.
+6. Once the PR from step 5 is merged, request a signed release tag. Contributors cannot push signed tags, so open a `[GitHub Request] Tag new opensearch-go vX.Y.Z release` issue in the [opensearch-project/.github](https://github.com/opensearch-project/.github/issues/new/choose) repo. Fill out the request form based on the previous release (e.g. [opensearch-project/.github#592](https://github.com/opensearch-project/.github/issues/592)). A member of @opensearch-project/admin creates the signed tag, which [makes the new version available](https://go.dev/doc/modules/publishing) on [pkg.go.dev](https://pkg.go.dev/github.com/opensearch-project/opensearch-go/v5).
+7. Once the tag exists, draft and publish a [new GitHub release](https://github.com/opensearch-project/opensearch-go/releases/new) from it, using the CHANGELOG section for that version as the release notes.
 8. Create a new `Unreleased` section in the [CHANGELOG](CHANGELOG.md), increment version in [version.go](internal/version/version.go) to the next developer iteration (e.g. `4.3.1`), and make a pull request with this change into `main`, e.g. [opensearch-go#448](https://github.com/opensearch-project/opensearch-go/pull/448).
 
    ```


### PR DESCRIPTION
### Description
Step 6 in RELEASING.md was wrong. It said contributors push the release tag directly, but only opensearch-project/admin members can create signed tags in this repo.

The corrected step covers the actual flow: once the prep PR merges, open a [GitHub Request] issue in opensearch-project/.github, link the merged PR, and wait for an admin to create the signed tag. Step 7 is updated to note the release should be drafted from the CHANGELOG section for that version, once the tag exists.

Two minor cleanups alongside: the major-version example in step 2 now references v3 instead of v5, and a stray #dependencies fragment is removed from the CHANGELOG link in step 4.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
