### PR TITLE
test(ci): validate link checker with temporary broken-link fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,6 @@ Next steps:
 ## Project Resources
 
 - [Project Website](https://opensearch.org/)
-- [TEMPORARY link-checker regression (RED, broken link) -- REVERT before merge](https://opensearch-go-regression.invalid/nope)
-- [TEMPORARY link-checker regression (YELLOW, 308 redirect) -- REVERT before merge](https://grafana.com/blog/2018/08/02/the-red-method-how-to-instrument-your-services/)
 - [Developer Guide](DEVELOPER_GUIDE.md)
 - [User Guide](USER_GUIDE.md)
 - [Upgrade Tool (`osapifix`)](cmd/osapifix/README.md)


### PR DESCRIPTION
TEMPORARY -- these fixtures must be reverted before merge.

#999 merged with two temp link-checker fixtures still in README.md and without the two-pass links.yml rework (it was uncommitted at merge time). This branch restores that workflow and re-validates it end to end:

- links.yml: two-pass checker (blocking 4xx/5xx + non-blocking 301/308 surfacing), redirect annotations, and a neutral 'Link Redirects' check-run. The neutral badge needs checks:write, so on fork PRs it degrades to the annotation path.
- README.md RED fixture: swapped the reserved .invalid TLD (which lychee excludes by default, so it never failed) for a real-host 404 that the blocking pass will actually catch.
- README.md YELLOW fixture: a 308 redirect the non-blocking pass surfaces.

Expected on this (fork) PR: linkchecker RED on the 404; the 308 shows as a warning annotation (neutral badge suppressed by the read-only token).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
