### PR TITLE
fix(opensearchtransport): keep dedicated cluster managers in the connection inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
-## [4.7.2]
+## [4.7.3]
+
+### Fixed
+
+- Fix an unbounded connection/heap leak in node discovery when the cluster has a dedicated cluster manager (`cluster_manager` role with no work roles). The node was filtered out of the `allConns` inventory while the router received the unfiltered added/removed diffs, so `findConnectionByURL` never matched it: a new `*Connection` was created every discovery cycle and the stale one was never evicted, accumulating without bound in the round-robin fallback pool whose `checkDead` health checks repopulated a per-connection `poolRegistry` `sync.Map` each cycle (leak rate scaled with discovery frequency). `allConns` is now the full connection inventory so discovery reuses and evicts symmetrically, and dedicated cluster managers are excluded at request-routing selection instead: `RoundRobinPolicy` skips them in its `DiscoveryUpdate` add path and `multiServerPool.Next()` skips them during selection (including the no-router fallback), both gated on `IncludeDedicatedClusterManagers`. Discovery still bootstraps against a dedicated cluster manager seed via the seed-fallback pool ([#1003](https://github.com/opensearch-project/opensearch-go/pull/1003))
 
 ## [4.7.0]
 
@@ -656,6 +660,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `github.com/stretchr/testify` from 1.8.0 to 1.8.1
 - Bumps `github.com/aws/aws-sdk-go` from 1.44.45 to 1.44.132
 
+[4.7.3]: https://github.com/opensearch-project/opensearch-go/compare/v4.7.2...v4.7.3
 [4.7.2]: https://github.com/opensearch-project/opensearch-go/compare/v4.7.1...v4.7.2
 [4.7.0]: https://github.com/opensearch-project/opensearch-go/compare/v4.6.0...v4.7.0
 [4.6.0]: https://github.com/opensearch-project/opensearch-go/compare/v4.5.0...v4.6.0

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -27,4 +27,4 @@
 package version
 
 // Client returns the client version as a string.
-const Client = "4.7.2"
+const Client = "4.7.3"

--- a/opensearchtransport/discovery.go
+++ b/opensearchtransport/discovery.go
@@ -967,27 +967,16 @@ func (c *Client) createOrUpdateMultiNodePoolWithLock(readyConnections, deadConne
 		return c.promoteConnectionPoolWithLock(readyConnections, deadConnections)
 	}
 
-	// Update existing multiServerPool or create new one
-	// Apply client-level filtering for dedicated cluster managers
+	// allConns is the bookkeeping inventory of every discovered connection,
+	// including dedicated cluster managers. Discovery reuses connections by
+	// scanning allConns (findConnectionByURL) and evicts them via the removed
+	// diff computed against allConns. Query traffic is kept off dedicated
+	// cluster managers at the routing-policy layer (see RoundRobinPolicy).
 	allReadyConns := make([]*Connection, 0, len(readyConnections))
 	allDeadConns := make([]*Connection, 0, len(deadConnections))
 
-	for _, conn := range readyConnections {
-		if !c.includeDedicatedClusterManagers && conn.Roles.isDedicatedClusterManager() {
-			if dl := loadDebugLogger(); dl != nil {
-				dl.Logf("Excluding dedicated cluster manager %q from connection pool\n", conn.Name)
-			}
-			continue
-		}
-		allReadyConns = append(allReadyConns, conn)
-	}
-
-	for _, conn := range deadConnections {
-		if !c.includeDedicatedClusterManagers && conn.Roles.isDedicatedClusterManager() {
-			continue
-		}
-		allDeadConns = append(allDeadConns, conn)
-	}
+	allReadyConns = append(allReadyConns, readyConnections...)
+	allDeadConns = append(allDeadConns, deadConnections...)
 
 	// Shuffle connections for load distribution unless disabled
 	if !c.skipConnectionShuffle && len(allReadyConns) > 1 {

--- a/opensearchtransport/discovery_integration_internal_test.go
+++ b/opensearchtransport/discovery_integration_internal_test.go
@@ -335,44 +335,48 @@ func TestShouldSkipDedicatedClusterManagers(t *testing.T) {
 // TestDiscoverNodesWithNewRoleValidation verifies the enhanced discovery behavior
 func TestDiscoverNodesWithNewRoleValidation(t *testing.T) {
 	tests := []struct {
-		name            string
-		nodes           map[string][]string // nodeName -> roles
-		expectedNodes   []string            // nodes that should be included
-		expectedSkipped []string            // nodes that should be skipped
+		name  string
+		nodes map[string][]string // nodeName -> roles
+		// expectedInInventory lists nodes that must appear in the allConns pool,
+		// which holds every discovered node regardless of role.
+		expectedInInventory []string
+		// expectedNotRoutable lists dedicated cluster managers that must not be
+		// selected for request routing.
+		expectedNotRoutable []string
 	}{
 		{
 			"mixed node types with validation",
 			map[string][]string{
-				"cm-only":     {RoleClusterManager},           // should be skipped
-				"master-only": {RoleMaster},                   // should be skipped
-				"data-node":   {RoleData},                     // should be included
-				"mixed-good":  {RoleClusterManager, RoleData}, // should be included
-				"search-only": {RoleSearch},                   // should be included
+				"cm-only":     {RoleClusterManager},           // dedicated CM: not routable
+				"master-only": {RoleMaster},                   // dedicated CM: not routable
+				"data-node":   {RoleData},                     // routable
+				"mixed-good":  {RoleClusterManager, RoleData}, // routable
+				"search-only": {RoleSearch},                   // routable
 			},
-			[]string{"data-node", "mixed-good", "search-only"},
+			[]string{"cm-only", "master-only", "data-node", "mixed-good", "search-only"},
 			[]string{"cm-only", "master-only"},
 		},
 		{
 			"OpenSearch 3.X compliant setup",
 			map[string][]string{
-				"dedicated-cm": {RoleClusterManager},   // should be skipped
-				"data-hot":     {RoleData, RoleIngest}, // should be included
-				"data-warm":    {RoleWarm, RoleData},   // should be included
-				"search-node":  {RoleSearch},           // should be included
-				"coordinating": {RoleCoordinatingOnly}, // should be included
+				"dedicated-cm": {RoleClusterManager},   // dedicated CM: not routable
+				"data-hot":     {RoleData, RoleIngest}, // routable
+				"data-warm":    {RoleWarm, RoleData},   // routable
+				"search-node":  {RoleSearch},           // routable
+				"coordinating": {RoleCoordinatingOnly}, // routable
 			},
-			[]string{"data-hot", "data-warm", "search-node", "coordinating"},
+			[]string{"dedicated-cm", "data-hot", "data-warm", "search-node", "coordinating"},
 			[]string{"dedicated-cm"},
 		},
 		{
 			"cluster manager and remote cluster client filtering",
 			map[string][]string{
-				"cm-rcc":    {RoleClusterManager, RoleRemoteClusterClient}, // should be skipped
-				"cm-data":   {RoleClusterManager, RoleData},                // should be included
-				"rcc-only":  {RoleRemoteClusterClient},                     // should be included
-				"data-node": {RoleData},                                    // should be included
+				"cm-rcc":    {RoleClusterManager, RoleRemoteClusterClient}, // dedicated CM: not routable
+				"cm-data":   {RoleClusterManager, RoleData},                // routable
+				"rcc-only":  {RoleRemoteClusterClient},                     // routable
+				"data-node": {RoleData},                                    // routable
 			},
-			[]string{"cm-data", "rcc-only", "data-node"},
+			[]string{"cm-rcc", "cm-data", "rcc-only", "data-node"},
 			[]string{"cm-rcc"},
 		},
 	}
@@ -398,29 +402,43 @@ func TestDiscoverNodesWithNewRoleValidation(t *testing.T) {
 			require.Truef(t, ok, "Expected multiServerPool but got %T with URLs: %v",
 				c.mu.connectionPool, c.mu.connectionPool.URLs())
 
-			// Check that expected nodes are included (in either ready or dead lists,
-			// since newly discovered nodes start in dead state pending health checks)
-			actualNodes := make(map[string]struct{})
+			// allConns holds every discovered node regardless of role (in either the
+			// ready or dead list, since newly discovered nodes start dead pending
+			// health checks). Dedicated cluster managers stay in the inventory so
+			// discovery can reuse and evict them symmetrically; they are excluded at
+			// selection time instead.
+			pool.mu.RLock()
+			inventory := make(map[string]struct{}, len(pool.mu.ready)+len(pool.mu.dead))
 			for _, conn := range pool.mu.ready {
-				actualNodes[conn.Name] = struct{}{}
+				inventory[conn.Name] = struct{}{}
 			}
 			for _, conn := range pool.mu.dead {
-				actualNodes[conn.Name] = struct{}{}
+				inventory[conn.Name] = struct{}{}
 			}
+			pool.mu.RUnlock()
 
-			require.Len(t, actualNodes, len(tt.expectedNodes),
-				"Expected %d nodes but got %d: %v", len(tt.expectedNodes), len(actualNodes), actualNodes)
+			require.Len(t, inventory, len(tt.expectedInInventory),
+				"Expected %d nodes in inventory but got %d: %v",
+				len(tt.expectedInInventory), len(inventory), inventory)
 
-			for _, expectedNode := range tt.expectedNodes {
-				_, ok := actualNodes[expectedNode]
+			for _, expectedNode := range tt.expectedInInventory {
+				_, ok := inventory[expectedNode]
 				require.True(t, ok,
-					"Expected node %q to be included but it wasn't", expectedNode)
+					"Expected node %q in the connection inventory but it wasn't", expectedNode)
 			}
 
-			for _, skippedNode := range tt.expectedSkipped {
-				_, ok := actualNodes[skippedNode]
-				require.False(t, ok,
-					"Expected node %q to be skipped but it was included", skippedNode)
+			// Dedicated cluster managers stay in the inventory but must not be handed
+			// out for routing. With no router, routing uses the inventory pool's
+			// Next(), which skips them.
+			for _, dcm := range tt.expectedNotRoutable {
+				for i := 0; i < len(tt.nodes)*4; i++ {
+					conn, nextErr := pool.Next()
+					if nextErr != nil {
+						break
+					}
+					require.NotEqual(t, dcm, conn.Name,
+						"Dedicated cluster manager %q must not be selected for routing", dcm)
+				}
 			}
 		})
 	}
@@ -432,39 +450,43 @@ func TestIncludeDedicatedClusterManagersConfiguration(t *testing.T) {
 		name                            string
 		includeDedicatedClusterManagers bool
 		nodes                           map[string][]string // nodeName -> roles
-		expectedIncluded                []string            // nodes that should be included
-		expectedExcluded                []string            // nodes that should be excluded
+		// expectedInInventory lists nodes that must appear in the allConns pool,
+		// which holds every discovered node regardless of role.
+		expectedInInventory []string
+		// expectedNotRoutable lists dedicated cluster managers that must not be
+		// selected for request routing.
+		expectedNotRoutable []string
 	}{
 		{
-			name:                            "IncludeDedicatedClusterManagers enabled - includes all nodes",
+			name:                            "IncludeDedicatedClusterManagers enabled - all nodes routable",
 			includeDedicatedClusterManagers: true,
 			nodes: map[string][]string{
 				"cm-only":   {RoleClusterManager},
 				"data-node": {RoleData},
 			},
-			expectedIncluded: []string{"cm-only", "data-node"},
-			expectedExcluded: []string{},
+			expectedInInventory: []string{"cm-only", "data-node"},
+			expectedNotRoutable: []string{},
 		},
 		{
-			name:                            "IncludeDedicatedClusterManagers disabled (default) - excludes dedicated CM nodes",
+			name:                            "IncludeDedicatedClusterManagers disabled (default) - dedicated CM in inventory but not routable",
 			includeDedicatedClusterManagers: false,
 			nodes: map[string][]string{
 				"cm-only":   {RoleClusterManager},
 				"data-node": {RoleData},
 				"dummy":     {RoleData}, // Add second node to avoid single connection pool
 			},
-			expectedIncluded: []string{"data-node", "dummy"},
-			expectedExcluded: []string{"cm-only"},
+			expectedInInventory: []string{"cm-only", "data-node", "dummy"},
+			expectedNotRoutable: []string{"cm-only"},
 		},
 		{
-			name:                            "Mixed roles with CM always included regardless of setting",
+			name:                            "Mixed roles with CM always routable regardless of setting",
 			includeDedicatedClusterManagers: false,
 			nodes: map[string][]string{
 				"cm-data": {RoleClusterManager, RoleData},
 				"dummy":   {RoleData}, // Add second node to avoid single connection pool
 			},
-			expectedIncluded: []string{"cm-data", "dummy"},
-			expectedExcluded: []string{},
+			expectedInInventory: []string{"cm-data", "dummy"},
+			expectedNotRoutable: []string{},
 		},
 	}
 
@@ -481,41 +503,60 @@ func TestIncludeDedicatedClusterManagersConfiguration(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			// Perform discovery
-			err = c.DiscoverNodes(t.Context())
-			require.NoError(t, err)
+			// Run discovery repeatedly. The inventory must converge to exactly one
+			// connection per node and stay there: an unbounded pool that re-created
+			// connections each cycle (the dedicated-cluster-manager leak) would grow
+			// with every iteration. Asserting the exact length on every cycle is the
+			// regression guard.
+			const cycles = 5
+			var pool *multiServerPool
+			for cycle := 1; cycle <= cycles; cycle++ {
+				require.NoErrorf(t, c.DiscoverNodes(t.Context()), "discovery cycle %d", cycle)
 
-			// Verify results
-			pool, ok := c.mu.connectionPool.(*multiServerPool)
-			require.Truef(t, ok, "Expected multiServerPool but got %T with URLs: %v",
-				c.mu.connectionPool, c.mu.connectionPool.URLs())
+				var ok bool
+				pool, ok = c.mu.connectionPool.(*multiServerPool)
+				require.Truef(t, ok, "Expected multiServerPool but got %T with URLs: %v",
+					c.mu.connectionPool, c.mu.connectionPool.URLs())
 
-			// Check included nodes (in either ready or dead lists,
-			// since newly discovered nodes start in dead state pending health checks)
-			actualNodes := make(map[string]struct{})
-			for _, conn := range pool.mu.ready {
-				actualNodes[conn.Name] = struct{}{}
+				pool.mu.RLock()
+				readyLen := len(pool.mu.ready)
+				deadLen := len(pool.mu.dead)
+				membersLen := len(pool.mu.members)
+				inventory := make(map[string]struct{}, readyLen+deadLen)
+				for _, conn := range pool.mu.ready {
+					inventory[conn.Name] = struct{}{}
+				}
+				for _, conn := range pool.mu.dead {
+					inventory[conn.Name] = struct{}{}
+				}
+				pool.mu.RUnlock()
+
+				require.Equalf(t, len(tt.nodes), readyLen+deadLen,
+					"cycle %d: inventory connection count (ready=%d dead=%d)", cycle, readyLen, deadLen)
+				require.Equalf(t, readyLen+deadLen, membersLen,
+					"cycle %d: members map must match ready+dead", cycle)
+				require.Lenf(t, inventory, len(tt.nodes),
+					"cycle %d: one connection per node (no duplicates)", cycle)
+				for _, expectedNode := range tt.expectedInInventory {
+					_, present := inventory[expectedNode]
+					require.Truef(t, present,
+						"cycle %d: expected node %q in the connection inventory", cycle, expectedNode)
+				}
 			}
-			for _, conn := range pool.mu.dead {
-				actualNodes[conn.Name] = struct{}{}
-			}
 
-			for _, expectedNode := range tt.expectedIncluded {
-				_, ok := actualNodes[expectedNode]
-				require.True(t, ok,
-					"Expected node %q to be included but it wasn't", expectedNode)
+			// Dedicated cluster managers stay in the inventory but must not be
+			// handed out for routing. With no router, routing uses the inventory
+			// pool's Next(), which skips them.
+			for _, dcm := range tt.expectedNotRoutable {
+				for i := 0; i < len(tt.nodes)*4; i++ {
+					conn, nextErr := pool.Next()
+					if nextErr != nil {
+						break
+					}
+					require.NotEqual(t, dcm, conn.Name,
+						"Dedicated cluster manager %q must not be selected for routing", dcm)
+				}
 			}
-
-			for _, excludedNode := range tt.expectedExcluded {
-				_, ok := actualNodes[excludedNode]
-				require.False(t, ok,
-					"Expected node %q to be excluded but it was included", excludedNode)
-			}
-
-			// Verify total count
-			expectedTotal := len(tt.expectedIncluded)
-			require.Len(t, actualNodes, expectedTotal,
-				"Expected %d nodes but got %d", expectedTotal, len(actualNodes))
 		})
 	}
 }

--- a/opensearchtransport/discovery_internal_test.go
+++ b/opensearchtransport/discovery_internal_test.go
@@ -250,10 +250,11 @@ func TestDiscovery(t *testing.T) {
 		pool, ok := tp.mu.connectionPool.(*multiServerPool)
 		require.True(t, ok, "Expected multiServerPool after discovery")
 
-		// The discovery should include es1 and es2 (data+ingest+cluster_manager)
-		// but exclude es3 and es4 (cluster_manager only)
+		// The inventory holds every discovered node regardless of role: es1 and
+		// es2 (data+ingest+cluster_manager) plus the dedicated cluster managers
+		// es3 and es4 (cluster_manager only).
 		totalConnections := len(pool.mu.ready) + len(pool.mu.dead)
-		require.Equal(t, 2, totalConnections, "Should have 2 total connections after policy filtering")
+		require.Equal(t, 4, totalConnections, "Should have all discovered nodes in the inventory")
 
 		// The exact split between ready/dead depends on health checks,
 		// but we should have the right nodes
@@ -267,8 +268,19 @@ func TestDiscovery(t *testing.T) {
 
 		require.Contains(t, foundNodes, "es1", "Should include es1")
 		require.Contains(t, foundNodes, "es2", "Should include es2")
-		require.NotContains(t, foundNodes, "es3", "Should not include es3 (cluster_manager only)")
-		require.NotContains(t, foundNodes, "es4", "Should not include es4 (cluster_manager only)")
+		require.Contains(t, foundNodes, "es3", "Inventory should include es3 (cluster_manager only)")
+		require.Contains(t, foundNodes, "es4", "Inventory should include es4 (cluster_manager only)")
+
+		// The dedicated cluster managers es3 and es4 stay in the inventory but
+		// must never be handed out for request routing.
+		for i := 0; i < len(foundNodes)*4; i++ {
+			conn, err := pool.Next()
+			if err != nil {
+				break
+			}
+			require.NotEqual(t, "es3", conn.Name, "Dedicated cluster manager es3 must not be selected for routing")
+			require.NotEqual(t, "es4", conn.Name, "Dedicated cluster manager es4 must not be selected for routing")
+		}
 	})
 
 	t.Run("DiscoverNodes() with SSL and authorization", func(t *testing.T) {
@@ -343,6 +355,9 @@ func TestDiscovery(t *testing.T) {
 		type testWants struct {
 			wantErr    bool
 			wantsNConn int
+			// wantsNotRoutable lists dedicated cluster managers that live in the
+			// inventory but must never be handed out by the routing pool's Next().
+			wantsNotRoutable []string
 		}
 		tests := []struct {
 			name string
@@ -404,7 +419,8 @@ func TestDiscovery(t *testing.T) {
 					},
 				},
 				testWants{
-					false, 3,
+					wantErr:    false,
+					wantsNConn: 3,
 				},
 			},
 			{
@@ -453,7 +469,9 @@ func TestDiscovery(t *testing.T) {
 				},
 
 				testWants{
-					false, 2,
+					wantErr:          false,
+					wantsNConn:       3,
+					wantsNotRoutable: []string{"es1"},
 				},
 			},
 			{
@@ -478,7 +496,8 @@ func TestDiscovery(t *testing.T) {
 				},
 
 				testWants{
-					false, 2,
+					wantErr:    false,
+					wantsNConn: 2,
 				},
 			},
 			{
@@ -536,7 +555,8 @@ func TestDiscovery(t *testing.T) {
 					},
 				},
 				testWants{
-					false, 3,
+					wantErr:    false,
+					wantsNConn: 3,
 				},
 			},
 			{
@@ -585,7 +605,9 @@ func TestDiscovery(t *testing.T) {
 				},
 
 				testWants{
-					false, 2,
+					wantErr:          false,
+					wantsNConn:       3,
+					wantsNotRoutable: []string{"es1"},
 				},
 			},
 			{
@@ -610,7 +632,8 @@ func TestDiscovery(t *testing.T) {
 				},
 
 				testWants{
-					false, 2,
+					wantErr:    false,
+					wantsNConn: 2,
 				},
 			},
 		}
@@ -730,6 +753,19 @@ func TestDiscovery(t *testing.T) {
 
 					if !reflect.DeepEqual(expectedRoles, actualRoles) {
 						t.Errorf("Unexpected roles for node %q, want=%q, got=%q", conn.Name, expectedRoles, actualRoles)
+					}
+				}
+
+				// Dedicated cluster managers stay in the inventory but must never
+				// be handed out for request routing.
+				for _, dcm := range tt.want.wantsNotRoutable {
+					for i := 0; i < len(allConns)*4; i++ {
+						conn, err := pool.Next()
+						if err != nil {
+							break
+						}
+						require.NotEqual(t, dcm, conn.Name,
+							"Dedicated cluster manager %q must not be selected for routing", dcm)
 					}
 				}
 
@@ -976,44 +1012,48 @@ func TestShouldSkipDedicatedClusterManagers(t *testing.T) {
 // TestDiscoverNodesWithNewRoleValidation verifies the enhanced discovery behavior
 func TestDiscoverNodesWithNewRoleValidation(t *testing.T) {
 	tests := []struct {
-		name            string
-		nodes           map[string][]string // nodeName -> roles
-		expectedNodes   []string            // nodes that should be included
-		expectedSkipped []string            // nodes that should be skipped
+		name  string
+		nodes map[string][]string // nodeName -> roles
+		// expectedInInventory lists nodes that must appear in the allConns pool.
+		// The inventory holds every discovered node regardless of role.
+		expectedInInventory []string
+		// expectedNotRoutable lists dedicated cluster managers that stay in the
+		// inventory but must never be handed out for request routing.
+		expectedNotRoutable []string
 	}{
 		{
 			"mixed node types with validation",
 			map[string][]string{
-				"cm-only":     {RoleClusterManager},           // should be skipped
-				"master-only": {RoleMaster},                   // should be skipped
-				"data-node":   {RoleData},                     // should be included
-				"mixed-good":  {RoleClusterManager, RoleData}, // should be included
-				"search-only": {RoleSearch},                   // should be included
+				"cm-only":     {RoleClusterManager},           // dedicated cluster manager
+				"master-only": {RoleMaster},                   // dedicated cluster manager
+				"data-node":   {RoleData},                     // routable
+				"mixed-good":  {RoleClusterManager, RoleData}, // routable
+				"search-only": {RoleSearch},                   // routable
 			},
-			[]string{"data-node", "mixed-good", "search-only"},
+			[]string{"cm-only", "master-only", "data-node", "mixed-good", "search-only"},
 			[]string{"cm-only", "master-only"},
 		},
 		{
 			"OpenSearch 3.X compliant setup",
 			map[string][]string{
-				"dedicated-cm": {RoleClusterManager},   // should be skipped
-				"data-hot":     {RoleData, RoleIngest}, // should be included
-				"data-warm":    {RoleWarm, RoleData},   // should be included
-				"search-node":  {RoleSearch},           // should be included
-				"coordinating": {RoleCoordinatingOnly}, // should be included
+				"dedicated-cm": {RoleClusterManager},   // dedicated cluster manager
+				"data-hot":     {RoleData, RoleIngest}, // routable
+				"data-warm":    {RoleWarm, RoleData},   // routable
+				"search-node":  {RoleSearch},           // routable
+				"coordinating": {RoleCoordinatingOnly}, // routable
 			},
-			[]string{"data-hot", "data-warm", "search-node", "coordinating"},
+			[]string{"dedicated-cm", "data-hot", "data-warm", "search-node", "coordinating"},
 			[]string{"dedicated-cm"},
 		},
 		{
 			"cluster manager and remote cluster client filtering",
 			map[string][]string{
-				"cm-rcc":    {RoleClusterManager, RoleRemoteClusterClient}, // should be skipped
-				"cm-data":   {RoleClusterManager, RoleData},                // should be included
-				"rcc-only":  {RoleRemoteClusterClient},                     // should be included
-				"data-node": {RoleData},                                    // should be included
+				"cm-rcc":    {RoleClusterManager, RoleRemoteClusterClient}, // dedicated cluster manager
+				"cm-data":   {RoleClusterManager, RoleData},                // routable
+				"rcc-only":  {RoleRemoteClusterClient},                     // routable
+				"data-node": {RoleData},                                    // routable
 			},
-			[]string{"cm-data", "rcc-only", "data-node"},
+			[]string{"cm-rcc", "cm-data", "rcc-only", "data-node"},
 			[]string{"cm-rcc"},
 		},
 	}
@@ -1103,7 +1143,8 @@ func TestDiscoverNodesWithNewRoleValidation(t *testing.T) {
 			pool, ok := c.mu.connectionPool.(*multiServerPool)
 			require.True(t, ok, "Expected multiServerPool")
 
-			// Check that expected nodes are included (ready or dead list)
+			// The allConns inventory holds every discovered node regardless of
+			// role so discovery can reuse and evict connections.
 			actualNodes := make(map[string]bool)
 			for _, conn := range pool.mu.ready {
 				actualNodes[conn.Name] = true
@@ -1112,17 +1153,25 @@ func TestDiscoverNodesWithNewRoleValidation(t *testing.T) {
 				actualNodes[conn.Name] = true
 			}
 
-			require.Len(t, actualNodes, len(tt.expectedNodes),
-				"Expected %d nodes but got %d: %v", len(tt.expectedNodes), len(actualNodes), actualNodes)
+			require.Len(t, actualNodes, len(tt.expectedInInventory),
+				"Expected %d nodes but got %d: %v", len(tt.expectedInInventory), len(actualNodes), actualNodes)
 
-			for _, expectedNode := range tt.expectedNodes {
+			for _, expectedNode := range tt.expectedInInventory {
 				require.True(t, actualNodes[expectedNode],
-					"Expected node %q to be included but it wasn't", expectedNode)
+					"Expected node %q in the connection inventory but it wasn't", expectedNode)
 			}
 
-			for _, skippedNode := range tt.expectedSkipped {
-				require.False(t, actualNodes[skippedNode],
-					"Expected node %q to be skipped but it was included", skippedNode)
+			// Dedicated cluster managers stay in the inventory but must never be
+			// handed out for request routing.
+			for _, dcm := range tt.expectedNotRoutable {
+				for i := 0; i < len(actualNodes)*4; i++ {
+					conn, err := pool.Next()
+					if err != nil {
+						break
+					}
+					require.NotEqual(t, dcm, conn.Name,
+						"Dedicated cluster manager %q must not be selected for routing", dcm)
+				}
 			}
 		})
 	}
@@ -1134,39 +1183,45 @@ func TestIncludeDedicatedClusterManagersConfiguration(t *testing.T) {
 		name                            string
 		includeDedicatedClusterManagers bool
 		nodes                           map[string][]string // nodeName -> roles
-		expectedIncluded                []string            // nodes that should be included
-		expectedExcluded                []string            // nodes that should be excluded
+		// expectedInInventory lists nodes that must appear in the allConns pool.
+		// The inventory holds every discovered node regardless of role so that
+		// discovery can reuse and evict connections; dedicated cluster managers
+		// are kept here and excluded from routing separately.
+		expectedInInventory []string
+		// expectedNotRoutable lists dedicated cluster managers that must be kept
+		// out of the round-robin routing pool.
+		expectedNotRoutable []string
 	}{
 		{
-			name:                            "IncludeDedicatedClusterManagers enabled - includes all nodes",
+			name:                            "IncludeDedicatedClusterManagers enabled - all nodes routable",
 			includeDedicatedClusterManagers: true,
 			nodes: map[string][]string{
 				"cm-only":   {RoleClusterManager},
 				"data-node": {RoleData},
 			},
-			expectedIncluded: []string{"cm-only", "data-node"},
-			expectedExcluded: []string{},
+			expectedInInventory: []string{"cm-only", "data-node"},
+			expectedNotRoutable: []string{},
 		},
 		{
-			name:                            "IncludeDedicatedClusterManagers disabled (default) - excludes dedicated CM nodes",
+			name:                            "IncludeDedicatedClusterManagers disabled (default) - dedicated CM in inventory but not routable",
 			includeDedicatedClusterManagers: false,
 			nodes: map[string][]string{
 				"cm-only":   {RoleClusterManager},
 				"data-node": {RoleData},
 				"dummy":     {RoleData}, // Add second node to avoid single connection pool
 			},
-			expectedIncluded: []string{"data-node", "dummy"},
-			expectedExcluded: []string{"cm-only"},
+			expectedInInventory: []string{"cm-only", "data-node", "dummy"},
+			expectedNotRoutable: []string{"cm-only"},
 		},
 		{
-			name:                            "Mixed roles with CM always included regardless of setting",
+			name:                            "Mixed roles with CM always routable regardless of setting",
 			includeDedicatedClusterManagers: false,
 			nodes: map[string][]string{
 				"cm-data": {RoleClusterManager, RoleData},
 				"dummy":   {RoleData}, // Add second node to avoid single connection pool
 			},
-			expectedIncluded: []string{"cm-data", "dummy"},
-			expectedExcluded: []string{},
+			expectedInInventory: []string{"cm-data", "dummy"},
+			expectedNotRoutable: []string{},
 		},
 	}
 
@@ -1264,37 +1319,61 @@ func TestIncludeDedicatedClusterManagersConfiguration(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			// Perform discovery
-			err = c.DiscoverNodes(t.Context())
-			require.NoError(t, err)
-
-			// Verify results
 			pool, ok := c.mu.connectionPool.(*multiServerPool)
-			require.True(t, ok, "Expected multiServerPool")
+			require.False(t, ok, "expected a single-server seed pool before discovery, got %T", c.mu.connectionPool)
 
-			// Check included nodes (ready or dead list)
-			actualNodes := make(map[string]bool)
-			for _, conn := range pool.mu.ready {
-				actualNodes[conn.Name] = true
-			}
-			for _, conn := range pool.mu.dead {
-				actualNodes[conn.Name] = true
+			// Run discovery repeatedly. The inventory must converge to exactly one
+			// connection per node and stay there: an unbounded pool that re-created
+			// connections each cycle (the dedicated-cluster-manager leak) would grow
+			// with every iteration. Asserting the exact length on every cycle is the
+			// regression guard.
+			const cycles = 5
+			for cycle := 1; cycle <= cycles; cycle++ {
+				require.NoError(t, c.DiscoverNodes(t.Context()), "discovery cycle %d", cycle)
+
+				pool, ok = c.mu.connectionPool.(*multiServerPool)
+				require.True(t, ok, "Expected multiServerPool after discovery")
+
+				pool.mu.RLock()
+				readyLen := len(pool.mu.ready)
+				deadLen := len(pool.mu.dead)
+				membersLen := len(pool.mu.members)
+				inventory := make(map[string]bool, readyLen+deadLen)
+				for _, conn := range pool.mu.ready {
+					inventory[conn.Name] = true
+				}
+				for _, conn := range pool.mu.dead {
+					inventory[conn.Name] = true
+				}
+				pool.mu.RUnlock()
+
+				// The inventory holds exactly one connection per discovered node,
+				// regardless of role, and never grows across cycles.
+				require.Equalf(t, len(tt.nodes), readyLen+deadLen,
+					"cycle %d: inventory connection count (ready=%d dead=%d)", cycle, readyLen, deadLen)
+				require.Equalf(t, readyLen+deadLen, membersLen,
+					"cycle %d: members map must match ready+dead", cycle)
+				require.Lenf(t, inventory, len(tt.nodes),
+					"cycle %d: one connection per node (no duplicates)", cycle)
+				for _, expectedNode := range tt.expectedInInventory {
+					require.Truef(t, inventory[expectedNode],
+						"cycle %d: expected node %q in the connection inventory", cycle, expectedNode)
+				}
 			}
 
-			for _, expectedNode := range tt.expectedIncluded {
-				require.True(t, actualNodes[expectedNode],
-					"Expected node %q to be included but it wasn't", expectedNode)
+			// Dedicated cluster managers stay in the inventory but must not be
+			// handed out for request routing. With no router configured, routing
+			// uses the inventory pool's Next(), which skips them.
+			for _, dcm := range tt.expectedNotRoutable {
+				for i := 0; i < len(tt.nodes)*4; i++ {
+					conn, nextErr := pool.Next()
+					if nextErr != nil {
+						break
+					}
+					require.NotEqual(t, dcm, conn.Name,
+						"Dedicated cluster manager %q must not be selected for routing", dcm)
+				}
 			}
-
-			for _, excludedNode := range tt.expectedExcluded {
-				require.False(t, actualNodes[excludedNode],
-					"Expected node %q to be excluded but it was included", excludedNode)
-			}
-
-			// Verify total count
-			expectedTotal := len(tt.expectedIncluded)
-			require.Len(t, actualNodes, expectedTotal,
-				"Expected %d nodes but got %d", expectedTotal, len(actualNodes))
 		})
 	}
 }

--- a/opensearchtransport/opensearchtransport.go
+++ b/opensearchtransport/opensearchtransport.go
@@ -1062,21 +1062,22 @@ func New(cfg Config) (*Client, error) {
 	// Configure policy settings for all policies in the router
 	if client.router != nil {
 		config := policyConfig{
-			ctx:                          client.ctx,
-			resurrectTimeoutInitial:      client.resurrectTimeoutInitial,
-			resurrectTimeoutMax:          client.resurrectTimeoutMax,
-			resurrectTimeoutFactorCutoff: client.resurrectTimeoutFactorCutoff,
-			minimumResurrectTimeout:      client.minimumResurrectTimeout,
-			jitterScale:                  client.jitterScale,
-			serverMaxNewConnsPerSec:      client.serverMaxNewConnsPerSec,
-			clientsPerServer:             client.clientsPerServer,
-			healthCheck:                  client.healthCheck,
-			observer:                     client.observer.Load(),
-			poolInfoReady:                &client.poolInfoReady,
-			clusterSearchCwnd:            &client.clusterSearch.cwnd,
-			activeListCap:                client.activeListCapConfig,
-			standbyPromotionChecks:       client.standbyPromotionChecks,
-			metrics:                      client.metrics,
+			ctx:                             client.ctx,
+			resurrectTimeoutInitial:         client.resurrectTimeoutInitial,
+			resurrectTimeoutMax:             client.resurrectTimeoutMax,
+			resurrectTimeoutFactorCutoff:    client.resurrectTimeoutFactorCutoff,
+			minimumResurrectTimeout:         client.minimumResurrectTimeout,
+			jitterScale:                     client.jitterScale,
+			serverMaxNewConnsPerSec:         client.serverMaxNewConnsPerSec,
+			clientsPerServer:                client.clientsPerServer,
+			healthCheck:                     client.healthCheck,
+			observer:                        client.observer.Load(),
+			poolInfoReady:                   &client.poolInfoReady,
+			clusterSearchCwnd:               &client.clusterSearch.cwnd,
+			activeListCap:                   client.activeListCapConfig,
+			standbyPromotionChecks:          client.standbyPromotionChecks,
+			includeDedicatedClusterManagers: client.includeDedicatedClusterManagers,
+			metrics:                         client.metrics,
 		}
 		// Use type assertion to check if the router (which is a Policy) implements policyConfigurable
 		if configurablePolicy, ok := client.router.(policyConfigurable); ok {
@@ -2441,6 +2442,7 @@ func (c *Client) newMultiServerPoolFromClientWithLock(name string, m *metrics) *
 		metrics:                      m,
 		activeListCapConfig:          c.activeListCapConfig,
 		standbyPromotionChecks:       c.standbyPromotionChecks,
+		excludeDCM:                   !c.includeDedicatedClusterManagers,
 	}
 	pool.mu.activeListCap = c.activeListCap
 	pool.mu.healthCheck = c.healthCheck
@@ -2456,10 +2458,13 @@ func (c *Client) newMultiServerPoolFromClientWithLock(name string, m *metrics) *
 func (c *Client) promoteConnectionPoolWithLock(readyConnections, deadConnections []*Connection) *multiServerPool {
 	switch currentPool := c.mu.connectionPool.(type) {
 	case *singleServerPool:
-		// Promote from single to multi-node pool using client-configured timeouts
+		// Promote from single to multi-node pool using client-configured timeouts.
+		// allConns is the full connection inventory; routing policies keep query
+		// traffic off dedicated cluster managers (see RoundRobinPolicy).
 		filteredReady := make([]*Connection, 0, len(readyConnections))
 		filteredDead := make([]*Connection, 0, len(deadConnections))
-		c.applyConnectionFiltering(readyConnections, deadConnections, &filteredReady, &filteredDead)
+		filteredReady = append(filteredReady, readyConnections...)
+		filteredDead = append(filteredDead, deadConnections...)
 
 		// Shuffle connections for load distribution unless disabled
 		if !c.skipConnectionShuffle && len(filteredReady) > 1 {
@@ -2550,26 +2555,6 @@ func (c *Client) demoteConnectionPoolWithLock() *singleServerPool {
 
 	default:
 		panic(fmt.Sprintf("unsupported connection pool type for demotion: %T", currentPool))
-	}
-}
-
-// applyConnectionFiltering applies client-level filtering for dedicated cluster managers
-func (c *Client) applyConnectionFiltering(readyConnections, deadConnections []*Connection, filteredReady, filteredDead *[]*Connection) {
-	for _, conn := range readyConnections {
-		if !c.includeDedicatedClusterManagers && conn.Roles.isDedicatedClusterManager() {
-			if dl := loadDebugLogger(); dl != nil {
-				dl.Logf("Excluding dedicated cluster manager %q from connection pool\n", conn.Name)
-			}
-			continue
-		}
-		*filteredReady = append(*filteredReady, conn)
-	}
-
-	for _, conn := range deadConnections {
-		if !c.includeDedicatedClusterManagers && conn.Roles.isDedicatedClusterManager() {
-			continue
-		}
-		*filteredDead = append(*filteredDead, conn)
 	}
 }
 

--- a/opensearchtransport/opensearchtransport_internal_test.go
+++ b/opensearchtransport/opensearchtransport_internal_test.go
@@ -1601,86 +1601,88 @@ func TestConnectionPoolPromotion(t *testing.T) {
 		require.Equal(t, customCutoff, newPool.resurrectTimeoutFactorCutoff, "Should preserve custom cutoff factor")
 	})
 
-	t.Run("promoteConnectionPoolWithLock filters dedicated cluster managers", func(t *testing.T) {
-		// Create connections with different roles
-		dataConn := &Connection{
-			URL:   &url.URL{Host: "data:9200"},
-			Name:  "data-node",
-			Roles: newRoleSet([]string{"data"}),
+	t.Run("promoteConnectionPoolWithLock dedicated cluster manager handling", func(t *testing.T) {
+		t.Parallel()
+
+		dataConn := func() *Connection {
+			return &Connection{URL: &url.URL{Host: "data:9200"}, Name: "data-node", Roles: newRoleSet([]string{"data"})}
 		}
-		clusterManagerConn := &Connection{
-			URL:   &url.URL{Host: "cm:9200"},
-			Name:  "cm-node",
-			Roles: newRoleSet([]string{"cluster_manager"}), // Dedicated cluster manager
+		cmConn := func() *Connection {
+			return &Connection{URL: &url.URL{Host: "cm:9200"}, Name: "cm-node", Roles: newRoleSet([]string{"cluster_manager"})}
 		}
-		mixedConn := &Connection{
-			URL:   &url.URL{Host: "mixed:9200"},
-			Name:  "mixed-node",
-			Roles: newRoleSet([]string{"cluster_manager", "data"}), // Not dedicated
+		mixedConn := func() *Connection {
+			return &Connection{URL: &url.URL{Host: "mixed:9200"}, Name: "mixed-node", Roles: newRoleSet([]string{"cluster_manager", "data"})}
 		}
 
-		u, _ := url.Parse("http://localhost:9200")
-		client, err := New(Config{
-			URLs:                            []*url.URL{u},
-			IncludeDedicatedClusterManagers: false, // Default: exclude dedicated CMs
-		})
-		require.NoError(t, err)
-
-		client.mu.Lock()
-		statusPool := client.promoteConnectionPoolWithLock(
-			[]*Connection{dataConn, clusterManagerConn, mixedConn},
-			[]*Connection{},
-		)
-		client.mu.Unlock()
-
-		// Should exclude dedicated cluster manager but include mixed role node
-		require.Len(t, statusPool.mu.ready, 2, "Should exclude dedicated cluster manager")
-
-		names := make([]string, len(statusPool.mu.ready))
-		for i, conn := range statusPool.mu.ready {
-			names[i] = conn.Name
-		}
-		require.Contains(t, names, "data-node", "Should include data node")
-		require.Contains(t, names, "mixed-node", "Should include mixed role node")
-		require.NotContains(t, names, "cm-node", "Should exclude dedicated cluster manager")
-	})
-
-	t.Run("promoteConnectionPoolWithLock includes dedicated cluster managers when configured", func(t *testing.T) {
-		// Create connections with different roles
-		dataConn := &Connection{
-			URL:   &url.URL{Host: "data:9200"},
-			Name:  "data-node",
-			Roles: newRoleSet([]string{"data"}),
-		}
-		clusterManagerConn := &Connection{
-			URL:   &url.URL{Host: "cm:9200"},
-			Name:  "cm-node",
-			Roles: newRoleSet([]string{"cluster_manager"}), // Dedicated cluster manager
+		tests := []struct {
+			name            string
+			includeDCM      bool
+			ready           []*Connection
+			wantReadyLen    int      // connections held in the inventory ready list
+			wantInInventory []string // names that must be present in the inventory
+			wantExcludeDCM  bool     // pool skips dedicated cluster managers on selection
+			wantNotRoutable []string // dedicated cluster managers Next() must never return
+		}{
+			{
+				name:            "default keeps dedicated cluster manager in inventory but not routable",
+				includeDCM:      false,
+				ready:           []*Connection{dataConn(), cmConn(), mixedConn()},
+				wantReadyLen:    3,
+				wantInInventory: []string{"data-node", "cm-node", "mixed-node"},
+				wantExcludeDCM:  true,
+				wantNotRoutable: []string{"cm-node"},
+			},
+			{
+				name:            "includes dedicated cluster manager when configured",
+				includeDCM:      true,
+				ready:           []*Connection{dataConn(), cmConn()},
+				wantReadyLen:    2,
+				wantInInventory: []string{"data-node", "cm-node"},
+				wantExcludeDCM:  false,
+				wantNotRoutable: nil,
+			},
 		}
 
-		u, _ := url.Parse("http://localhost:9200")
-		client, err := New(Config{
-			URLs:                            []*url.URL{u},
-			IncludeDedicatedClusterManagers: true, // Include dedicated CMs
-		})
-		require.NoError(t, err)
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				u, _ := url.Parse("http://localhost:9200")
+				client, err := New(Config{
+					URLs:                            []*url.URL{u},
+					IncludeDedicatedClusterManagers: tt.includeDCM,
+				})
+				require.NoError(t, err)
 
-		client.mu.Lock()
-		statusPool := client.promoteConnectionPoolWithLock(
-			[]*Connection{dataConn, clusterManagerConn},
-			[]*Connection{},
-		)
-		client.mu.Unlock()
+				client.mu.Lock()
+				statusPool := client.promoteConnectionPoolWithLock(tt.ready, []*Connection{})
+				client.mu.Unlock()
 
-		// Should include all connections including dedicated cluster manager
-		require.Len(t, statusPool.mu.ready, 2, "Should include all connections")
+				require.Len(t, statusPool.mu.ready, tt.wantReadyLen, "inventory ready-list length")
+				require.Empty(t, statusPool.mu.dead, "no connections expected in the dead list")
 
-		names := make([]string, len(statusPool.mu.ready))
-		for i, conn := range statusPool.mu.ready {
-			names[i] = conn.Name
+				names := make([]string, len(statusPool.mu.ready))
+				for i, conn := range statusPool.mu.ready {
+					names[i] = conn.Name
+				}
+				for _, want := range tt.wantInInventory {
+					require.Contains(t, names, want, "inventory must contain %q", want)
+				}
+
+				require.Equal(t, tt.wantExcludeDCM, statusPool.excludeDCM, "excludeDCM")
+
+				// Dedicated cluster managers stay in the inventory but must not be
+				// handed out by Next() when excludeDCM is set.
+				for _, dcm := range tt.wantNotRoutable {
+					for range len(tt.ready) * 4 {
+						conn, nextErr := statusPool.Next()
+						if nextErr != nil {
+							break
+						}
+						require.NotEqual(t, dcm, conn.Name, "dedicated cluster manager %q must not be selected", dcm)
+					}
+				}
+			})
 		}
-		require.Contains(t, names, "data-node", "Should include data node")
-		require.Contains(t, names, "cm-node", "Should include dedicated cluster manager")
 	})
 }
 
@@ -2081,9 +2083,29 @@ func TestConnectionPoolPromotionIntegration(t *testing.T) {
 		)
 		client.mu.Unlock()
 
-		// Should exclude dedicated cluster manager and debug log it
-		require.Len(t, statusPool.mu.ready, 1, "Should exclude dedicated cluster manager")
-		require.Equal(t, "data-node", statusPool.mu.ready[0].Name, "Should include data node")
+		// The inventory holds every connection regardless of role, so the
+		// dedicated cluster manager remains present alongside the data node.
+		require.Len(t, statusPool.mu.ready, 2, "Inventory should hold all connections including the dedicated cluster manager")
+
+		names := map[string]bool{}
+		for _, conn := range statusPool.mu.ready {
+			names[conn.Name] = true
+		}
+		require.True(t, names["data-node"], "Inventory should include data node")
+		require.True(t, names["cm-node"], "Inventory should include dedicated cluster manager")
+
+		// With IncludeDedicatedClusterManagers disabled the pool excludes
+		// dedicated cluster managers from routing selection.
+		require.True(t, statusPool.excludeDCM, "Pool should exclude dedicated cluster managers from routing")
+
+		// The dedicated cluster manager must never be handed out for routing.
+		for i := 0; i < len(statusPool.mu.ready)*4; i++ {
+			conn, err := statusPool.Next()
+			if err != nil {
+				break
+			}
+			require.Equal(t, "data-node", conn.Name, "Only the data node should be selected for routing")
+		}
 	})
 
 	t.Run("promoteConnectionPoolWithLock preserves multiServerPool settings", func(t *testing.T) {

--- a/opensearchtransport/policy.go
+++ b/opensearchtransport/policy.go
@@ -59,6 +59,11 @@ type policyConfig struct {
 	activeListCap          *int  // nil = auto-scale; non-nil = user-specified cap value
 	standbyPromotionChecks int64 // consecutive health checks before standby->ready
 
+	// includeDedicatedClusterManagers admits dedicated cluster managers into the
+	// round-robin routing pool. Honored only by RoundRobinPolicy, the sole policy
+	// that admits nodes irrespective of role.
+	includeDedicatedClusterManagers bool
+
 	// Metrics is always non-nil for a New()-constructed transport. Detailed
 	// callback registration below is gated by metrics.detailedEnabled()
 	// (EnableMetrics), not by nil-ness. Policies may register metric callbacks

--- a/opensearchtransport/policy_roundrobin.go
+++ b/opensearchtransport/policy_roundrobin.go
@@ -44,6 +44,13 @@ var (
 type RoundRobinPolicy struct {
 	pool        *multiServerPool // Embedded connection pool for round-robin selection
 	policyState atomic.Int32     // Bitfield: psEnabled|psDisabled|psEnvEnabled|psEnvDisabled
+
+	// includeDCM admits dedicated cluster managers into the round-robin pool.
+	// When false (default), dedicated cluster managers are not routed to. This
+	// is the only routing policy that admits nodes irrespective of role, so it
+	// is the only one that honors this setting; role-scoped policies exclude
+	// dedicated cluster managers by their role criteria.
+	includeDCM bool
 }
 
 func (p *RoundRobinPolicy) policyTypeName() string      { return policyTypeNameRoundRobin }
@@ -58,6 +65,7 @@ func NewRoundRobinPolicy() Policy {
 
 // configurePolicySettings configures pool settings for this policy (leaf policy - no sub-policies).
 func (p *RoundRobinPolicy) configurePolicySettings(config policyConfig) error {
+	p.includeDCM = config.includeDedicatedClusterManagers
 	// Create pool with proper settings if we don't have one yet
 	if p.pool == nil {
 		config.name = policyTypeNameRoundRobin
@@ -118,6 +126,12 @@ func (p *RoundRobinPolicy) DiscoveryUpdate(added, removed, unchanged []*Connecti
 
 	// Add new connections based on their health status
 	for _, conn := range added {
+		// Dedicated cluster managers do not serve request traffic unless
+		// explicitly included; they remain in the connection inventory for
+		// discovery but are not admitted to the round-robin pool.
+		if !p.includeDCM && conn.Roles.isDedicatedClusterManager() {
+			continue
+		}
 		// Guard: skip if already a member of this pool.
 		if _, exists := p.pool.mu.members[conn]; exists {
 			continue

--- a/opensearchtransport/pool_multi_server.go
+++ b/opensearchtransport/pool_multi_server.go
@@ -26,6 +26,12 @@ import (
 type multiServerPool struct {
 	name string // Pool identity for metrics/debug (e.g. "roundrobin", "role:data")
 
+	// excludeDCM skips dedicated cluster managers during selection. Set only on
+	// the allConns inventory pool, which serves requests as a last resort when no
+	// router is configured; the inventory holds dedicated cluster managers for
+	// discovery reuse, but they must not receive request traffic by default.
+	excludeDCM bool
+
 	// ctx is the lifecycle context for async pool operations (health checks,
 	// resurrection, RTT probes). Derived from Client.ctx during pool construction
 	// so that Client.Close() cancels all background goroutines. cancel is the

--- a/opensearchtransport/pool_selection.go
+++ b/opensearchtransport/pool_selection.go
@@ -58,6 +58,14 @@ func (cp *multiServerPool) Next() (*Connection, error) {
 			if conn == nil {
 				continue // selector error
 			}
+
+			// Dedicated cluster managers stay in the inventory for discovery but
+			// do not serve request traffic. Skipping here means a pool of only
+			// dedicated cluster managers exhausts its attempts and falls through
+			// to the no-connection path below.
+			if cp.excludeDCM && conn.Roles.isDedicatedClusterManager() {
+				continue
+			}
 			state := conn.loadConnState()
 
 			if state.lifecycle()&(lcActive|lcStandby) == 0 {
@@ -183,6 +191,9 @@ func (cp *multiServerPool) nextWithEviction() (*Connection, error) {
 		if conn == nil {
 			continue
 		}
+		if cp.excludeDCM && conn.Roles.isDedicatedClusterManager() {
+			continue // dedicated cluster managers do not serve request traffic
+		}
 		state := conn.loadConnState()
 
 		if state.lifecycle()&(lcActive|lcStandby) != 0 {
@@ -222,6 +233,9 @@ func (cp *multiServerPool) nextFallback() (*Connection, error) {
 		if conn == nil {
 			continue
 		}
+		if cp.excludeDCM && conn.Roles.isDedicatedClusterManager() {
+			continue // dedicated cluster managers do not serve request traffic
+		}
 		state := conn.loadConnState()
 
 		if state.lifecycle()&(lcActive|lcStandby) != 0 {
@@ -244,7 +258,7 @@ func (cp *multiServerPool) nextFallback() (*Connection, error) {
 //   - Caller must hold pool write lock
 func (cp *multiServerPool) nextFallbackWithLock() (*Connection, error) {
 	// Try standby before zombie -- standby connections are healthy but idle
-	if c := cp.tryStandbyWithLock(); c != nil {
+	if c := cp.tryStandbyWithLock(); c != nil && !(cp.excludeDCM && c.Roles.isDedicatedClusterManager()) {
 		cp.poolRequests.Add(1)
 		return c, nil
 	}
@@ -253,7 +267,7 @@ func (cp *multiServerPool) nextFallbackWithLock() (*Connection, error) {
 	// availableForRouting (see that method for why). An all-unavailable dead
 	// list yields nil, so Next reports ErrNoConnections and the request
 	// cascades to the seed-URL fallback rather than dialing a dead zombie.
-	if c := cp.tryZombieWithLock(); c != nil {
+	if c := cp.tryZombieWithLock(); c != nil && !(cp.excludeDCM && c.Roles.isDedicatedClusterManager()) {
 		cp.poolRequests.Add(1)
 		return c, nil
 	}

--- a/opensearchtransport/transport_coverage_internal_test.go
+++ b/opensearchtransport/transport_coverage_internal_test.go
@@ -295,57 +295,6 @@ func TestDemoteConnectionPoolWithLock(t *testing.T) {
 	})
 }
 
-func TestApplyConnectionFiltering(t *testing.T) {
-	t.Parallel()
-
-	makeConn := func(name string, roles []string) *Connection {
-		return &Connection{Name: name, Roles: newRoleSet(roles)}
-	}
-
-	t.Run("excludes dedicated cluster managers", func(t *testing.T) {
-		t.Parallel()
-		c := &Client{includeDedicatedClusterManagers: false}
-
-		data := makeConn("data-1", []string{"data", "ingest"})
-		cm := makeConn("cm-1", []string{"cluster_manager"})
-		mixed := makeConn("mixed-1", []string{"cluster_manager", "data"})
-
-		var filteredReady, filteredDead []*Connection
-		c.applyConnectionFiltering([]*Connection{data, cm, mixed}, nil, &filteredReady, &filteredDead)
-
-		require.Len(t, filteredReady, 2)
-		require.Equal(t, "data-1", filteredReady[0].Name)
-		require.Equal(t, "mixed-1", filteredReady[1].Name)
-	})
-
-	t.Run("includes all when flag is true", func(t *testing.T) {
-		t.Parallel()
-		c := &Client{includeDedicatedClusterManagers: true}
-
-		data := makeConn("data-1", []string{"data"})
-		cm := makeConn("cm-1", []string{"cluster_manager"})
-
-		var filteredReady, filteredDead []*Connection
-		c.applyConnectionFiltering([]*Connection{data, cm}, nil, &filteredReady, &filteredDead)
-
-		require.Len(t, filteredReady, 2)
-	})
-
-	t.Run("filters dead list too", func(t *testing.T) {
-		t.Parallel()
-		c := &Client{includeDedicatedClusterManagers: false}
-
-		dataDead := makeConn("data-dead", []string{"data"})
-		cmDead := makeConn("cm-dead", []string{"cluster_manager"})
-
-		var filteredReady, filteredDead []*Connection
-		c.applyConnectionFiltering(nil, []*Connection{dataDead, cmDead}, &filteredReady, &filteredDead)
-
-		require.Len(t, filteredDead, 1)
-		require.Equal(t, "data-dead", filteredDead[0].Name)
-	})
-}
-
 func TestLogRoundTrip_Coverage(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
A dedicated cluster manager (cluster_manager role with no work roles) was
filtered out of the allConns pool during discovery and promotion, while the
router received the unfiltered added/removed diffs. Because the node was absent
from allConns, the discovery reuse lookup (findConnectionByURL) never matched
it, so a new *Connection was created for it on every discovery cycle, and the
removed diff (computed against allConns) never contained it, so the prior
cycle's connection was never evicted. The round-robin fallback pool accumulated
these connections without bound, and its checkDead health checks repopulated a
per-connection poolRegistry sync.Map each cycle, growing the heap without limit.
The rate scaled with discovery frequency.

Make allConns the full connection inventory: it holds every discovered node
regardless of role, so discovery reuses and evicts connections symmetrically.
Keep dedicated cluster managers out of request routing at the point of
selection instead:

  - RoundRobinPolicy, the only policy that admits nodes irrespective of role,
    skips dedicated cluster managers in its DiscoveryUpdate add path unless
    IncludeDedicatedClusterManagers is set. The setting flows via policyConfig.
  - The allConns pool carries excludeDCM (set when IncludeDedicatedClusterManagers
    is false) so multiServerPool.Next() skips dedicated cluster managers during
    selection, including the no-router fallback path. A pool of only dedicated
    cluster managers exhausts its attempts and reports ErrNoConnections.

Discovery still bootstraps against a dedicated cluster manager seed via the
seed-fallback pool, which is unaffected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
