### PR TITLE
Wrap transport stream errors with the request method and URL

### DIFF
--- a/opensearchtransport/opensearchtransport.go
+++ b/opensearchtransport/opensearchtransport.go
@@ -1814,8 +1814,45 @@ func (c *Transport) stream(req *http.Request) (*http.Response, streamResult, err
 		res, err = c.performSeedFallback(req.Context(), req, &sr)
 	}
 
-	// TODO: Consider wrapping the error with request context.
+	// Wrap the error with the request method and a credential-redacted URL so
+	// callers debugging a failure don't have to correlate it back to the
+	// request by hand. Skipped when err is nil (the common case) since that
+	// would otherwise turn a successful response into a non-nil error.
+	if err != nil {
+		err = fmt.Errorf("%s %s: %w", req.Method, redactedRequestURL(req), err)
+	}
+
 	return res, sr, err
+}
+
+// redactedRequestURL renders req.URL for inclusion in error messages, with
+// userinfo and the query string stripped.
+//
+// setReqURL only ever copies Scheme/Host/Path from the connection URL onto
+// req.URL, never User, so basic-auth credentials configured on a connection
+// (e.g. https://user:pass@host:9200) do not normally reach req.URL. Userinfo
+// is still stripped here as a defense in depth, since req.URL is caller
+// input: it is whatever *http.Request was passed to Stream/Request, which a
+// caller building requests directly against Transport (bypassing
+// opensearchapi) could construct with embedded credentials.
+//
+// The query string is dropped unconditionally because it routinely carries
+// secrets that never touch userinfo -- SigV4 presigned requests place the
+// signature and credential scope in query parameters (e.g. X-Amz-Signature,
+// X-Amz-Credential), and some deployments accept API keys as a query
+// parameter. Method, scheme, host, and path are enough to identify which
+// request failed without risking a leak into logs or error-tracking systems.
+func redactedRequestURL(req *http.Request) string {
+	if req == nil || req.URL == nil {
+		return "<no url>"
+	}
+	u := *req.URL
+	u.User = nil
+	u.RawQuery = ""
+	u.ForceQuery = false
+	u.Fragment = ""
+	u.RawFragment = ""
+	return u.String()
 }
 
 // defaultOperationClassifier lazily builds a single [OperationClassifier] shared

--- a/opensearchtransport/opensearchtransport_internal_test.go
+++ b/opensearchtransport/opensearchtransport_internal_test.go
@@ -494,8 +494,11 @@ func TestTransportStream(t *testing.T) {
 
 		//nolint:bodyclose // Mock response does not have a body to close
 		_, err := tp.Stream(req)
-		if err.Error() != `cannot get connection: no connections available` {
-			t.Fatalf("Expected error `cannot get connection: no connections available`: but got error %q", err)
+		if err.Error() != `GET /abc: cannot get connection: no connections available` {
+			t.Fatalf("Expected error `GET /abc: cannot get connection: no connections available`: but got error %q", err)
+		}
+		if !errors.Is(err, ErrNoConnections) {
+			t.Error("Expected wrapped error to still satisfy errors.Is(err, ErrNoConnections)")
 		}
 	})
 }
@@ -1056,6 +1059,129 @@ func TestTransportStreamRetries(t *testing.T) {
 
 		if j != numRetries {
 			t.Errorf("Unexpected number of backoffs, want=>%d, got=%d", numRetries, j)
+		}
+	})
+}
+
+// TestTransportStreamErrorRequestContext covers the request-context wrapping
+// applied at the end of Transport.stream: a non-nil error should come back
+// prefixed with "METHOD url: ", and that URL should never carry userinfo or
+// query-string secrets.
+func TestTransportStreamErrorRequestContext(t *testing.T) {
+	t.Run("wraps an exhausted-retry error with method and URL", func(t *testing.T) {
+		u, _ := url.Parse("http://foo.bar")
+		tp, _ := New(Config{
+			URLs:                  []*url.URL{u},
+			SkipConnectionShuffle: true,            // Disable shuffling for predictable test results
+			HealthCheck:           NoOpHealthCheck, // Disable health checks to avoid extra requests during resurrection
+			NodeStatsInterval:     -1,              // Disable stats poller to avoid background requests through mock transport
+			MaxRetries:            1,
+			// io.EOF is retried unconditionally by stream() and, unlike
+			// mockNetError (a bare net.Error with no Unwrap), passes
+			// straight through fmt.Errorf's %w chain, so errors.Is can see
+			// past the added request-context wrapping below.
+			Transport: mockhttp.NewRoundTripFunc(t, func(req *http.Request) (*http.Response, error) {
+				return nil, io.EOF
+			}),
+		})
+		t.Cleanup(func() { _ = tp.Close() })
+
+		req, _ := http.NewRequest(http.MethodGet, "/my-index/_doc/1", nil)
+
+		//nolint:bodyclose // Mock response does not have a body to close
+		_, err := tp.Stream(req)
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+
+		const wantPrefix = "GET http://foo.bar/my-index/_doc/1: "
+		if !strings.HasPrefix(err.Error(), wantPrefix) {
+			t.Errorf("Expected error to start with %q, got %q", wantPrefix, err.Error())
+		}
+		if !errors.Is(err, io.EOF) {
+			t.Error("Expected the wrapped error to still satisfy errors.Is(err, io.EOF)")
+		}
+	})
+
+	t.Run("does not wrap a nil error", func(t *testing.T) {
+		u, _ := url.Parse("http://foo.bar")
+		tp, _ := New(Config{
+			URLs:                  []*url.URL{u},
+			SkipConnectionShuffle: true,
+			HealthCheck:           NoOpHealthCheck,
+			NodeStatsInterval:     -1,
+			Transport: mockhttp.NewRoundTripFunc(t, func(req *http.Request) (*http.Response, error) {
+				return &http.Response{Status: "OK", StatusCode: http.StatusOK}, nil
+			}),
+		})
+		t.Cleanup(func() { _ = tp.Close() })
+
+		req, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+		//nolint:bodyclose // Mock response does not have a body to close
+		_, err := tp.Stream(req)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("redacts userinfo credentials embedded in the request URL", func(t *testing.T) {
+		u, _ := url.Parse("http://foo.bar")
+		tp, _ := New(Config{
+			URLs:                  []*url.URL{u},
+			SkipConnectionShuffle: true,
+			HealthCheck:           NoOpHealthCheck,
+			NodeStatsInterval:     -1,
+			DisableRetry:          true,
+			Transport: mockhttp.NewRoundTripFunc(t, func(req *http.Request) (*http.Response, error) {
+				return nil, &mockNetError{error: errors.New("boom")}
+			}),
+		})
+		t.Cleanup(func() { _ = tp.Close() })
+
+		// A request built with credentials embedded in the URL, e.g. by a
+		// caller driving Transport directly rather than through
+		// opensearchapi. setReqURL only ever copies Scheme/Host/Path from
+		// the connection URL, never User, so this userinfo survives
+		// unmodified into the error path unless explicitly stripped.
+		req, _ := http.NewRequest(http.MethodGet, "http://user:s3cr3t-password@foo.bar/", nil)
+
+		//nolint:bodyclose // Mock response does not have a body to close
+		_, err := tp.Stream(req)
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if strings.Contains(err.Error(), "s3cr3t-password") || strings.Contains(err.Error(), "user:") {
+			t.Errorf("Expected credentials to be redacted from the error, got %q", err.Error())
+		}
+	})
+
+	t.Run("redacts the query string from the request URL", func(t *testing.T) {
+		u, _ := url.Parse("http://foo.bar")
+		tp, _ := New(Config{
+			URLs:                  []*url.URL{u},
+			SkipConnectionShuffle: true,
+			HealthCheck:           NoOpHealthCheck,
+			NodeStatsInterval:     -1,
+			DisableRetry:          true,
+			Transport: mockhttp.NewRoundTripFunc(t, func(req *http.Request) (*http.Response, error) {
+				return nil, &mockNetError{error: errors.New("boom")}
+			}),
+		})
+		t.Cleanup(func() { _ = tp.Close() })
+
+		// Query parameters can carry secrets that never touch userinfo, e.g.
+		// SigV4 presigned-request signatures or API keys passed as a query
+		// parameter.
+		req, _ := http.NewRequest(http.MethodGet, "/?X-Amz-Signature=topsecret&apikey=abc123", nil)
+
+		//nolint:bodyclose // Mock response does not have a body to close
+		_, err := tp.Stream(req)
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if strings.Contains(err.Error(), "topsecret") || strings.Contains(err.Error(), "abc123") {
+			t.Errorf("Expected the query string to be redacted from the error, got %q", err.Error())
 		}
 	})
 }

--- a/opensearchutil/bulk_indexer_internal_test.go
+++ b/opensearchutil/bulk_indexer_internal_test.go
@@ -866,7 +866,10 @@ func TestBulkIndexerCallbacks(t *testing.T) {
 					Client:     client,
 					OnError: func(ctx context.Context, err error) {
 						onErrorCallCount++
-						if err.Error() != "flush: simulated bulk request error" {
+						// opensearchtransport wraps the underlying transport error with
+						// "METHOD url: " request context, so match on prefix/suffix
+						// rather than the exact string.
+						if !strings.HasPrefix(err.Error(), "flush: ") || !strings.HasSuffix(err.Error(), ": simulated bulk request error") {
 							t.Errorf("Unexpected error: %v", err)
 						}
 					},
@@ -881,7 +884,10 @@ func TestBulkIndexerCallbacks(t *testing.T) {
 						DocumentID: id,
 						Body:       strings.NewReader(fmt.Sprintf(`{"title":"doc_%d"}`, i)),
 						OnFailure: func(ctx context.Context, item BulkIndexerItem, resp opensearchapi.BulkRespItem, err error) {
-							if err.Error() != "flush: simulated bulk request error" {
+							// opensearchtransport wraps the underlying transport error with
+							// "METHOD url: " request context, so match on prefix/suffix
+							// rather than the exact string.
+							if !strings.HasPrefix(err.Error(), "flush: ") || !strings.HasSuffix(err.Error(), ": simulated bulk request error") {
 								t.Errorf("Unexpected error in OnFailure: %v", err)
 							}
 							idsFailureCount[item.DocumentID]++


### PR DESCRIPTION
## Description
Transport errors returned from `opensearchtransport`'s `stream()` carried no information about which request failed, making it hard to correlate a bare error like "unexpected EOF" or "context deadline exceeded" back to a specific call when several requests are in flight concurrently.

This wraps the error with the request method and URL before returning it from `stream()`, using `fmt.Errorf`'s `%w` so `errors.Is`/`errors.As` still see through to the original cause. The URL has its userinfo and query string stripped first: userinfo could carry embedded basic-auth credentials, and the query string can carry secrets that never touch userinfo, such as SigV4 presigned-request signatures or an API key passed as a query parameter. Scheme, host, and path are enough to identify the failing request without risking a credential leaking into logs or an error-tracking system.

This also updates two tests whose expected error strings depended on the old, unwrapped error format: one directly in `opensearchtransport`, and one in `opensearchutil/bulk_indexer_internal_test.go`, whose mock transport error flows through the same `stream()` path.

## Issues Resolved
No tracking issue -- found while reviewing `opensearchtransport`'s error paths. Happy to open one first if maintainers would rather track it before reviewing the code.

## Testing
`go build ./...` and `go vet ./...` pass clean. `go test ./opensearchtransport/... ./opensearchutil/...` passes, including the new `TestTransportStreamErrorRequestContext`. One unrelated pre-existing failure, `TestMetrics/String()`, reproduces identically on `main` without this change (a timezone-dependent formatting assertion), so it is not something this PR touches or affects.

## By submitting this pull request, I confirm my contribution is made under the terms of the Apache 2.0 license.
