### PR TITLE
docs(opensearchapi): show the Errors(err) dispatch idiom in the package doc and README

### DIFF
--- a/opensearchapi/README.md
+++ b/opensearchapi/README.md
@@ -173,7 +173,23 @@ params := opensearchapi.SomeParams{
 
 OpenSearch returns HTTP 200 even when a request only partially succeeded: bulk operations whose items failed individually, searches that lost some shards, writes whose replica shards rejected the request. `opensearchapi` turns those partial failures into typed Go errors so they surface through the idiomatic `if err != nil` path.
 
-By default (`Config.Errors == nil` resolves to `errmask.Empty`) every category is reported; set `Config.Errors: errmask.New(errmask.All)` or `OPENSEARCH_GO_ERROR_MASK` to mask categories. Dispatch on the typed errors with a `for`/`switch` over `opensearchapi.Errors(err)`.
+By default (`Config.Errors == nil` resolves to `errmask.Empty`) every category is reported; set `Config.Errors: errmask.New(errmask.All)` or `OPENSEARCH_GO_ERROR_MASK` to mask categories. Dispatch on the typed errors with a `for`/`switch` over `opensearchapi.Errors(err)`:
+
+```go
+resp, err := client.MSearch(ctx, req)
+for _, sub := range opensearchapi.Errors(err) {
+    switch e := sub.(type) {
+    case *opensearchapi.PartialSearchError:
+        log.Printf("%d/%d shards failed", e.FailedShards, e.TotalShards)
+    case *opensearchapi.MultiSearchItemError:
+        log.Printf("%d sub-queries failed", len(e.Items))
+    default:
+        // transport / HTTP / decoding error
+        return err
+    }
+}
+// resp is fully populated; use it regardless of partial failure.
+```
 
 [`guides/usage-error_handling.md`](../guides/usage-error_handling.md) is the canonical reference for the full model: the error-mask configuration and env-var override, the [error type reference table](../guides/usage-error_handling.md#error-type-reference), the recommended `for`/`switch` pattern, the `IsPartialFailure`/`ToleratePartialFailures`/`RequireSuccessRate` helpers, and why a type switch is preferred over `errors.As`/`Has` or per-Resp helpers. The exhaustive `OPENSEARCH_GO_ERROR_MASK` token list lives in [`guides/config-envvars.md`](../guides/config-envvars.md#opensearch_go_error_mask-tokens).
 

--- a/opensearchapi/doc.go
+++ b/opensearchapi/doc.go
@@ -104,8 +104,23 @@ SnapshotClient.Restore restores a snapshot.
 
 OpenSearch is a distributed system in which operations may partially succeed. By default the
 client surfaces partial failures as errors, which a caller detects with a type switch over
-[Errors]. The [Error Handling guide] is the canonical reference for the typed error model, the
-error mask, and the recommended handling pattern.
+[Errors]:
+
+	resp, err := client.MSearch(ctx, req)
+	for _, sub := range opensearchapi.Errors(err) {
+	  switch e := sub.(type) {
+	  case *opensearchapi.PartialSearchError:
+	    log.Printf("%d/%d shards failed", e.FailedShards, e.TotalShards)
+	  case *opensearchapi.MultiSearchItemError:
+	    log.Printf("%d sub-queries failed", len(e.Items))
+	  default: // transport / HTTP / decoding error
+	    return err
+	  }
+	}
+	// resp is fully populated; use it regardless of partial failure.
+
+The [Error Handling guide] is the canonical reference for the typed error model, the error mask,
+and the recommended handling pattern.
 
 # Plugin APIs
 


### PR DESCRIPTION
The `opensearchapi` package doc and README both tell you to dispatch partial failures with a `for`/`switch` over `opensearchapi.Errors(err)`, then link out to `guides/usage-error_handling.md` for the code. The page names the idiom but never shows it.

This adds the snippet to both surfaces, folded into the sentence that already names the idiom. It is the same snippet the `Errors` func godoc and the error-handling guide already carry, so there is one shape to learn rather than a third variant.
  - `opensearchapi/doc.go`, `# Partial Failures`
  - `opensearchapi/README.md`, `## Partial Failure Errors`

Docs only, no behavior change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
