### PR TITLE
chore(v4): bump go to 1.25.12

### DIFF
--- a/cmd/osgen/go.mod
+++ b/cmd/osgen/go.mod
@@ -1,6 +1,6 @@
 module github.com/opensearch-project/opensearch-go/v4/cmd/osgen
 
-go 1.25.9
+go 1.25.12
 
 require (
 	github.com/getkin/kin-openapi v0.145.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opensearch-project/opensearch-go/v4
 
-go 1.25.9
+go 1.25.12
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.1


### PR DESCRIPTION
### Description
For v4, 1.25.9 has known CVEs; bump root, osprom, osotel, osgen, and osapilint modules plus go.work.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
