### PR TITLE
fix(opensearchtransport): stop ranking from reordering the live connection list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+
+### Fixed
+
+- Fix `rendezvousTopK` sorting the live connection list when shard placement is unknown. `rankByHash` sorts in place, and the empty-placement path (`/_cat/shards` not yet populated: first requests, a new index, or `-cat_shards`) aliased the caller's `activeConns`/`sortedConns` slice instead of copying into the pooled buffer the shard-names path already used. Concurrent `Route()` then raced with discovery, and the RTT-bucket order that rendezvous filling "MUST" preserve — rebuilt on health checks, not per request — was destroyed. Both branches now copy before ranking ([#1090](https://github.com/opensearch-project/opensearch-go/pull/1090))
+
 ## [4.7.3]
 
 ### Changed

--- a/opensearchtransport/rendezvous_hash.go
+++ b/opensearchtransport/rendezvous_hash.go
@@ -76,13 +76,15 @@ func rendezvousTopK(
 		k = len(conns)
 	}
 
-	// Split into shard-hosting and non-shard partitions, preserving
-	// the caller's RTT sort order within each partition.
+	// Rank on a private copy of conns: rankByHash sorts in place, while
+	// callers pass their live RTT-ordered connection list and hold no lock
+	// for the duration of this call. Sorting that slice would race with
+	// concurrent Route() calls and destroy the RTT-bucket order slot
+	// filling reads, which only health checks rebuild.
 	var shard, nonShard []*Connection
-	var partBuf *[]*Connection // pooled buffer backing shard + nonShard
+	partBuf := getConnSlice(len(conns))
+	part := (*partBuf)[:0]
 	if len(shardNodeNames) > 0 {
-		partBuf = getConnSlice(len(conns))
-		part := (*partBuf)[:0]
 		// Append shard nodes first, then non-shard nodes.
 		for _, c := range conns {
 			if _, ok := shardNodeNames[c.Name]; ok {
@@ -97,11 +99,11 @@ func rendezvousTopK(
 		}
 		shard = part[:shardLen]
 		nonShard = part[shardLen:]
-		*partBuf = part // keep slice header in sync for putConnSlice
 	} else {
-		// No shard placement data -- treat all nodes equally.
-		shard = conns
+		part = append(part, conns...)
+		shard = part
 	}
+	*partBuf = part // keep slice header in sync for putConnSlice
 
 	var slots []*Connection
 	if buf != nil {
@@ -119,9 +121,7 @@ func rendezvousTopK(
 		_ = fillSlotsFromTiers(keyA, keyB, nonShard, slots, remaining, &slots)
 	}
 
-	if partBuf != nil {
-		putConnSlice(partBuf)
-	}
+	putConnSlice(partBuf)
 
 	// Phase 3: rotate within the slots by the jitter offset (in-place).
 	n := len(slots)
@@ -170,7 +170,9 @@ func fillSlotsFromTiers(keyA, keyB string, conns []*Connection, dst []*Connectio
 }
 
 // rankByHash sorts connections in-place by rendezvous hash weight (descending)
-// for consistent key-to-node assignment within an RTT tier.
+// for consistent key-to-node assignment within an RTT tier. conns must be a
+// buffer private to the caller, never a shared connection list such as the
+// pool's activeConns/sortedConns.
 func rankByHash(keyA, keyB string, conns []*Connection) []*Connection {
 	// Pre-compute weights using a pooled map. The map avoids repeated
 	// hashing during sort comparisons.

--- a/opensearchtransport/rendezvous_hash_internal_test.go
+++ b/opensearchtransport/rendezvous_hash_internal_test.go
@@ -7,7 +7,9 @@
 package opensearchtransport
 
 import (
+	"fmt"
 	"net/url"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -123,6 +125,59 @@ func TestRankByHash(t *testing.T) {
 		}
 		require.True(t, differ, "different keys should usually produce different orderings")
 	})
+}
+
+// TestRendezvousTopKDoesNotReorderInput pins the caller-slice contract: callers
+// pass their live RTT-ordered connection list, so ranking must touch only a
+// private copy. Run with -race for the concurrent case.
+func TestRendezvousTopKDoesNotReorderInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		nodes      int
+		k          int
+		goroutines int
+		iters      int
+	}{
+		// k below the node count puts every node in one RTT tier that is
+		// larger than the slots to fill, which is the only path that ranks.
+		{name: "single call", nodes: 4, k: 2, goroutines: 1, iters: 1},
+		{name: "concurrent calls", nodes: 8, k: 3, goroutines: 8, iters: 200},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			conns := make([]*Connection, tt.nodes)
+			orig := make([]string, tt.nodes)
+			for i := range conns {
+				id := fmt.Sprintf("n%d", i+1)
+				conns[i] = testConn(t, fmt.Sprintf("node%d:9200", i+1), id, 1*time.Millisecond)
+				orig[i] = conns[i].URLString
+			}
+
+			var wg sync.WaitGroup
+			wg.Add(tt.goroutines)
+			for range tt.goroutines {
+				go func() {
+					defer wg.Done()
+					for range tt.iters {
+						buf := getConnSlice(tt.k)
+						_ = rendezvousTopK("key", "", conns, tt.k, nil, nil, buf)
+						putConnSlice(buf)
+					}
+				}()
+			}
+			wg.Wait()
+
+			for i, c := range conns {
+				require.Equal(t, orig[i], c.URLString,
+					"position %d: input must keep its RTT order; rankByHash must sort only a private copy", i)
+			}
+		})
+	}
 }
 
 func TestRendezvousTopK(t *testing.T) {


### PR DESCRIPTION
### Description

Back-porting #1090 to `v4` branch.

rankByHash sorts in place. When shard placement is unknown (/_cat/shards
not yet populated, or -cat_shards), rendezvousTopK aliased the caller's
live RTT-ordered activeConns/sortedConns slice instead of copying into
the pooled buffer the shard-names path already used. Concurrent Route()
calls then raced, and the RTT-bucket order slot filling reads was lost.

Both branches now copy before ranking. The copy reuses the existing
pooled buffer, so allocations are unchanged.

(cherry picked from commit 6813f3d424245cca80b4fb098fc12207263172f1)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
